### PR TITLE
Enhance event and organization routers with new filtering options

### DIFF
--- a/packages/api/src/router/org.ts
+++ b/packages/api/src/router/org.ts
@@ -61,6 +61,13 @@ export const orgRouter = {
         statuses: arrayOrSingle(z.enum(IsActiveStatus)).optional(),
         parentOrgIds: arrayOrSingle(z.coerce.number()).optional(),
         onlyMine: z.coerce.boolean().optional(),
+        countOnly: z
+          .coerce
+          .boolean()
+          .optional()
+          .describe(
+            "When true, only the total count is returned and the `orgs` array is omitted.",
+          ),
       }),
     )
     .route({
@@ -146,6 +153,10 @@ export const orgRouter = {
         .leftJoin(parentOrg, eq(org.parentId, parentOrg.id))
         .where(where);
 
+      if (input?.countOnly) {
+        return { total: orgCount?.count ?? 0 };
+      }
+      
       const select = {
         id: org.id,
         parentId: org.parentId,


### PR DESCRIPTION
- Added support for filtering events by event type names and categories in the event router.
- Introduced a countOnly option in the organization router to return only the total count of organizations without the data array.
- Improved input validation and error handling across both routers.
- Updated SQL queries to accommodate new filtering criteria and ensure accurate data retrieval.