### PR TITLE
stringified logs so they stick together in GCP

### DIFF
--- a/packages/api/src/get-editable-org-ids.ts
+++ b/packages/api/src/get-editable-org-ids.ts
@@ -106,10 +106,13 @@ export const getEditableOrgIdsForUser = async (
       return found === idx;
     });
 
-  console.log("getEditableOrgIdsForUser", {
-    editableOrgs,
-    editableOrgsCount: editableOrgs.length,
-  });
+  console.log(
+    "getEditableOrgIdsForUser",
+    JSON.stringify({
+      editableOrgs,
+      editableOrgsCount: editableOrgs.length,
+    }),
+  );
 
   return {
     editableOrgs,

--- a/packages/api/src/lib/move-ao-locs-to-new-region.ts
+++ b/packages/api/src/lib/move-ao-locs-to-new-region.ts
@@ -27,7 +27,7 @@ export const moveAOLocsToNewRegion = async (
   },
 ) => {
   const newLocationIds: number[] = [];
-  console.log("moveAOToNewRegion", input);
+  console.log("moveAOToNewRegion", JSON.stringify(input));
   const { aoId, oldRegionId, newRegionId } = input;
 
   const aoEvents = await ctx.db

--- a/packages/api/src/lib/webhook-events.ts
+++ b/packages/api/src/lib/webhook-events.ts
@@ -115,7 +115,7 @@ const buildPayload = (event: WebhookEvent): WebhookPayload => {
  */
 export const notifyMapDataChange = (event: WebhookEvent): void => {
   const payload = buildPayload(event);
-  console.log("notifyMapDataChange", { event, payload });
+  console.log("notifyMapDataChange", JSON.stringify({ event, payload }));
 
   // Revalidate the statically generated map page so Next.js serves fresh data
   // on the next request. Only works in Next.js request context (not in tests).
@@ -131,15 +131,21 @@ export const notifyMapDataChange = (event: WebhookEvent): void => {
       // Expected in test environment, no need to log
     } else {
       // Unexpected error, log it but don't throw
-      console.error("notifyMapDataChange revalidation failed", {
-        event,
-        error,
-      });
+      console.error(
+        "notifyMapDataChange revalidation failed",
+        JSON.stringify({
+          event,
+          error,
+        }),
+      );
     }
   }
 
   // Fire and forget - don't await to not block response
   notifyWebhooks(payload).catch((error: unknown) => {
-    console.error("notifyMapDataChange failed", { event, error });
+    console.error(
+      "notifyMapDataChange failed",
+      JSON.stringify({ event, error }),
+    );
   });
 };

--- a/packages/api/src/router/request.ts
+++ b/packages/api/src/router/request.ts
@@ -803,7 +803,7 @@ export const applyUpdateRequest = async (
   // AO
   if (updateRequest.aoId == undefined) {
     // INSERT AO
-    console.log("inserting ao", updateRequest);
+    console.log("inserting ao", JSON.stringify(updateRequest));
     const [ao] = await ctx.db
       .insert(schema.orgs)
       .values({
@@ -875,7 +875,7 @@ export const applyUpdateRequest = async (
     }
     eventId = _updated.id;
   } else {
-    console.log("inserting event", updateRequest);
+    console.log("inserting event", JSON.stringify(updateRequest));
     const newEvent: typeof schema.events.$inferInsert = {
       name: updateRequest.eventName,
       locationId: updateRequest.locationId,

--- a/packages/api/src/router/user.ts
+++ b/packages/api/src/router/user.ts
@@ -333,7 +333,7 @@ export const userRouter = {
       // Normalize email for case-insensitive storage and lookup
       const normalizedEmail = _email ? normalizeEmail(_email) : _email;
 
-      console.log("Update set", updateSet);
+      console.log("Update set", JSON.stringify(updateSet));
 
       let user: typeof schema.users.$inferSelect;
       try {
@@ -364,7 +364,7 @@ export const userRouter = {
         throw error;
       }
 
-      console.log("User", user);
+      console.log("User", JSON.stringify(user));
 
       const dbRoles = await ctx.db.select().from(schema.roles);
 
@@ -382,7 +382,7 @@ export const userRouter = {
         .select()
         .from(schema.rolesXUsersXOrg)
         .where(eq(schema.rolesXUsersXOrg.userId, user.id));
-      console.log("Existing roles", existingRoles);
+      console.log("Existing roles", JSON.stringify(existingRoles));
 
       const newRolesToInsert = roles.filter(
         (role) =>
@@ -392,7 +392,7 @@ export const userRouter = {
               existingRole.orgId === role.orgId,
           ),
       );
-      console.log("New roles to insert", newRolesToInsert);
+      console.log("New roles to insert", JSON.stringify(newRolesToInsert));
 
       for (const role of newRolesToInsert) {
         const { success } = await checkHasRoleOnOrg({
@@ -416,7 +416,7 @@ export const userRouter = {
               role.orgId === existingRole.orgId,
           ),
       );
-      console.log("Roles to delete", rolesToDelete);
+      console.log("Roles to delete", JSON.stringify(rolesToDelete));
 
       for (const role of rolesToDelete) {
         const { success } = await checkHasRoleOnOrg({
@@ -458,7 +458,7 @@ export const userRouter = {
         );
       }
 
-      console.log("New roles to insert", newRolesToInsert);
+      console.log("New roles to insert", JSON.stringify(newRolesToInsert));
       const updatedRoles = await ctx.db
         .select({
           orgId: schema.rolesXUsersXOrg.orgId,

--- a/packages/api/src/services/map-request-notification.ts
+++ b/packages/api/src/services/map-request-notification.ts
@@ -238,16 +238,22 @@ export const notifyMapChangeRequest = async ({
         recipientOrg: recipient.orgName ?? "Unknown",
       });
 
-      console.log("notifyMapChangeRequest: Email sent", {
-        recipient: recipient.email,
-        requestId,
-      });
+      console.log(
+        "notifyMapChangeRequest: Email sent",
+        JSON.stringify({
+          recipient: recipient.email,
+          requestId,
+        }),
+      );
     } catch (error) {
-      console.error("notifyMapChangeRequest: Error sending email", {
-        error,
-        recipient: recipient.email,
-        requestId,
-      });
+      console.error(
+        "notifyMapChangeRequest: Error sending email",
+        JSON.stringify({
+          error,
+          recipient: recipient.email,
+          requestId,
+        }),
+      );
     }
   });
 

--- a/packages/api/src/shared.ts
+++ b/packages/api/src/shared.ts
@@ -252,11 +252,14 @@ export const getSession = async ({ context }: { context: BaseContext }) => {
 
   if (!apiKeyRecord) {
     if (apiKey) {
-      console.log("getSession", {
-        apiKey: apiKey ? `${apiKey.slice(0, 4)}...${apiKey.slice(-4)}` : null,
-        appClient,
-        message: "API key not found in database or invalid",
-      });
+      console.log(
+        "getSession",
+        JSON.stringify({
+          apiKey: apiKey ? `${apiKey.slice(0, 4)}...${apiKey.slice(-4)}` : null,
+          appClient,
+          message: "API key not found in database or invalid",
+        }),
+      );
     }
     return null;
   }


### PR DESCRIPTION
events are being logged to GCP. But we are sending objects, and GCP is listing each property in the object as it's own log line. This makes troubleshooting hard. You can search for a keyword, but it only returns that one property, not the rest. This converts the objects to a single json string before logging.

<img width="600" height="497" alt="image" src="https://github.com/user-attachments/assets/102ae1cd-3ac5-406a-bf32-6e399a4a7054" />
