### PR TITLE
Enhance bug report template with affected apps

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -3,6 +3,21 @@ description: Create a bug report to help us improve
 title: "bug: "
 labels: ["🐞❔ unconfirmed bug"]
 body:
+  - type: checkboxes
+    id: affected_apps
+    attributes:
+      label: Affected application(s)
+      description: Select all apps this issue applies to
+      options:
+        - label: Admin
+        - label: API
+        - label: Auth
+        - label: Codex
+        - label: Database
+        - label: Map
+        - label: PAX Vault
+        - label: Region Pages
+        - label: Slackbot
   - type: textarea
     attributes:
       label: Provide environment information


### PR DESCRIPTION
Added checkboxes for affected applications in bug report template. GitHub Action will auto-add a label (at least that's the goal)
