### PR TITLE
[MOUNT-45] Refactor AdminEventTypesModal and update event type schema

### DIFF
--- a/packages/db/drizzle/schema.ts
+++ b/packages/db/drizzle/schema.ts
@@ -432,7 +432,7 @@ export const eventTypes = pgTable(
     updated: timestamp({ mode: "string" })
       .default(sql`timezone('utc'::text, now())`)
       .notNull(),
-    specificOrgId: integer("specific_org_id"),
+    specificOrgId: integer("specific_org_id").notNull(),
     eventCategory: eventCategory("event_category").notNull(),
     isActive: boolean("is_active").default(true).notNull(),
   },

--- a/packages/validators/src/index.ts
+++ b/packages/validators/src/index.ts
@@ -47,7 +47,15 @@ export const LocationInsertSchema = createInsertSchema(locations);
 export const LocationSelectSchema = createSelectSchema(locations);
 
 // EVENT TYPE SCHEMA
-export const EventTypeInsertSchema = createInsertSchema(eventTypes);
+export const EventTypeInsertSchema = createInsertSchema(eventTypes, {
+  name: (s: z.ZodString) => s.min(1, { message: "Required" }),
+  specificOrgId: () =>
+    z
+      .number({
+        required_error: "Required",
+        invalid_type_error: "Required",
+      })
+});
 export const EventTypeSelectSchema = createSelectSchema(eventTypes);
 
 // EVENT SCHEMA


### PR DESCRIPTION
<!--
Learn more about GitHub Pull Request Templates at...
https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository
-->
<!--
### 🚧 This PR is Part of a Series
-->
<!--
You can simply remove this section
if you don't need it for your use-case
(e.g., a one-off PR that isn't actually
stacked or part of a series)
-->
<!--
- #1 short description
- #2 short description
- #3 short description
-->

### 👋 TL;DR

<!-- keep it simple, a sentence or two at most -->

- Changed query options in AdminEventTypesModal to use `orpc.org.mine` for region data
- Updated handling of `specificOrgId` to use `undefined` instead of `null`
- Improved success and error toast messages to reflect the action being performed (add/update)
- Made `specificOrgId` in the event type schema a required field
- Enhanced EventTypeInsertSchema to enforce validation on `name` and `specificOrgId` fields

### 🔎 Details

<!--
This is the place to get in the weeds about what changed.
Consider linking out to project artifacts like:
- Jira issue(s)
- Slack post(s)
- Loom video(s)
- Figma design(s)
- etc.
-->

(coming soon)

### ✅ How to Test

<!--
Document what a real testing looks like.
Think not only about code review,
but also about QA/UAT.
Given-When-Then acceptance criteria are great,
but even just a flat list of common test cases
in common language is better than nothing
-->

(coming soon)

### 🥜 GIF

<!-- GIFs are always optional but never forgotten -->

![lack-of-hustle](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExNWZ2enV5YXY5YXdzb2IwOWFtMGp1OTd0bGljdHBzNXpiYXVzM2Y2ZCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/3oKIPACZEWen2eaBm8/giphy.gif)
