### PR TITLE
[MD-8121] Add isPrivate field to events and update related components

### DIFF
--- a/apps/map/src/app/_components/modal/admin-workouts-modal.tsx
+++ b/apps/map/src/app/_components/modal/admin-workouts-modal.tsx
@@ -135,6 +135,7 @@ export default function AdminWorkoutsModal({
         mapSeed: event?.meta?.mapSeed ?? false,
       },
       description: event?.description ?? "",
+      isPrivate: event?.isPrivate ?? false,
     });
   }, [form, event]);
 
@@ -142,7 +143,15 @@ export default function AdminWorkoutsModal({
     orpc.event.crupdate.mutationOptions({
       onSuccess: async () => {
         await invalidateQueries({
-          predicate: (query) => query.queryKey[0] === "event",
+          predicate: (query) => {
+            const key = query.queryKey;
+            return (
+              Array.isArray(key) &&
+              key.length > 0 &&
+              (key[0] === "event" ||
+                (Array.isArray(key[0]) && key[0][0] === "event"))
+            );
+          },
         });
         closeModal();
         toast.success("Successfully updated event");
@@ -520,6 +529,35 @@ export default function AdminWorkoutsModal({
                           value={field.value ?? ""}
                         />
                       </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </div>
+              <div className="mb-4 w-1/2 px-2">
+                <FormField
+                  control={form.control}
+                  name="isPrivate"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Visibility</FormLabel>
+                      <Select
+                        onValueChange={(value) =>
+                          value &&
+                          field.onChange(value === "true" ? true : false)
+                        }
+                        value={field.value === true ? "true" : "false"}
+                      >
+                        <FormControl>
+                          <SelectTrigger>
+                            <SelectValue placeholder="Select visibility" />
+                          </SelectTrigger>
+                        </FormControl>
+                        <SelectContent>
+                          <SelectItem value="false">Public</SelectItem>
+                          <SelectItem value="true">Private</SelectItem>
+                        </SelectContent>
+                      </Select>
                       <FormMessage />
                     </FormItem>
                   )}

--- a/apps/map/src/app/admin/workouts/workouts-table.tsx
+++ b/apps/map/src/app/admin/workouts/workouts-table.tsx
@@ -174,6 +174,26 @@ const columns: TableOptions<
     },
   },
   {
+    accessorKey: "isPrivate",
+    meta: { name: "Visibility" },
+    header: Header,
+    cell: ({ row }) => {
+      return (
+        <div className="flex items-center justify-start">
+          <span
+            className={`inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-medium ${
+              row.original.isPrivate
+                ? "border-amber-200 bg-amber-100 text-amber-700"
+                : "border-blue-200 bg-blue-100 text-blue-700"
+            }`}
+          >
+            {row.original.isPrivate ? "Private" : "Public"}
+          </span>
+        </div>
+      );
+    },
+  },
+  {
     accessorKey: "created",
     accessorFn: (row) => new Date(row.created).toLocaleDateString(),
     meta: { name: "Created At" },

--- a/packages/api/src/router/event.ts
+++ b/packages/api/src/router/event.ts
@@ -130,6 +130,7 @@ export const eventRouter = {
         name: schema.events.name,
         description: schema.events.description,
         isActive: schema.events.isActive,
+        isPrivate: schema.events.isPrivate,
         parent: parentOrg.name,
         locationId: schema.events.locationId,
         startDate: schema.events.startDate,
@@ -274,6 +275,7 @@ export const eventRouter = {
           highlight: schema.events.highlight,
           created: schema.events.created,
           meta: schema.events.meta,
+          isPrivate: schema.events.isPrivate,
           aos: sql<{ aoId: number; aoName: string }[]>`COALESCE(
             json_agg(
               DISTINCT jsonb_build_object(

--- a/packages/api/src/router/map/location.test.ts
+++ b/packages/api/src/router/map/location.test.ts
@@ -1,0 +1,335 @@
+/**
+ * Tests for Map Location Router endpoints
+ *
+ * These tests require:
+ * - TEST_DATABASE_URL environment variable to be set
+ * - Test database to be seeded with test data
+ */
+
+import { schema } from "@acme/db";
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  cleanup,
+  createAdminSession,
+  createTestClient,
+  db,
+  getOrCreateF3NationOrg,
+  mockAuthWithSession,
+  uniqueId,
+} from "../../__tests__/test-utils";
+
+describe("Map Location Router", () => {
+  // Track created entities for cleanup
+  const createdEventIds: number[] = [];
+  const createdLocationIds: number[] = [];
+  const createdOrgIds: number[] = [];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterAll(async () => {
+    // Clean up in reverse order, respecting FK constraints
+    for (const eventId of createdEventIds.reverse()) {
+      try {
+        await cleanup.event(eventId);
+      } catch {
+        // Ignore errors during cleanup
+      }
+    }
+    for (const locationId of createdLocationIds.reverse()) {
+      try {
+        await cleanup.location(locationId);
+      } catch {
+        // Ignore errors during cleanup
+      }
+    }
+    for (const orgId of createdOrgIds.reverse()) {
+      try {
+        await cleanup.org(orgId);
+      } catch {
+        // Ignore errors during cleanup
+      }
+    }
+  });
+
+  // Helper to create test region
+  const createTestRegion = async () => {
+    const nationOrg = await getOrCreateF3NationOrg();
+    const [region] = await db
+      .insert(schema.orgs)
+      .values({
+        name: `Test Region ${uniqueId()}`,
+        orgType: "region",
+        parentId: nationOrg.id,
+        isActive: true,
+      })
+      .returning();
+
+    if (region) {
+      createdOrgIds.push(region.id);
+    }
+    return region;
+  };
+
+  // Helper to create test AO
+  const createTestAO = async (regionId: number) => {
+    const [ao] = await db
+      .insert(schema.orgs)
+      .values({
+        name: `Test AO ${uniqueId()}`,
+        orgType: "ao",
+        parentId: regionId,
+        isActive: true,
+      })
+      .returning();
+
+    if (ao) {
+      createdOrgIds.push(ao.id);
+    }
+    return ao;
+  };
+
+  // Helper to create test location
+  const createTestLocation = async (orgId: number) => {
+    const [location] = await db
+      .insert(schema.locations)
+      .values({
+        name: `Test Location ${uniqueId()}`,
+        orgId,
+        isActive: true,
+        latitude: 35.5,
+        longitude: -80.5,
+      })
+      .returning();
+
+    if (location) {
+      createdLocationIds.push(location.id);
+    }
+    return location;
+  };
+
+  describe("eventsAndLocations", () => {
+    it("should return locations with events for the map", async () => {
+      const session = await createAdminSession();
+      await mockAuthWithSession(session);
+
+      const client = createTestClient();
+      const result = await client.map.location.eventsAndLocations();
+
+      expect(Array.isArray(result)).toBe(true);
+    });
+
+    it("should exclude private events from map data", async () => {
+      const session = await createAdminSession();
+      await mockAuthWithSession(session);
+
+      const region = await createTestRegion();
+      if (!region) return;
+
+      const ao = await createTestAO(region.id);
+      if (!ao) return;
+
+      const location = await createTestLocation(region.id);
+      if (!location) return;
+
+      // Create a public event (should appear on map)
+      const [publicEvent] = await db
+        .insert(schema.events)
+        .values({
+          name: `Public Map Event ${uniqueId()}`,
+          orgId: ao.id,
+          locationId: location.id,
+          dayOfWeek: "monday",
+          startTime: "0530",
+          isActive: true,
+          highlight: false,
+          startDate: "2026-01-01",
+          isPrivate: false,
+        })
+        .returning();
+
+      if (publicEvent) {
+        createdEventIds.push(publicEvent.id);
+      }
+
+      // Create a private event (should NOT appear on map)
+      const [privateEvent] = await db
+        .insert(schema.events)
+        .values({
+          name: `Private Map Event ${uniqueId()}`,
+          orgId: ao.id,
+          locationId: location.id,
+          dayOfWeek: "tuesday",
+          startTime: "0600",
+          isActive: true,
+          highlight: false,
+          startDate: "2026-01-01",
+          isPrivate: true,
+        })
+        .returning();
+
+      if (privateEvent) {
+        createdEventIds.push(privateEvent.id);
+      }
+
+      const client = createTestClient();
+      const result = await client.map.location.eventsAndLocations();
+
+      // Find the location in the results
+      // Map data format: [locationId, name, logo, lat, lon, fullAddress, events[]]
+      const locationData = result.find(
+        (loc: [number, ...unknown[]]) => loc[0] === location.id,
+      );
+
+      if (locationData) {
+        // Events are at index 6 in the tuple
+        const events = locationData[6] as [number, ...unknown[]][];
+
+        // Public event should be in the events
+        const hasPublicEvent = events.some(
+          (event: [number, ...unknown[]]) => event[0] === publicEvent?.id,
+        );
+        expect(hasPublicEvent).toBe(true);
+
+        // Private event should NOT be in the events
+        const hasPrivateEvent = events.some(
+          (event: [number, ...unknown[]]) => event[0] === privateEvent?.id,
+        );
+        expect(hasPrivateEvent).toBe(false);
+      }
+    });
+
+    it("should exclude inactive events from map data", async () => {
+      const session = await createAdminSession();
+      await mockAuthWithSession(session);
+
+      const region = await createTestRegion();
+      if (!region) return;
+
+      const ao = await createTestAO(region.id);
+      if (!ao) return;
+
+      const location = await createTestLocation(region.id);
+      if (!location) return;
+
+      // Create an inactive event (should NOT appear on map)
+      const [inactiveEvent] = await db
+        .insert(schema.events)
+        .values({
+          name: `Inactive Map Event ${uniqueId()}`,
+          orgId: ao.id,
+          locationId: location.id,
+          dayOfWeek: "wednesday",
+          startTime: "0700",
+          isActive: false,
+          highlight: false,
+          startDate: "2026-01-01",
+          isPrivate: false,
+        })
+        .returning();
+
+      if (inactiveEvent) {
+        createdEventIds.push(inactiveEvent.id);
+      }
+
+      const client = createTestClient();
+      const result = await client.map.location.eventsAndLocations();
+
+      // Find the location in the results
+      const locationData = result.find(
+        (loc: [number, ...unknown[]]) => loc[0] === location.id,
+      );
+
+      if (locationData) {
+        const events = locationData[6] as [number, ...unknown[]][];
+
+        // Inactive event should NOT be in the events
+        const hasInactiveEvent = events.some(
+          (event: [number, ...unknown[]]) => event[0] === inactiveEvent?.id,
+        );
+        expect(hasInactiveEvent).toBe(false);
+      }
+    });
+
+    it("should only show active public events on the map", async () => {
+      const session = await createAdminSession();
+      await mockAuthWithSession(session);
+
+      const region = await createTestRegion();
+      if (!region) return;
+
+      const ao = await createTestAO(region.id);
+      if (!ao) return;
+
+      const location = await createTestLocation(region.id);
+      if (!location) return;
+
+      // Create an active public event (should appear)
+      const [activePublicEvent] = await db
+        .insert(schema.events)
+        .values({
+          name: `Active Public ${uniqueId()}`,
+          orgId: ao.id,
+          locationId: location.id,
+          dayOfWeek: "thursday",
+          startTime: "0530",
+          isActive: true,
+          highlight: false,
+          startDate: "2026-01-01",
+          isPrivate: false,
+        })
+        .returning();
+
+      if (activePublicEvent) {
+        createdEventIds.push(activePublicEvent.id);
+      }
+
+      // Create an inactive private event (should NOT appear - both conditions fail)
+      const [inactivePrivateEvent] = await db
+        .insert(schema.events)
+        .values({
+          name: `Inactive Private ${uniqueId()}`,
+          orgId: ao.id,
+          locationId: location.id,
+          dayOfWeek: "friday",
+          startTime: "0600",
+          isActive: false,
+          highlight: false,
+          startDate: "2026-01-01",
+          isPrivate: true,
+        })
+        .returning();
+
+      if (inactivePrivateEvent) {
+        createdEventIds.push(inactivePrivateEvent.id);
+      }
+
+      const client = createTestClient();
+      const result = await client.map.location.eventsAndLocations();
+
+      // Find the location in the results
+      const locationData = result.find(
+        (loc: [number, ...unknown[]]) => loc[0] === location.id,
+      );
+
+      if (locationData) {
+        const events = locationData[6] as [number, ...unknown[]][];
+
+        // Active public event should be in the events
+        const hasActivePublic = events.some(
+          (event: [number, ...unknown[]]) => event[0] === activePublicEvent?.id,
+        );
+        expect(hasActivePublic).toBe(true);
+
+        // Inactive private event should NOT be in the events
+        const hasInactivePrivate = events.some(
+          (event: [number, ...unknown[]]) =>
+            event[0] === inactivePrivateEvent?.id,
+        );
+        expect(hasInactivePrivate).toBe(false);
+      }
+    });
+  });
+});
+

--- a/packages/api/src/router/map/location.ts
+++ b/packages/api/src/router/map/location.ts
@@ -72,6 +72,7 @@ export const mapLocationRouter = os.router({
           and(
             eq(schema.events.locationId, schema.locations.id),
             eq(schema.events.isActive, true),
+            eq(schema.events.isPrivate, false),
           ),
         )
         .leftJoin(aoOrg, eq(schema.events.orgId, aoOrg.id))
@@ -236,6 +237,7 @@ export const mapLocationRouter = os.router({
           and(
             eq(schema.locations.id, schema.events.locationId),
             eq(schema.events.isActive, true),
+            eq(schema.events.isPrivate, false),
           ),
         )
         .leftJoin(parentOrg, eq(schema.events.orgId, parentOrg.id))


### PR DESCRIPTION
<!--
Learn more about GitHub Pull Request Templates at...
https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository
-->
<!--
### 🚧 This PR is Part of a Series
-->
<!--
You can simply remove this section
if you don't need it for your use-case
(e.g., a one-off PR that isn't actually
stacked or part of a series)
-->
<!--
- Introduced isPrivate field in AdminWorkoutsModal for event visibility selection.
- Updated workouts-table to display event visibility status.
- Enhanced event router to include isPrivate in event responses.
- Added tests to verify isPrivate functionality for events.
- Modified map location router to exclude private events from map data.
-->

### 👋 TL;DR

<!-- keep it simple, a sentence or two at most -->

(coming soon)

### 🔎 Details

<!--
This is the place to get in the weeds about what changed.
Consider linking out to project artifacts like:
- Jira issue(s)
- Slack post(s)
- Loom video(s)
- Figma design(s)
- etc.
-->

(coming soon)

### ✅ How to Test

<!--
Document what a real testing looks like.
Think not only about code review,
but also about QA/UAT.
Given-When-Then acceptance criteria are great,
but even just a flat list of common test cases
in common language is better than nothing
-->

(coming soon)

### 🥜 GIF

<!-- GIFs are always optional but never forgotten -->

![lack-of-hustle](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExNWZ2enV5YXY5YXdzb2IwOWFtMGp1OTd0bGljdHBzNXpiYXVzM2Y2ZCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/3oKIPACZEWen2eaBm8/giphy.gif)
