### PR TITLE
[MOUNT-51] Updated the location query options to include a new parameter 

### DIFF
--- a/apps/map/src/app/_components/modal/admin-workouts-modal.tsx
+++ b/apps/map/src/app/_components/modal/admin-workouts-modal.tsx
@@ -89,7 +89,7 @@ export default function AdminWorkoutsModal({
     orpc.org.all.queryOptions({ input: { orgTypes: ["region"] } }),
   );
   const { data: locations } = useQuery(
-    orpc.location.all.queryOptions({ input: undefined }),
+    orpc.location.all.queryOptions({ input: { onlyActive: true } }),
   );
   const { data: aos } = useQuery(
     orpc.org.all.queryOptions({ input: { orgTypes: ["ao"] } }),

--- a/packages/api/src/router/location.ts
+++ b/packages/api/src/router/location.ts
@@ -65,6 +65,12 @@ export const locationRouter = {
             .describe(
               "If true, only return locations in organizations where the requester has editor or admin role.",
             ),
+          onlyActive: z.coerce
+            .boolean()
+            .optional()
+            .describe(
+              "Filter locations by status. If not specified, returns all statuses.",
+            ),
         })
         .optional(),
     )
@@ -126,6 +132,9 @@ export const locationRouter = {
         // Filter by editable org IDs if onlyMine is true and not a nation admin
         input?.onlyMine && !isNationAdmin && editableOrgIds.length > 0
           ? inArray(schema.locations.orgId, editableOrgIds)
+          : undefined,
+        input?.onlyActive
+          ? eq(schema.locations.isActive, true)
           : undefined,
       );
 


### PR DESCRIPTION
<!--
Learn more about GitHub Pull Request Templates at...
https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository
-->
<!--
### 🚧 This PR is Part of a Series
-->
<!--
You can simply remove this section
if you don't need it for your use-case
(e.g., a one-off PR that isn't actually
stacked or part of a series)
-->
<!--
- #1 short description
- #2 short description
- #3 short description
-->

### 👋 TL;DR

<!-- keep it simple, a sentence or two at most -->

- Add`onlyActive` param, allowing the retrieval of only active locations.

### 🔎 Details

<!--
This is the place to get in the weeds about what changed.
Consider linking out to project artifacts like:
- Jira issue(s)
- Slack post(s)
- Loom video(s)
- Figma design(s)
- etc.
-->

(coming soon)

### ✅ How to Test

<!--
Document what a real testing looks like.
Think not only about code review,
but also about QA/UAT.
Given-When-Then acceptance criteria are great,
but even just a flat list of common test cases
in common language is better than nothing
-->

(coming soon)

### 🥜 GIF

<!-- GIFs are always optional but never forgotten -->

![lack-of-hustle](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExNWZ2enV5YXY5YXdzb2IwOWFtMGp1OTd0bGljdHBzNXpiYXVzM2Y2ZCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/3oKIPACZEWen2eaBm8/giphy.gif)
