### PR TITLE
Feat: Add event instance cascade service to event and organization routes

### DIFF
--- a/packages/api/src/lib/cascade-service.test.ts
+++ b/packages/api/src/lib/cascade-service.test.ts
@@ -49,14 +49,20 @@ describe("Cascade Service", () => {
     // Clean up event instances first (FK references events via seriesId)
     for (const eventId of createdEventIds) {
       try {
-        await db.delete(schema.eventInstancesXEventTypes).where(
-          eq(
-            schema.eventInstancesXEventTypes.eventInstanceId,
-            // Delete all join rows for instances of this series
-            // Use a subquery approach: delete instances then join rows
-            eventId,
-          ),
-        );
+        // Delete all join rows for instances of this series by resolving
+        // instance IDs from the event_instances table.
+        const instances = await db
+          .select({ id: schema.eventInstances.id })
+          .from(schema.eventInstances)
+          .where(eq(schema.eventInstances.seriesId, eventId));
+
+        for (const instance of instances) {
+          await db
+            .delete(schema.eventInstancesXEventTypes)
+            .where(
+              eq(schema.eventInstancesXEventTypes.eventInstanceId, instance.id),
+            );
+        }
       } catch {
         // ignore
       }

--- a/packages/api/src/lib/cascade-service.test.ts
+++ b/packages/api/src/lib/cascade-service.test.ts
@@ -1,0 +1,880 @@
+/**
+ * Tests for Cascade Service
+ *
+ * These tests require:
+ * - TEST_DATABASE_URL environment variable to be set
+ * - Test database to be seeded with test data
+ */
+
+import { vi } from "vitest";
+
+vi.mock("@orpc/experimental-ratelimit/memory", () => ({
+  MemoryRatelimiter: vi.fn().mockImplementation(() => ({
+    limit: vi.fn().mockResolvedValue({
+      success: true,
+      limit: 10,
+      remaining: 9,
+      reset: Date.now() + 60000,
+    }),
+  })),
+}));
+
+import { and, eq, gte, schema } from "@acme/db";
+import { afterAll, beforeEach, describe, expect, it } from "vitest";
+import { db, getOrCreateF3NationOrg, uniqueId } from "../__tests__/test-utils";
+import type { SeriesData } from "./cascade-service";
+import {
+  createEventInstancesForSeries,
+  deleteFutureInstancesForSeries,
+  isStructuralChange,
+  recreateFutureInstances,
+  softDeleteFutureInstancesForOrg,
+  softDeleteFutureInstancesForSeries,
+  softDeleteSeriesForOrg,
+  updateFutureInstances,
+} from "./cascade-service";
+
+describe("Cascade Service", () => {
+  // Track created entities for cleanup
+  const createdEventIds: number[] = [];
+  const createdEventTypeIds: number[] = [];
+  const createdLocationIds: number[] = [];
+  const createdOrgIds: number[] = [];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterAll(async () => {
+    // Clean up event instances first (FK references events via seriesId)
+    for (const eventId of createdEventIds) {
+      try {
+        await db.delete(schema.eventInstancesXEventTypes).where(
+          eq(
+            schema.eventInstancesXEventTypes.eventInstanceId,
+            // Delete all join rows for instances of this series
+            // Use a subquery approach: delete instances then join rows
+            eventId,
+          ),
+        );
+      } catch {
+        // ignore
+      }
+    }
+    // Delete event instances by seriesId
+    for (const eventId of createdEventIds) {
+      try {
+        await db
+          .delete(schema.eventInstances)
+          .where(eq(schema.eventInstances.seriesId, eventId));
+      } catch {
+        // ignore
+      }
+    }
+    // Delete events
+    for (const eventId of createdEventIds.reverse()) {
+      try {
+        await db
+          .delete(schema.eventsXEventTypes)
+          .where(eq(schema.eventsXEventTypes.eventId, eventId));
+        await db.delete(schema.events).where(eq(schema.events.id, eventId));
+      } catch {
+        // ignore
+      }
+    }
+    // Delete event types
+    for (const eventTypeId of createdEventTypeIds.reverse()) {
+      try {
+        await db
+          .delete(schema.eventTypes)
+          .where(eq(schema.eventTypes.id, eventTypeId));
+      } catch {
+        // ignore
+      }
+    }
+    // Delete locations
+    for (const locationId of createdLocationIds.reverse()) {
+      try {
+        await db
+          .update(schema.events)
+          .set({ locationId: null })
+          .where(eq(schema.events.locationId, locationId));
+        await db
+          .delete(schema.locations)
+          .where(eq(schema.locations.id, locationId));
+      } catch {
+        // ignore
+      }
+    }
+    // Delete orgs
+    for (const orgId of createdOrgIds.reverse()) {
+      try {
+        await db
+          .delete(schema.rolesXUsersXOrg)
+          .where(eq(schema.rolesXUsersXOrg.orgId, orgId));
+        await db.delete(schema.orgs).where(eq(schema.orgs.id, orgId));
+      } catch {
+        // ignore
+      }
+    }
+  }, 30000);
+
+  // --- Helpers ---
+
+  const createTestRegion = async () => {
+    const nationOrg = await getOrCreateF3NationOrg();
+    const [region] = await db
+      .insert(schema.orgs)
+      .values({
+        name: `Cascade Region ${uniqueId()}`,
+        orgType: "region",
+        parentId: nationOrg.id,
+        isActive: true,
+      })
+      .returning();
+    if (region) createdOrgIds.push(region.id);
+    return region!;
+  };
+
+  const createTestAO = async (regionId: number) => {
+    const [ao] = await db
+      .insert(schema.orgs)
+      .values({
+        name: `Cascade AO ${uniqueId()}`,
+        orgType: "ao",
+        parentId: regionId,
+        isActive: true,
+      })
+      .returning();
+    if (ao) createdOrgIds.push(ao.id);
+    return ao!;
+  };
+
+  const createTestLocation = async (orgId: number) => {
+    const [location] = await db
+      .insert(schema.locations)
+      .values({
+        name: `Cascade Location ${uniqueId()}`,
+        orgId,
+        isActive: true,
+        latitude: 35.5,
+        longitude: -80.5,
+      })
+      .returning();
+    if (location) createdLocationIds.push(location.id);
+    return location!;
+  };
+
+  const createTestEventType = async () => {
+    const [eventType] = await db
+      .insert(schema.eventTypes)
+      .values({
+        name: `Cascade EventType ${uniqueId()}`,
+        eventCategory: "first_f",
+        isActive: true,
+      })
+      .returning();
+    if (eventType) createdEventTypeIds.push(eventType.id);
+    return eventType!;
+  };
+
+  /** Create a series (event with recurrence pattern) in the DB and return SeriesData */
+  const createTestSeries = async (
+    aoId: number,
+    locationId: number | null,
+    overrides?: Partial<SeriesData>,
+  ) => {
+    const defaults = {
+      name: `Cascade Series ${uniqueId()}`,
+      orgId: aoId,
+      locationId,
+      dayOfWeek: "monday" as const,
+      startDate: "2026-01-01",
+      endDate: null,
+      startTime: "0530",
+      endTime: "0615",
+      recurrencePattern: "weekly" as const,
+      recurrenceInterval: 1,
+      indexWithinInterval: 1,
+      isActive: true,
+      isPrivate: false,
+      highlight: false,
+      description: null,
+      meta: null,
+    };
+    const data = { ...defaults, ...overrides };
+
+    const [event] = await db
+      .insert(schema.events)
+      .values({
+        name: data.name,
+        orgId: data.orgId,
+        locationId: data.locationId,
+        dayOfWeek: data.dayOfWeek,
+        startDate: data.startDate,
+        endDate: data.endDate,
+        startTime: data.startTime,
+        endTime: data.endTime,
+        recurrencePattern: data.recurrencePattern,
+        recurrenceInterval: data.recurrenceInterval,
+        indexWithinInterval: data.indexWithinInterval,
+        isActive: data.isActive,
+        isPrivate: data.isPrivate,
+        highlight: data.highlight,
+        description: data.description,
+        meta: data.meta,
+      })
+      .returning();
+
+    if (event) createdEventIds.push(event.id);
+
+    const series: SeriesData = {
+      id: event!.id,
+      ...data,
+    };
+    return series;
+  };
+
+  // --- Pure function tests ---
+
+  describe("isStructuralChange", () => {
+    it("should return false when no structural fields change", () => {
+      const existing = { name: "old", startTime: "0530" };
+      const updated = { name: "new", startTime: "0600" };
+      expect(isStructuralChange(existing, updated)).toBe(false);
+    });
+
+    it("should return true when dayOfWeek changes", () => {
+      expect(
+        isStructuralChange({ dayOfWeek: "monday" }, { dayOfWeek: "wednesday" }),
+      ).toBe(true);
+    });
+
+    it("should return true when recurrencePattern changes", () => {
+      expect(
+        isStructuralChange(
+          { recurrencePattern: "weekly" },
+          { recurrencePattern: "monthly" },
+        ),
+      ).toBe(true);
+    });
+
+    it("should return true when recurrenceInterval changes", () => {
+      expect(
+        isStructuralChange(
+          { recurrenceInterval: 1 },
+          { recurrenceInterval: 2 },
+        ),
+      ).toBe(true);
+    });
+
+    it("should return true when indexWithinInterval changes", () => {
+      expect(
+        isStructuralChange(
+          { indexWithinInterval: 1 },
+          { indexWithinInterval: 2 },
+        ),
+      ).toBe(true);
+    });
+
+    it("should return true when startDate changes", () => {
+      expect(
+        isStructuralChange(
+          { startDate: "2026-01-01" },
+          { startDate: "2026-02-01" },
+        ),
+      ).toBe(true);
+    });
+
+    it("should return true when endDate changes", () => {
+      expect(
+        isStructuralChange(
+          { endDate: "2026-12-31" },
+          { endDate: "2027-06-30" },
+        ),
+      ).toBe(true);
+    });
+
+    it("should return false when fields are undefined", () => {
+      expect(isStructuralChange({ dayOfWeek: "monday" }, {})).toBe(false);
+      expect(isStructuralChange({}, { dayOfWeek: "monday" })).toBe(false);
+    });
+  });
+
+  // --- Database integration tests ---
+
+  describe("createEventInstancesForSeries", () => {
+    it("should create weekly instances for a series", async () => {
+      const region = await createTestRegion();
+      const ao = await createTestAO(region.id);
+      const location = await createTestLocation(region.id);
+
+      const series = await createTestSeries(ao.id, location.id, {
+        dayOfWeek: "monday",
+        recurrencePattern: "weekly",
+        recurrenceInterval: 1,
+        startDate: "2026-04-01",
+        endDate: "2026-06-30",
+      });
+
+      const count = await createEventInstancesForSeries(
+        db,
+        series,
+        4,
+        "2026-04-01",
+      );
+
+      // ~13 Mondays between Apr 1 and Jun 30, 2026
+      expect(count).toBeGreaterThanOrEqual(12);
+      expect(count).toBeLessThanOrEqual(14);
+
+      // Verify actual instances in DB
+      const instances = await db
+        .select()
+        .from(schema.eventInstances)
+        .where(eq(schema.eventInstances.seriesId, series.id));
+
+      expect(instances.length).toBe(count);
+      // All instances should inherit series properties
+      for (const inst of instances) {
+        expect(inst.name).toBe(series.name);
+        expect(inst.orgId).toBe(series.orgId);
+        expect(inst.locationId).toBe(series.locationId);
+        expect(inst.startTime).toBe(series.startTime);
+        expect(inst.endTime).toBe(series.endTime);
+        expect(inst.isActive).toBe(true);
+        expect(inst.seriesId).toBe(series.id);
+      }
+    });
+
+    it("should create biweekly instances (interval=2)", async () => {
+      const region = await createTestRegion();
+      const ao = await createTestAO(region.id);
+
+      const series = await createTestSeries(ao.id, null, {
+        dayOfWeek: "wednesday",
+        recurrencePattern: "weekly",
+        recurrenceInterval: 2,
+        startDate: "2026-04-01",
+        endDate: "2026-06-30",
+      });
+
+      const count = await createEventInstancesForSeries(
+        db,
+        series,
+        4,
+        "2026-04-01",
+      );
+
+      // ~13 Wednesdays / 2 ≈ 6-7
+      expect(count).toBeGreaterThanOrEqual(5);
+      expect(count).toBeLessThanOrEqual(8);
+    });
+
+    it("should create monthly instances", async () => {
+      const region = await createTestRegion();
+      const ao = await createTestAO(region.id);
+
+      // First Monday of every month
+      const series = await createTestSeries(ao.id, null, {
+        dayOfWeek: "monday",
+        recurrencePattern: "monthly",
+        recurrenceInterval: 1,
+        indexWithinInterval: 1,
+        startDate: "2026-01-01",
+        endDate: "2026-12-31",
+      });
+
+      const count = await createEventInstancesForSeries(
+        db,
+        series,
+        4,
+        "2026-01-01",
+      );
+
+      // 12 months => 12 first Mondays
+      expect(count).toBe(12);
+    });
+
+    it("should return 0 for series without recurrence", async () => {
+      const region = await createTestRegion();
+      const ao = await createTestAO(region.id);
+
+      const series = await createTestSeries(ao.id, null, {
+        dayOfWeek: null,
+        recurrencePattern: null,
+      });
+
+      const count = await createEventInstancesForSeries(db, series);
+      expect(count).toBe(0);
+    });
+
+    it("should create event type join rows when eventTypeId is provided", async () => {
+      const region = await createTestRegion();
+      const ao = await createTestAO(region.id);
+      const eventType = await createTestEventType();
+
+      const series = await createTestSeries(ao.id, null, {
+        dayOfWeek: "friday",
+        recurrencePattern: "weekly",
+        recurrenceInterval: 1,
+        startDate: "2026-04-01",
+        endDate: "2026-04-30",
+        eventTypeId: eventType.id,
+      });
+
+      const count = await createEventInstancesForSeries(
+        db,
+        series,
+        4,
+        "2026-04-01",
+      );
+
+      expect(count).toBeGreaterThan(0);
+
+      // Verify join table entries
+      const instances = await db
+        .select({ id: schema.eventInstances.id })
+        .from(schema.eventInstances)
+        .where(eq(schema.eventInstances.seriesId, series.id));
+
+      const joinRows = await db
+        .select()
+        .from(schema.eventInstancesXEventTypes)
+        .where(eq(schema.eventInstancesXEventTypes.eventTypeId, eventType.id));
+
+      // Every instance should have an event type association
+      const instanceIds = new Set(instances.map((i) => i.id));
+      const joinInstanceIds = joinRows
+        .filter((j) => instanceIds.has(j.eventInstanceId))
+        .map((j) => j.eventInstanceId);
+
+      expect(joinInstanceIds.length).toBe(instances.length);
+    });
+
+    it("should not create instances past the endDate", async () => {
+      const region = await createTestRegion();
+      const ao = await createTestAO(region.id);
+
+      const series = await createTestSeries(ao.id, null, {
+        dayOfWeek: "monday",
+        recurrencePattern: "weekly",
+        recurrenceInterval: 1,
+        startDate: "2026-04-01",
+        endDate: "2026-04-15",
+      });
+
+      const count = await createEventInstancesForSeries(
+        db,
+        series,
+        4,
+        "2026-04-01",
+      );
+
+      // Only 2-3 Mondays in Apr 1-15 range (Apr 6, Apr 13)
+      expect(count).toBeLessThanOrEqual(3);
+
+      const instances = await db
+        .select()
+        .from(schema.eventInstances)
+        .where(eq(schema.eventInstances.seriesId, series.id));
+
+      for (const inst of instances) {
+        expect(inst.startDate <= "2026-04-15").toBe(true);
+      }
+    });
+  });
+
+  describe("softDeleteSeriesForOrg", () => {
+    it("should soft delete all series for an org", async () => {
+      const region = await createTestRegion();
+      const ao = await createTestAO(region.id);
+
+      // Create two series for this org
+      await createTestSeries(ao.id, null, {
+        recurrencePattern: "weekly",
+        dayOfWeek: "monday",
+      });
+      await createTestSeries(ao.id, null, {
+        recurrencePattern: "weekly",
+        dayOfWeek: "tuesday",
+      });
+
+      const deletedCount = await softDeleteSeriesForOrg(db, ao.id);
+      expect(deletedCount).toBe(2);
+
+      // Verify they're inactive
+      const events = await db
+        .select()
+        .from(schema.events)
+        .where(eq(schema.events.orgId, ao.id));
+
+      for (const event of events) {
+        expect(event.isActive).toBe(false);
+      }
+    });
+
+    it("should not affect events without recurrence patterns", async () => {
+      const region = await createTestRegion();
+      const ao = await createTestAO(region.id);
+
+      // Create a non-recurring event
+      const [nonRecurring] = await db
+        .insert(schema.events)
+        .values({
+          name: `NonRecurring ${uniqueId()}`,
+          orgId: ao.id,
+          locationId: null,
+          dayOfWeek: null,
+          startDate: "2026-01-01",
+          isActive: true,
+          highlight: false,
+          isPrivate: false,
+          recurrencePattern: null,
+        })
+        .returning();
+      if (nonRecurring) createdEventIds.push(nonRecurring.id);
+
+      const deletedCount = await softDeleteSeriesForOrg(db, ao.id);
+      expect(deletedCount).toBe(0);
+
+      // Non-recurring event should still be active
+      const [event] = await db
+        .select()
+        .from(schema.events)
+        .where(eq(schema.events.id, nonRecurring!.id));
+      expect(event!.isActive).toBe(true);
+    });
+  });
+
+  describe("softDeleteFutureInstancesForOrg", () => {
+    it("should soft delete future instances for an org", async () => {
+      const region = await createTestRegion();
+      const ao = await createTestAO(region.id);
+
+      const series = await createTestSeries(ao.id, null, {
+        dayOfWeek: "monday",
+        recurrencePattern: "weekly",
+        startDate: "2026-04-01",
+        endDate: "2026-05-31",
+      });
+
+      await createEventInstancesForSeries(db, series, 4, "2026-04-01");
+
+      const deletedCount = await softDeleteFutureInstancesForOrg(
+        db,
+        ao.id,
+        "2026-04-15",
+      );
+
+      expect(deletedCount).toBeGreaterThan(0);
+
+      // Instances before cutoff date should still be active
+      const activeInstances = await db
+        .select()
+        .from(schema.eventInstances)
+        .where(
+          and(
+            eq(schema.eventInstances.orgId, ao.id),
+            eq(schema.eventInstances.isActive, true),
+          ),
+        );
+
+      for (const inst of activeInstances) {
+        expect(inst.startDate < "2026-04-15").toBe(true);
+      }
+    });
+  });
+
+  describe("softDeleteFutureInstancesForSeries", () => {
+    it("should soft delete future instances for a specific series", async () => {
+      const region = await createTestRegion();
+      const ao = await createTestAO(region.id);
+
+      const series = await createTestSeries(ao.id, null, {
+        dayOfWeek: "wednesday",
+        recurrencePattern: "weekly",
+        startDate: "2026-04-01",
+        endDate: "2026-05-31",
+      });
+
+      await createEventInstancesForSeries(db, series, 4, "2026-04-01");
+
+      const totalBefore = await db
+        .select()
+        .from(schema.eventInstances)
+        .where(eq(schema.eventInstances.seriesId, series.id));
+
+      const deletedCount = await softDeleteFutureInstancesForSeries(
+        db,
+        series.id,
+        "2026-05-01",
+      );
+
+      expect(deletedCount).toBeGreaterThan(0);
+      expect(deletedCount).toBeLessThan(totalBefore.length);
+
+      // Check remaining active instances are all before the cutoff
+      const stillActive = await db
+        .select()
+        .from(schema.eventInstances)
+        .where(
+          and(
+            eq(schema.eventInstances.seriesId, series.id),
+            eq(schema.eventInstances.isActive, true),
+          ),
+        );
+
+      for (const inst of stillActive) {
+        expect(inst.startDate < "2026-05-01").toBe(true);
+      }
+    });
+  });
+
+  describe("deleteFutureInstancesForSeries", () => {
+    it("should hard delete future instances for a series", async () => {
+      const region = await createTestRegion();
+      const ao = await createTestAO(region.id);
+
+      const series = await createTestSeries(ao.id, null, {
+        dayOfWeek: "thursday",
+        recurrencePattern: "weekly",
+        startDate: "2026-04-01",
+        endDate: "2026-05-31",
+      });
+
+      await createEventInstancesForSeries(db, series, 4, "2026-04-01");
+
+      const totalBefore = await db
+        .select()
+        .from(schema.eventInstances)
+        .where(eq(schema.eventInstances.seriesId, series.id));
+
+      const deletedCount = await deleteFutureInstancesForSeries(
+        db,
+        series.id,
+        "2026-05-01",
+      );
+
+      expect(deletedCount).toBeGreaterThan(0);
+
+      // Remaining instances should only be pre-cutoff
+      const remaining = await db
+        .select()
+        .from(schema.eventInstances)
+        .where(eq(schema.eventInstances.seriesId, series.id));
+
+      expect(remaining.length).toBe(totalBefore.length - deletedCount);
+      for (const inst of remaining) {
+        expect(inst.startDate < "2026-05-01").toBe(true);
+      }
+    });
+  });
+
+  describe("updateFutureInstances", () => {
+    it("should update non-structural fields on future instances", async () => {
+      const region = await createTestRegion();
+      const ao = await createTestAO(region.id);
+      const location = await createTestLocation(region.id);
+
+      const series = await createTestSeries(ao.id, null, {
+        dayOfWeek: "tuesday",
+        recurrencePattern: "weekly",
+        startDate: "2026-04-01",
+        endDate: "2026-05-31",
+      });
+
+      await createEventInstancesForSeries(db, series, 4, "2026-04-01");
+
+      // Update the series data with new non-structural fields
+      const updatedSeries: SeriesData = {
+        ...series,
+        name: "Updated Series Name",
+        description: "New description",
+        locationId: location.id,
+        startTime: "0600",
+        endTime: "0700",
+        isPrivate: true,
+        highlight: true,
+      };
+
+      const updatedCount = await updateFutureInstances(
+        db,
+        updatedSeries,
+        "2026-04-15",
+      );
+
+      expect(updatedCount).toBeGreaterThan(0);
+
+      // Verify the updates
+      const updatedInstances = await db
+        .select()
+        .from(schema.eventInstances)
+        .where(
+          and(
+            eq(schema.eventInstances.seriesId, series.id),
+            gte(schema.eventInstances.startDate, "2026-04-15"),
+          ),
+        );
+
+      for (const inst of updatedInstances) {
+        expect(inst.name).toBe("Updated Series Name");
+        expect(inst.description).toBe("New description");
+        expect(inst.locationId).toBe(location.id);
+        expect(inst.startTime).toBe("0600");
+        expect(inst.endTime).toBe("0700");
+        expect(inst.isPrivate).toBe(true);
+        expect(inst.highlight).toBe(true);
+      }
+    });
+
+    it("should update event type associations for future instances", async () => {
+      const region = await createTestRegion();
+      const ao = await createTestAO(region.id);
+      const eventType1 = await createTestEventType();
+      const eventType2 = await createTestEventType();
+
+      const series = await createTestSeries(ao.id, null, {
+        dayOfWeek: "friday",
+        recurrencePattern: "weekly",
+        startDate: "2026-04-01",
+        endDate: "2026-04-30",
+        eventTypeId: eventType1.id,
+      });
+
+      await createEventInstancesForSeries(db, series, 4, "2026-04-01");
+
+      // Change event type
+      const updatedSeries: SeriesData = {
+        ...series,
+        eventTypeId: eventType2.id,
+      };
+
+      await updateFutureInstances(db, updatedSeries, "2026-04-01");
+
+      // Verify new event type associations
+      const instances = await db
+        .select({ id: schema.eventInstances.id })
+        .from(schema.eventInstances)
+        .where(eq(schema.eventInstances.seriesId, series.id));
+
+      for (const inst of instances) {
+        const joinRows = await db
+          .select()
+          .from(schema.eventInstancesXEventTypes)
+          .where(eq(schema.eventInstancesXEventTypes.eventInstanceId, inst.id));
+        expect(joinRows.length).toBe(1);
+        expect(joinRows[0]!.eventTypeId).toBe(eventType2.id);
+      }
+    });
+
+    it("should return 0 when there are no future instances", async () => {
+      const region = await createTestRegion();
+      const ao = await createTestAO(region.id);
+
+      const series = await createTestSeries(ao.id, null, {
+        dayOfWeek: "monday",
+        recurrencePattern: "weekly",
+        startDate: "2026-04-01",
+        endDate: "2026-04-15",
+      });
+
+      // Create instances in the past (won't match a far-future cutoff)
+      await createEventInstancesForSeries(db, series, 4, "2026-04-01");
+
+      const updatedCount = await updateFutureInstances(
+        db,
+        series,
+        "2099-01-01",
+      );
+      expect(updatedCount).toBe(0);
+    });
+  });
+
+  describe("recreateFutureInstances", () => {
+    it("should delete and recreate instances for structural changes", async () => {
+      const region = await createTestRegion();
+      const ao = await createTestAO(region.id);
+
+      const series = await createTestSeries(ao.id, null, {
+        dayOfWeek: "monday",
+        recurrencePattern: "weekly",
+        startDate: "2026-04-01",
+        endDate: "2026-06-30",
+      });
+
+      // Create initial instances
+      await createEventInstancesForSeries(db, series, 4, "2026-04-01");
+
+      const beforeInstances = await db
+        .select()
+        .from(schema.eventInstances)
+        .where(eq(schema.eventInstances.seriesId, series.id));
+
+      // Recreate with a structural change (e.g. changed dayOfWeek)
+      const updatedSeries: SeriesData = {
+        ...series,
+        dayOfWeek: "wednesday",
+      };
+
+      const result = await recreateFutureInstances(
+        db,
+        updatedSeries,
+        "2026-04-01",
+        4,
+      );
+
+      expect(result.deleted).toBe(beforeInstances.length);
+      expect(result.created).toBeGreaterThan(0);
+
+      // Verify new instances exist and are all on Wednesdays
+      const newInstances = await db
+        .select()
+        .from(schema.eventInstances)
+        .where(eq(schema.eventInstances.seriesId, series.id));
+
+      expect(newInstances.length).toBe(result.created);
+      for (const inst of newInstances) {
+        const date = new Date(inst.startDate + "T12:00:00Z");
+        expect(date.getUTCDay()).toBe(3); // Wednesday = 3
+      }
+    });
+
+    it("should preserve pre-cutoff instances and recreate post-cutoff", async () => {
+      const region = await createTestRegion();
+      const ao = await createTestAO(region.id);
+
+      const series = await createTestSeries(ao.id, null, {
+        dayOfWeek: "tuesday",
+        recurrencePattern: "weekly",
+        startDate: "2026-04-01",
+        endDate: "2026-05-31",
+      });
+
+      await createEventInstancesForSeries(db, series, 4, "2026-04-01");
+
+      const allBefore = await db
+        .select()
+        .from(schema.eventInstances)
+        .where(eq(schema.eventInstances.seriesId, series.id));
+
+      const preCutoff = allBefore.filter((i) => i.startDate < "2026-05-01");
+
+      const result = await recreateFutureInstances(db, series, "2026-05-01", 4);
+
+      // Pre-cutoff instances should still exist
+      const remaining = await db
+        .select()
+        .from(schema.eventInstances)
+        .where(eq(schema.eventInstances.seriesId, series.id));
+
+      const remainingPreCutoff = remaining.filter(
+        (i) => i.startDate < "2026-05-01",
+      );
+
+      expect(remainingPreCutoff.length).toBe(preCutoff.length);
+      expect(result.deleted).toBeGreaterThan(0);
+      expect(result.created).toBeGreaterThan(0);
+    });
+  });
+});

--- a/packages/api/src/lib/cascade-service.test.ts
+++ b/packages/api/src/lib/cascade-service.test.ts
@@ -415,7 +415,7 @@ describe("Cascade Service", () => {
       expect(count).toBe(0);
     });
 
-    it("should create event type join rows when eventTypeId is provided", async () => {
+    it("should create event type join rows when eventTypeIds is provided", async () => {
       const region = await createTestRegion();
       const ao = await createTestAO(region.id);
       const eventType = await createTestEventType();
@@ -426,7 +426,7 @@ describe("Cascade Service", () => {
         recurrenceInterval: 1,
         startDate: "2026-04-01",
         endDate: "2026-04-30",
-        eventTypeId: eventType.id,
+        eventTypeIds: [eventType.id],
       });
 
       const count = await createEventInstancesForSeries(
@@ -745,7 +745,7 @@ describe("Cascade Service", () => {
         recurrencePattern: "weekly",
         startDate: "2026-04-01",
         endDate: "2026-04-30",
-        eventTypeId: eventType1.id,
+        eventTypeIds: [eventType1.id],
       });
 
       await createEventInstancesForSeries(db, series, 4, "2026-04-01");
@@ -753,7 +753,7 @@ describe("Cascade Service", () => {
       // Change event type
       const updatedSeries: SeriesData = {
         ...series,
-        eventTypeId: eventType2.id,
+        eventTypeIds: [eventType2.id],
       };
 
       await updateFutureInstances(db, updatedSeries, "2026-04-01");

--- a/packages/api/src/lib/cascade-service.ts
+++ b/packages/api/src/lib/cascade-service.ts
@@ -1,0 +1,457 @@
+/**
+ * Cascade Service
+ *
+ * Reusable functions for cascading operations between series (events) and event instances.
+ * This handles creating instances when series are created, updating them when series are edited,
+ * and soft-deleting them when series or orgs are deleted.
+ */
+
+import { and, eq, gte, inArray, isNotNull, schema } from "@acme/db";
+import type { AppDb } from "@acme/db/client";
+import type { DayOfWeek, EventCadence } from "@acme/shared/app/enums";
+
+// Type for a series (event with recurrence pattern)
+export interface SeriesData {
+  id: number;
+  orgId: number;
+  locationId: number | null;
+  name: string;
+  description: string | null;
+  startDate: string;
+  endDate: string | null;
+  startTime: string | null;
+  endTime: string | null;
+  dayOfWeek: DayOfWeek | null;
+  recurrencePattern: EventCadence | null;
+  recurrenceInterval: number | null;
+  indexWithinInterval: number | null;
+  isActive: boolean;
+  isPrivate: boolean;
+  highlight: boolean;
+  meta: Record<string, unknown> | null;
+  eventTypeId?: number;
+  eventTagId?: number;
+}
+
+// Structural fields that require recreating instances
+const STRUCTURAL_FIELDS = [
+  "dayOfWeek",
+  "recurrencePattern",
+  "recurrenceInterval",
+  "indexWithinInterval",
+  "startDate",
+  "endDate",
+] as const;
+
+/**
+ * Check if changes between existing and updated series are structural
+ * (require recreating instances vs just updating them in place)
+ */
+export function isStructuralChange(
+  existing: Partial<SeriesData>,
+  updated: Partial<SeriesData>,
+): boolean {
+  for (const field of STRUCTURAL_FIELDS) {
+    if (
+      existing[field] !== undefined &&
+      updated[field] !== undefined &&
+      existing[field] !== updated[field]
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Get today's date in YYYY-MM-DD format (UTC)
+ */
+function getCurrentDate(): string {
+  return new Date().toISOString().split("T")[0]!;
+}
+
+/**
+ * Soft delete all series (events with recurrence patterns) belonging to an org
+ */
+export async function softDeleteSeriesForOrg(
+  db: AppDb,
+  orgId: number,
+): Promise<number> {
+  const result = await db
+    .update(schema.events)
+    .set({ isActive: false })
+    .where(
+      and(
+        eq(schema.events.orgId, orgId),
+        eq(schema.events.isActive, true),
+        isNotNull(schema.events.recurrencePattern),
+      ),
+    )
+    .returning({ id: schema.events.id });
+
+  return result.length;
+}
+
+/**
+ * Soft delete future event instances for an org (starting from today or specified date)
+ */
+export async function softDeleteFutureInstancesForOrg(
+  db: AppDb,
+  orgId: number,
+  startDate?: string,
+): Promise<number> {
+  const fromDate = startDate ?? getCurrentDate();
+
+  const result = await db
+    .update(schema.eventInstances)
+    .set({ isActive: false })
+    .where(
+      and(
+        eq(schema.eventInstances.orgId, orgId),
+        eq(schema.eventInstances.isActive, true),
+        gte(schema.eventInstances.startDate, fromDate),
+      ),
+    )
+    .returning({ id: schema.eventInstances.id });
+
+  return result.length;
+}
+
+/**
+ * Soft delete future event instances for a series (starting from today or specified date)
+ */
+export async function softDeleteFutureInstancesForSeries(
+  db: AppDb,
+  seriesId: number,
+  startDate?: string,
+): Promise<number> {
+  const fromDate = startDate ?? getCurrentDate();
+
+  const result = await db
+    .update(schema.eventInstances)
+    .set({ isActive: false })
+    .where(
+      and(
+        eq(schema.eventInstances.seriesId, seriesId),
+        eq(schema.eventInstances.isActive, true),
+        gte(schema.eventInstances.startDate, fromDate),
+      ),
+    )
+    .returning({ id: schema.eventInstances.id });
+
+  return result.length;
+}
+
+/**
+ * Hard delete future event instances for a series (used when recreating)
+ */
+export async function deleteFutureInstancesForSeries(
+  db: AppDb,
+  seriesId: number,
+  startDate?: string,
+): Promise<number> {
+  const fromDate = startDate ?? getCurrentDate();
+
+  const result = await db
+    .delete(schema.eventInstances)
+    .where(
+      and(
+        eq(schema.eventInstances.seriesId, seriesId),
+        gte(schema.eventInstances.startDate, fromDate),
+      ),
+    )
+    .returning({ id: schema.eventInstances.id });
+
+  return result.length;
+}
+
+/**
+ * Parse a date string (YYYY-MM-DD) to a Date object
+ */
+function parseDate(dateStr: string): Date {
+  const [year, month, day] = dateStr.split("-").map(Number);
+  return new Date(year!, month! - 1, day);
+}
+
+/**
+ * Format a Date to YYYY-MM-DD string
+ */
+function formatDate(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+/**
+ * Get the day of week name from a Date object
+ */
+function getDayOfWeek(date: Date): DayOfWeek {
+  const days: DayOfWeek[] = [
+    "sunday",
+    "monday",
+    "tuesday",
+    "wednesday",
+    "thursday",
+    "friday",
+    "saturday",
+  ];
+  return days[date.getDay()]!;
+}
+
+/**
+ * Add days to a Date object
+ */
+function addDays(date: Date, days: number): Date {
+  const result = new Date(date);
+  result.setDate(result.getDate() + days);
+  return result;
+}
+
+/**
+ * Create event instances for a series based on its recurrence pattern.
+ * Algorithm ported from Python reference implementation.
+ *
+ * @param db Database connection
+ * @param series The series (event) to create instances for
+ * @param yearsAhead How many years of instances to create (default 4)
+ * @param fromDate Optional start date (defaults to today)
+ * @returns Number of instances created
+ */
+export async function createEventInstancesForSeries(
+  db: AppDb,
+  series: SeriesData,
+  yearsAhead = 4,
+  fromDate?: string,
+): Promise<number> {
+  if (!series.dayOfWeek || !series.recurrencePattern) {
+    // Not a valid recurring series
+    return 0;
+  }
+
+  const seriesStartDate = parseDate(series.startDate);
+  const today = fromDate ? parseDate(fromDate) : new Date();
+
+  // Start from the later of series start date or today
+  const startDate = seriesStartDate > today ? seriesStartDate : new Date(today);
+
+  // End date is series end date or X years from start
+  const endDate = series.endDate
+    ? parseDate(series.endDate)
+    : new Date(
+        startDate.getFullYear() + yearsAhead,
+        startDate.getMonth(),
+        startDate.getDate(),
+      );
+
+  const maxInterval = series.recurrenceInterval ?? 1;
+  const indexWithinInterval = series.indexWithinInterval ?? 1;
+  const recurrencePattern = series.recurrencePattern;
+
+  const instanceRecords: (typeof schema.eventInstances.$inferInsert)[] = [];
+
+  let currentDate = new Date(startDate);
+  let currentInterval = 1;
+  let currentIndex = 0;
+
+  // For monthly series, figure out which occurrence of the day of week we're at
+  if (recurrencePattern === "monthly") {
+    currentDate = new Date(
+      currentDate.getFullYear(),
+      currentDate.getMonth(),
+      1,
+    );
+    const actualStart = new Date(startDate);
+
+    while (currentDate <= actualStart) {
+      if (getDayOfWeek(currentDate) === series.dayOfWeek) {
+        currentIndex++;
+      }
+      currentDate = addDays(currentDate, 1);
+    }
+    // Reset to iterate from start
+    currentDate = new Date(startDate);
+  }
+
+  // Event creation algorithm
+  while (currentDate <= endDate) {
+    if (getDayOfWeek(currentDate) === series.dayOfWeek) {
+      currentIndex++;
+
+      const shouldCreate =
+        recurrencePattern === "weekly" || currentIndex === indexWithinInterval;
+
+      if (shouldCreate && currentInterval === 1) {
+        instanceRecords.push({
+          name: series.name,
+          description: series.description,
+          orgId: series.orgId,
+          locationId: series.locationId,
+          startDate: formatDate(currentDate),
+          endDate: formatDate(currentDate),
+          startTime: series.startTime,
+          endTime: series.endTime,
+          isActive: true,
+          seriesId: series.id,
+          isPrivate: series.isPrivate,
+          meta: series.meta,
+          highlight: series.highlight,
+        });
+      }
+
+      if (shouldCreate) {
+        currentInterval =
+          currentInterval < maxInterval ? currentInterval + 1 : 1;
+      }
+    }
+
+    currentDate = addDays(currentDate, 1);
+
+    // Reset index at the start of each month (for monthly recurrence)
+    if (currentDate.getDate() === 1) {
+      currentIndex = 0;
+    }
+  }
+
+  if (instanceRecords.length === 0) {
+    return 0;
+  }
+
+  // Batch insert all instances
+  const created = await db
+    .insert(schema.eventInstances)
+    .values(instanceRecords)
+    .returning({ id: schema.eventInstances.id });
+
+  // Handle event type join table
+  if (series.eventTypeId && created.length > 0) {
+    await db.insert(schema.eventInstancesXEventTypes).values(
+      created.map((instance) => ({
+        eventInstanceId: instance.id,
+        eventTypeId: series.eventTypeId!,
+      })),
+    );
+  }
+
+  // Handle event tag join table
+  if (series.eventTagId && created.length > 0) {
+    await db.insert(schema.eventTagsXEventInstances).values(
+      created.map((instance) => ({
+        eventInstanceId: instance.id,
+        eventTagId: series.eventTagId!,
+      })),
+    );
+  }
+
+  return created.length;
+}
+
+/**
+ * Update future event instances with non-structural changes from series
+ */
+export async function updateFutureInstances(
+  db: AppDb,
+  series: SeriesData,
+  startDate?: string,
+): Promise<number> {
+  const fromDate = startDate ?? getCurrentDate();
+
+  // Get IDs of future instances
+  const futureInstances = await db
+    .select({ id: schema.eventInstances.id })
+    .from(schema.eventInstances)
+    .where(
+      and(
+        eq(schema.eventInstances.seriesId, series.id),
+        gte(schema.eventInstances.startDate, fromDate),
+      ),
+    );
+
+  if (futureInstances.length === 0) {
+    return 0;
+  }
+
+  const instanceIds = futureInstances.map((i) => i.id);
+
+  // Update the instances
+  await db
+    .update(schema.eventInstances)
+    .set({
+      locationId: series.locationId,
+      startTime: series.startTime,
+      endTime: series.endTime,
+      isPrivate: series.isPrivate,
+      meta: series.meta,
+      description: series.description,
+      highlight: series.highlight,
+    })
+    .where(inArray(schema.eventInstances.id, instanceIds));
+
+  // Update event types if provided
+  if (series.eventTypeId !== undefined) {
+    // Delete existing event type associations
+    await db
+      .delete(schema.eventInstancesXEventTypes)
+      .where(
+        inArray(schema.eventInstancesXEventTypes.eventInstanceId, instanceIds),
+      );
+
+    // Add new associations
+    if (series.eventTypeId) {
+      await db.insert(schema.eventInstancesXEventTypes).values(
+        instanceIds.map((id) => ({
+          eventInstanceId: id,
+          eventTypeId: series.eventTypeId!,
+        })),
+      );
+    }
+  }
+
+  // Update event tags if provided
+  if (series.eventTagId !== undefined) {
+    // Delete existing event tag associations
+    await db
+      .delete(schema.eventTagsXEventInstances)
+      .where(
+        inArray(schema.eventTagsXEventInstances.eventInstanceId, instanceIds),
+      );
+
+    // Add new associations
+    if (series.eventTagId) {
+      await db.insert(schema.eventTagsXEventInstances).values(
+        instanceIds.map((id) => ({
+          eventInstanceId: id,
+          eventTagId: series.eventTagId!,
+        })),
+      );
+    }
+  }
+
+  return futureInstances.length;
+}
+
+/**
+ * Recreate future event instances (delete and recreate)
+ * Used when structural changes are made to a series
+ */
+export async function recreateFutureInstances(
+  db: AppDb,
+  series: SeriesData,
+  startDate?: string,
+  yearsAhead = 4,
+): Promise<{ deleted: number; created: number }> {
+  const fromDate = startDate ?? getCurrentDate();
+
+  // Delete existing future instances
+  const deleted = await deleteFutureInstancesForSeries(db, series.id, fromDate);
+
+  // Create new instances
+  const created = await createEventInstancesForSeries(
+    db,
+    series,
+    yearsAhead,
+    fromDate,
+  );
+
+  return { deleted, created };
+}

--- a/packages/api/src/lib/cascade-service.ts
+++ b/packages/api/src/lib/cascade-service.ts
@@ -30,7 +30,7 @@ export interface SeriesData {
   highlight: boolean;
   meta: Record<string, unknown> | null;
   eventTypeId?: number;
-  eventTagId?: number;
+  // eventTagId?: number; // TODO: event tag support
 }
 
 // Structural fields that require recreating instances
@@ -334,14 +334,15 @@ export async function createEventInstancesForSeries(
   }
 
   // Handle event tag join table
-  if (series.eventTagId && created.length > 0) {
-    await db.insert(schema.eventTagsXEventInstances).values(
-      created.map((instance) => ({
-        eventInstanceId: instance.id,
-        eventTagId: series.eventTagId!,
-      })),
-    );
-  }
+  // TODO: event tag support - need to add eventTagId to SeriesData and handle in event router
+  // if (series.eventTagId && created.length > 0) {
+  //   await db.insert(schema.eventTagsXEventInstances).values(
+  //     created.map((instance) => ({
+  //       eventInstanceId: instance.id,
+  //       eventTagId: series.eventTagId!,
+  //     })),
+  //   );
+  // }
 
   return created.length;
 }
@@ -384,6 +385,8 @@ export async function updateFutureInstances(
       meta: series.meta,
       description: series.description,
       highlight: series.highlight,
+      name: series.name,
+      orgId: series.orgId,
     })
     .where(inArray(schema.eventInstances.id, instanceIds));
 
@@ -408,29 +411,28 @@ export async function updateFutureInstances(
   }
 
   // Update event tags if provided
-  if (series.eventTagId !== undefined) {
-    // Delete existing event tag associations
-    await db
-      .delete(schema.eventTagsXEventInstances)
-      .where(
-        inArray(schema.eventTagsXEventInstances.eventInstanceId, instanceIds),
-      );
+  // TODO: event tag support - need to add eventTagId to SeriesData and handle in event router
+  // if (series.eventTagId !== undefined) {
+  //   // Delete existing event tag associations
+  //   await db
+  //     .delete(schema.eventTagsXEventInstances)
+  //     .where(
+  //       inArray(schema.eventTagsXEventInstances.eventInstanceId, instanceIds),
+  //     );
 
-    // Add new associations
-    if (series.eventTagId) {
-      await db.insert(schema.eventTagsXEventInstances).values(
-        instanceIds.map((id) => ({
-          eventInstanceId: id,
-          eventTagId: series.eventTagId!,
-        })),
-      );
-    }
-  }
+  //   // Add new associations
+  //   if (series.eventTagId) {
+  //     await db.insert(schema.eventTagsXEventInstances).values(
+  //       instanceIds.map((id) => ({
+  //         eventInstanceId: id,
+  //         eventTagId: series.eventTagId!,
+  //       })),
+  //     );
+  //   }
+  // }
 
   return futureInstances.length;
-}
-
-/**
+} /**
  * Recreate future event instances (delete and recreate)
  * Used when structural changes are made to a series
  */

--- a/packages/api/src/lib/cascade-service.ts
+++ b/packages/api/src/lib/cascade-service.ts
@@ -9,7 +9,6 @@
 import { and, eq, gte, inArray, isNotNull, schema } from "@acme/db";
 import type { AppDb } from "@acme/db/client";
 import type { DayOfWeek, EventCadence } from "@acme/shared/app/enums";
-import { get } from "lodash";
 
 // Type for a series (event with recurrence pattern)
 export interface SeriesData {

--- a/packages/api/src/lib/cascade-service.ts
+++ b/packages/api/src/lib/cascade-service.ts
@@ -30,7 +30,7 @@ export interface SeriesData {
   isPrivate: boolean;
   highlight: boolean;
   meta: Record<string, unknown> | null;
-  eventTypeId?: number;
+  eventTypeIds?: number[];
   // eventTagId?: number; // TODO: event tag support
 }
 
@@ -325,12 +325,14 @@ export async function createEventInstancesForSeries(
     .returning({ id: schema.eventInstances.id });
 
   // Handle event type join table
-  if (series.eventTypeId && created.length > 0) {
+  if (series.eventTypeIds?.length && created.length > 0) {
     await db.insert(schema.eventInstancesXEventTypes).values(
-      created.map((instance) => ({
-        eventInstanceId: instance.id,
-        eventTypeId: series.eventTypeId!,
-      })),
+      created.flatMap((instance) =>
+        series.eventTypeIds!.map((eventTypeId) => ({
+          eventInstanceId: instance.id,
+          eventTypeId,
+        })),
+      ),
     );
   }
 
@@ -392,7 +394,7 @@ export async function updateFutureInstances(
     .where(inArray(schema.eventInstances.id, instanceIds));
 
   // Update event types if provided
-  if (series.eventTypeId !== undefined) {
+  if (series.eventTypeIds !== undefined) {
     // Delete existing event type associations
     await db
       .delete(schema.eventInstancesXEventTypes)
@@ -401,12 +403,14 @@ export async function updateFutureInstances(
       );
 
     // Add new associations
-    if (series.eventTypeId) {
+    if (series.eventTypeIds.length > 0) {
       await db.insert(schema.eventInstancesXEventTypes).values(
-        instanceIds.map((id) => ({
-          eventInstanceId: id,
-          eventTypeId: series.eventTypeId!,
-        })),
+        instanceIds.flatMap((id) =>
+          series.eventTypeIds!.map((eventTypeId) => ({
+            eventInstanceId: id,
+            eventTypeId,
+          })),
+        ),
       );
     }
   }

--- a/packages/api/src/lib/cascade-service.ts
+++ b/packages/api/src/lib/cascade-service.ts
@@ -9,6 +9,7 @@
 import { and, eq, gte, inArray, isNotNull, schema } from "@acme/db";
 import type { AppDb } from "@acme/db/client";
 import type { DayOfWeek, EventCadence } from "@acme/shared/app/enums";
+import { get } from "lodash";
 
 // Type for a series (event with recurrence pattern)
 export interface SeriesData {
@@ -230,7 +231,7 @@ export async function createEventInstancesForSeries(
   }
 
   const seriesStartDate = parseDate(series.startDate);
-  const today = fromDate ? parseDate(fromDate) : new Date();
+  const today = fromDate ? parseDate(fromDate) : getCurrentDate();
 
   // Start from the later of series start date or today
   const startDate = seriesStartDate > today ? seriesStartDate : new Date(today);

--- a/packages/api/src/lib/cascade-service.ts
+++ b/packages/api/src/lib/cascade-service.ts
@@ -291,7 +291,7 @@ export async function createEventInstancesForSeries(
           endDate: formatDate(currentDate),
           startTime: series.startTime,
           endTime: series.endTime,
-          isActive: true,
+          isActive: series.isActive,
           seriesId: series.id,
           isPrivate: series.isPrivate,
           meta: series.meta,

--- a/packages/api/src/lib/cascade-service.ts
+++ b/packages/api/src/lib/cascade-service.ts
@@ -224,7 +224,7 @@ export async function createEventInstancesForSeries(
   yearsAhead = 4,
   fromDate?: string,
 ): Promise<number> {
-  if (!series.dayOfWeek || !series.recurrencePattern) {
+  if (!series.dayOfWeek) {
     // Not a valid recurring series
     return 0;
   }
@@ -246,7 +246,7 @@ export async function createEventInstancesForSeries(
 
   const maxInterval = series.recurrenceInterval ?? 1;
   const indexWithinInterval = series.indexWithinInterval ?? 1;
-  const recurrencePattern = series.recurrencePattern;
+  const recurrencePattern = series.recurrencePattern ?? "weekly";
 
   const instanceRecords: (typeof schema.eventInstances.$inferInsert)[] = [];
 

--- a/packages/api/src/router/event.test.ts
+++ b/packages/api/src/router/event.test.ts
@@ -17,7 +17,7 @@ vi.mock("@orpc/experimental-ratelimit/memory", () => ({
   })),
 }));
 
-import { eq, schema, and } from "@acme/db";
+import { eq, schema } from "@acme/db";
 import { afterAll, beforeEach, describe, expect, it } from "vitest";
 import {
   cleanup,

--- a/packages/api/src/router/event.test.ts
+++ b/packages/api/src/router/event.test.ts
@@ -17,7 +17,7 @@ vi.mock("@orpc/experimental-ratelimit/memory", () => ({
   })),
 }));
 
-import { eq, schema } from "@acme/db";
+import { eq, schema, and } from "@acme/db";
 import { afterAll, beforeEach, describe, expect, it } from "vitest";
 import {
   cleanup,
@@ -1137,6 +1137,438 @@ describe("Event Router", () => {
 
       expect(result).toHaveProperty("lookup");
       expect(typeof result.lookup).toBe("object");
+    });
+  });
+  describe("cascade service integration", () => {
+    describe("crupdate with recurrence", () => {
+      it("should create event instances when creating a new recurring series", async () => {
+        const session = await createAdminSession();
+        await mockAuthWithSession(session);
+
+        const region = await createTestRegion();
+        if (!region) return;
+
+        const ao = await createTestAO(region.id);
+        if (!ao) return;
+
+        const location = await createTestLocation(region.id);
+        if (!location) return;
+
+        const eventType = await createTestEventType();
+        if (!eventType) return;
+
+        const editorSession = createEditorSession({
+          orgId: ao.id,
+          orgName: ao.name,
+        });
+        await mockAuthWithSession(editorSession);
+
+        const client = createTestClient();
+        const seriesName = `Recurring Series ${uniqueId()}`;
+
+        const result = await client.event.crupdate({
+          name: seriesName,
+          aoId: ao.id,
+          regionId: region.id,
+          locationId: location.id,
+          dayOfWeek: "monday",
+          startTime: "0530",
+          endTime: "0615",
+          startDate: "2026-01-01",
+          endDate: "2026-03-31",
+          recurrencePattern: "weekly",
+          recurrenceInterval: 1,
+          indexWithinInterval: null,
+          highlight: false,
+          isActive: true,
+          eventTypeIds: [eventType.id],
+          email: null,
+        });
+
+        expect(result.event).not.toBeNull();
+        expect(result.event?.recurrencePattern).toBe("weekly");
+
+        const seriesId = result.event?.id;
+        if (seriesId) {
+          createdEventIds.push(seriesId);
+
+          // Verify instances were created
+          const instances = await db
+            .select()
+            .from(schema.eventInstances)
+            .where(eq(schema.eventInstances.seriesId, seriesId));
+
+          expect(instances.length).toBeGreaterThan(0);
+          // Should have instances for each Monday from Jan 1 to March 31, 2026
+          expect(instances.length).toBeGreaterThanOrEqual(12);
+          // Instances in eventInstances are cascade-deleted with the parent series event
+        }
+      });
+
+      it("should update future instances in place for non-structural changes", async () => {
+        const session = await createAdminSession();
+        await mockAuthWithSession(session);
+
+        const region = await createTestRegion();
+        if (!region) return;
+
+        const ao = await createTestAO(region.id);
+        if (!ao) return;
+
+        const location = await createTestLocation(region.id);
+        if (!location) return;
+
+        const eventType = await createTestEventType();
+        if (!eventType) return;
+
+        // Create initial series
+        const [seriesEvent] = await db
+          .insert(schema.events)
+          .values({
+            name: `Original Series ${uniqueId()}`,
+            orgId: ao.id,
+            locationId: location.id,
+            dayOfWeek: "monday",
+            startTime: "0530",
+            endTime: "0615",
+            startDate: "2026-01-01",
+            endDate: "2026-03-31",
+            recurrencePattern: "weekly",
+            recurrenceInterval: 1,
+            indexWithinInterval: null,
+            isActive: true,
+            highlight: false,
+          })
+          .returning();
+
+        if (!seriesEvent) return;
+        createdEventIds.push(seriesEvent.id);
+
+        // Create some instances
+        const [instance1] = await db
+          .insert(schema.eventInstances)
+          .values({
+            name: `Original Series ${uniqueId()}`,
+            orgId: ao.id,
+            locationId: location.id,
+            startTime: "0530",
+            endTime: "0615",
+            startDate: "2026-04-07",
+            isActive: true,
+            highlight: false,
+            seriesId: seriesEvent.id,
+            isPrivate: false,
+          })
+          .returning();
+
+        const editorSession = createEditorSession({
+          orgId: ao.id,
+          orgName: ao.name,
+        });
+        await mockAuthWithSession(editorSession);
+
+        const client = createTestClient();
+        const updatedName = `Updated Series ${uniqueId()}`;
+
+        // Non-structural change: update name and time (not dayOfWeek, recurrence pattern, etc.)
+        const result = await client.event.crupdate({
+          id: seriesEvent.id,
+          name: updatedName,
+          aoId: ao.id,
+          regionId: region.id,
+          locationId: location.id,
+          dayOfWeek: "monday", // Same
+          startTime: "0600", // Changed (non-structural)
+          endTime: "0645", // Changed (non-structural)
+          startDate: "2026-01-01", // Same
+          endDate: "2026-03-31", // Same
+          recurrencePattern: "weekly", // Same
+          recurrenceInterval: 1, // Same
+          indexWithinInterval: null, // Same
+          highlight: false,
+          isActive: true,
+          eventTypeIds: [eventType.id],
+          email: null,
+        });
+
+        expect(result.event?.name).toBe(updatedName);
+        expect(result.event?.startTime).toBe("0600");
+
+        // Verify instance was updated in place (not recreated with new ID)
+        if (instance1) {
+          const [updatedInstance] = await db
+            .select()
+            .from(schema.eventInstances)
+            .where(eq(schema.eventInstances.id, instance1.id));
+
+          expect(updatedInstance?.name).toBe(updatedName);
+          expect(updatedInstance?.startTime).toBe("0600");
+          expect(updatedInstance?.seriesId).toBe(seriesEvent.id);
+        }
+      });
+
+      it("should recreate future instances for structural changes", async () => {
+        const session = await createAdminSession();
+        await mockAuthWithSession(session);
+
+        const region = await createTestRegion();
+        if (!region) return;
+
+        const ao = await createTestAO(region.id);
+        if (!ao) return;
+
+        const location = await createTestLocation(region.id);
+        if (!location) return;
+
+        const eventType = await createTestEventType();
+        if (!eventType) return;
+
+        // Create initial series on Mondays
+        const [seriesEvent] = await db
+          .insert(schema.events)
+          .values({
+            name: `Structural Change Series ${uniqueId()}`,
+            orgId: ao.id,
+            locationId: location.id,
+            dayOfWeek: "monday",
+            startTime: "0530",
+            endTime: "0615",
+            startDate: "2026-01-01",
+            endDate: "2026-03-31",
+            recurrencePattern: "weekly",
+            recurrenceInterval: 1,
+            indexWithinInterval: null,
+            isActive: true,
+            highlight: false,
+          })
+          .returning();
+
+        if (!seriesEvent) return;
+        createdEventIds.push(seriesEvent.id);
+
+        // Create initial instance on Monday
+        const [instance1] = await db
+          .insert(schema.eventInstances)
+          .values({
+            name: `Structural Change Series ${uniqueId()}`,
+            orgId: ao.id,
+            locationId: location.id,
+            startTime: "0530",
+            endTime: "0615",
+            startDate: "2026-04-07",
+            isActive: true,
+            highlight: false,
+            seriesId: seriesEvent.id,
+            isPrivate: false,
+          })
+          .returning();
+
+        const editorSession = createEditorSession({
+          orgId: ao.id,
+          orgName: ao.name,
+        });
+        await mockAuthWithSession(editorSession);
+
+        const client = createTestClient();
+
+        // Structural change: change dayOfWeek from Monday to Tuesday
+        const result = await client.event.crupdate({
+          id: seriesEvent.id,
+          name: seriesEvent.name,
+          aoId: ao.id,
+          regionId: region.id,
+          locationId: location.id,
+          dayOfWeek: "tuesday", // Changed from Monday (structural)
+          startTime: "0530",
+          endTime: "0615",
+          startDate: "2026-01-01",
+          endDate: "2026-03-31",
+          recurrencePattern: "weekly",
+          recurrenceInterval: 1,
+          indexWithinInterval: null,
+          highlight: false,
+          isActive: true,
+          eventTypeIds: [eventType.id],
+          email: null,
+        });
+
+        expect(result.event?.dayOfWeek).toBe("tuesday");
+
+        // Verify old instance was hard-deleted (recreateFutureInstances deletes and recreates)
+        if (instance1) {
+          const [deletedInstance] = await db
+            .select()
+            .from(schema.eventInstances)
+            .where(eq(schema.eventInstances.id, instance1.id));
+
+          expect(deletedInstance).toBeUndefined();
+        }
+
+        // Verify new instances were created for Tuesdays
+        const newInstances = await db
+          .select()
+          .from(schema.eventInstances)
+          .where(eq(schema.eventInstances.seriesId, seriesEvent.id));
+
+        expect(newInstances.length).toBeGreaterThan(0);
+      });
+
+      it("should create weekly instances when recurrencePattern is null (defaults to weekly)", async () => {
+        const session = await createAdminSession();
+        await mockAuthWithSession(session);
+
+        const region = await createTestRegion();
+        if (!region) return;
+
+        const ao = await createTestAO(region.id);
+        if (!ao) return;
+
+        const location = await createTestLocation(region.id);
+        if (!location) return;
+
+        const eventType = await createTestEventType();
+        if (!eventType) return;
+
+        const editorSession = createEditorSession({
+          orgId: ao.id,
+          orgName: ao.name,
+        });
+        await mockAuthWithSession(editorSession);
+
+        const client = createTestClient();
+
+        // Create event with null recurrencePattern — should default to weekly
+        const result = await client.event.crupdate({
+          name: `Null Recurrence Weekly ${uniqueId()}`,
+          aoId: ao.id,
+          regionId: region.id,
+          locationId: location.id,
+          dayOfWeek: "wednesday",
+          startTime: "0530",
+          endTime: "0615",
+          startDate: "2026-01-01",
+          endDate: "2026-03-31",
+          recurrencePattern: null,
+          recurrenceInterval: null,
+          indexWithinInterval: null,
+          highlight: false,
+          isActive: true,
+          eventTypeIds: [eventType.id],
+          email: null,
+        });
+
+        expect(result.event).not.toBeNull();
+        expect(result.event?.recurrencePattern).toBeNull();
+
+        if (result.event) {
+          createdEventIds.push(result.event.id);
+
+          // Should still have weekly instances generated
+          const instances = await db
+            .select()
+            .from(schema.eventInstances)
+            .where(eq(schema.eventInstances.seriesId, result.event.id));
+
+          expect(instances.length).toBeGreaterThan(0);
+          // ~12 Wednesdays from Jan 1 to March 31
+          expect(instances.length).toBeGreaterThanOrEqual(12);
+        }
+      });
+
+      it("should cascade soft-delete to instances when deleting a series", async () => {
+        const session = await createAdminSession();
+        await mockAuthWithSession(session);
+
+        const region = await createTestRegion();
+        if (!region) return;
+
+        const ao = await createTestAO(region.id);
+        if (!ao) return;
+
+        const location = await createTestLocation(region.id);
+        if (!location) return;
+
+        // Create initial recurring series
+        const [seriesEvent] = await db
+          .insert(schema.events)
+          .values({
+            name: `Delete Series ${uniqueId()}`,
+            orgId: ao.id,
+            locationId: location.id,
+            dayOfWeek: "monday",
+            startTime: "0530",
+            endTime: "0615",
+            startDate: "2026-01-01",
+            endDate: "2026-03-31",
+            recurrencePattern: "weekly",
+            recurrenceInterval: 1,
+            indexWithinInterval: null,
+            isActive: true,
+            highlight: false,
+          })
+          .returning();
+
+        if (!seriesEvent) return;
+        createdEventIds.push(seriesEvent.id);
+
+        // Create instances
+        const [instance1] = await db
+          .insert(schema.eventInstances)
+          .values({
+            name: `Delete Series ${uniqueId()}`,
+            orgId: ao.id,
+            locationId: location.id,
+            startTime: "0530",
+            endTime: "0615",
+            startDate: "2026-04-07",
+            isActive: true,
+            highlight: false,
+            seriesId: seriesEvent.id,
+            isPrivate: false,
+          })
+          .returning();
+
+        const adminSession = await createAdminSession();
+        if (adminSession.roles && adminSession.user?.roles) {
+          adminSession.roles.push({
+            orgId: ao.id,
+            orgName: ao.name,
+            roleName: "admin",
+          });
+          adminSession.user.roles.push({
+            orgId: ao.id,
+            orgName: ao.name,
+            roleName: "admin",
+          });
+        }
+        await mockAuthWithSession(adminSession);
+
+        const client = createTestClient();
+
+        const result = await client.event.delete({
+          id: seriesEvent.id,
+        });
+
+        expect(result.eventId).toBe(seriesEvent.id);
+
+        // Verify series is soft-deleted
+        const [deletedSeries] = await db
+          .select()
+          .from(schema.events)
+          .where(eq(schema.events.id, seriesEvent.id));
+
+        expect(deletedSeries?.isActive).toBe(false);
+
+        // Verify instances are soft-deleted
+        if (instance1) {
+          const [deletedInstance] = await db
+            .select()
+            .from(schema.eventInstances)
+            .where(eq(schema.eventInstances.id, instance1.id));
+
+          expect(deletedInstance?.isActive).toBe(false);
+        }
+      });
     });
   });
 });

--- a/packages/api/src/router/event.ts
+++ b/packages/api/src/router/event.ts
@@ -678,7 +678,7 @@ export const eventRouter = {
       tags: ["event"],
       summary: "Create or update event",
       description:
-        "Create a new event or update an existing one. Requires editor role for the event's organization. Events are associated with locations and can have multiple event types.",
+        "Create a new event or update an existing one. Requires editor role for the event's organization. Events are associated with locations and can have multiple event types. When creating or updating an event, future instances will be automatically created or updated based on the event's recurrence pattern. Changes to series events will cascade to future instances.",
     })
     .output(
       z.object({
@@ -793,6 +793,74 @@ export const eventRouter = {
         eventId: result.id,
       });
 
+      // Handle event instance cascade operations for series (events with recurrence patterns)
+      if (result.recurrencePattern) {
+        const {
+          isStructuralChange,
+          createEventInstancesForSeries,
+          updateFutureInstances,
+          recreateFutureInstances,
+        } = await import("../lib/cascade-service");
+
+        // Build series data for cascade operations
+        const seriesData = {
+          id: result.id,
+          orgId: result.orgId,
+          locationId: result.locationId,
+          name: result.name,
+          description: result.description,
+          startDate: result.startDate,
+          endDate: result.endDate,
+          startTime: result.startTime,
+          endTime: result.endTime,
+          dayOfWeek: result.dayOfWeek,
+          recurrencePattern: result.recurrencePattern,
+          recurrenceInterval: result.recurrenceInterval,
+          indexWithinInterval: result.indexWithinInterval,
+          isActive: result.isActive,
+          isPrivate: result.isPrivate,
+          highlight: result.highlight,
+          meta: result.meta as Record<string, unknown> | null,
+          eventTypeId: eventTypeIds?.[0],
+          // eventTagId: eventTagIds?.[0], // TODO: event tag support
+        };
+
+        if (!existingEvent) {
+          // New series: create event instances
+          await createEventInstancesForSeries(ctx.db, seriesData);
+        } else if (existingEvent.recurrencePattern) {
+          // Existing series: check for structural changes
+          const existingSeriesData = {
+            dayOfWeek: existingEvent.dayOfWeek,
+            recurrencePattern: existingEvent.recurrencePattern,
+            recurrenceInterval: existingEvent.recurrenceInterval,
+            indexWithinInterval: existingEvent.indexWithinInterval,
+            startDate: existingEvent.startDate,
+            endDate: existingEvent.endDate,
+          };
+
+          const updatedSeriesData = {
+            dayOfWeek: result.dayOfWeek,
+            recurrencePattern: result.recurrencePattern,
+            recurrenceInterval: result.recurrenceInterval,
+            indexWithinInterval: result.indexWithinInterval,
+            startDate: result.startDate,
+            endDate: result.endDate,
+          };
+
+          if (isStructuralChange(existingSeriesData, updatedSeriesData)) {
+            // Structural change: delete and recreate future instances
+            await recreateFutureInstances(ctx.db, seriesData);
+          } else {
+            // Non-structural change: update future instances in place
+            await updateFutureInstances(ctx.db, seriesData);
+          }
+        } else {
+          // Converting a non-series event to a series: create instances
+          await createEventInstancesForSeries(ctx.db, seriesData);
+        }
+      }
+
       return { event: result ?? null };
     }),
   eventIdToRegionNameLookup: protectedProcedure
@@ -867,7 +935,7 @@ export const eventRouter = {
       tags: ["event"],
       summary: "Delete event",
       description:
-        "Soft delete an event by marking it as inactive. The event will no longer appear on the map but the data is preserved.",
+        "Soft delete an event by marking it as inactive. The event will no longer appear on the map but the data is preserved. Future instances of this series event will also be soft deleted.",
     })
     .handler(async ({ context: ctx, input }) => {
       const [event] = await ctx.db
@@ -900,6 +968,12 @@ export const eventRouter = {
 
       // Notify webhooks and invalidate cache about the event deletion
       notifyMapDataChange({ type: "event.deleted", eventId: input.id });
+
+      // Cascade delete event instances for series events
+      const { softDeleteFutureInstancesForSeries } = await import(
+        "../lib/cascade-service"
+      );
+      await softDeleteFutureInstancesForSeries(ctx.db, input.id);
 
       return { eventId: input.id };
     }),

--- a/packages/api/src/router/event.ts
+++ b/packages/api/src/router/event.ts
@@ -793,8 +793,9 @@ export const eventRouter = {
         eventId: result.id,
       });
 
-      // Handle event instance cascade operations for series (events with recurrence patterns)
-      if (result.recurrencePattern) {
+      // Handle event instance cascade operations for series (events with recurrence patterns).
+      // null recurrencePattern defaults to weekly in createEventInstancesForSeries.
+      if (result.dayOfWeek) {
         const {
           isStructuralChange,
           createEventInstancesForSeries,
@@ -826,8 +827,13 @@ export const eventRouter = {
         };
 
         if (!existingEvent) {
-          // New series: create event instances
-          await createEventInstancesForSeries(ctx.db, seriesData);
+          // New series: create event instances from series start date
+          await createEventInstancesForSeries(
+            ctx.db,
+            seriesData,
+            4,
+            seriesData.startDate,
+          );
         } else if (existingEvent.recurrencePattern) {
           // Existing series: check for structural changes
           const existingSeriesData = {
@@ -856,8 +862,13 @@ export const eventRouter = {
             await updateFutureInstances(ctx.db, seriesData);
           }
         } else {
-          // Converting a non-series event to a series: create instances
-          await createEventInstancesForSeries(ctx.db, seriesData);
+          // Converting a non-series event to a series: create instances from series start date
+          await createEventInstancesForSeries(
+            ctx.db,
+            seriesData,
+            4,
+            seriesData.startDate,
+          );
         }
       }
 

--- a/packages/api/src/router/event.ts
+++ b/packages/api/src/router/event.ts
@@ -822,7 +822,7 @@ export const eventRouter = {
           isPrivate: result.isPrivate,
           highlight: result.highlight,
           meta: result.meta as Record<string, unknown> | null,
-          eventTypeId: eventTypeIds?.[0],
+          eventTypeIds: eventTypeIds,
           // eventTagId: eventTagIds?.[0], // TODO: event tag support
         };
 

--- a/packages/api/src/router/event.ts
+++ b/packages/api/src/router/event.ts
@@ -787,12 +787,6 @@ export const eventRouter = {
         );
       }
 
-      // Notify webhooks and invalidate cache about the event change
-      notifyMapDataChange({
-        type: input.id ? "event.updated" : "event.created",
-        eventId: result.id,
-      });
-
       // Handle event instance cascade operations for series (events with recurrence patterns).
       // null recurrencePattern defaults to weekly in createEventInstancesForSeries.
       if (result.dayOfWeek) {
@@ -870,6 +864,12 @@ export const eventRouter = {
             seriesData.startDate,
           );
         }
+
+        // Notify webhooks and invalidate cache about the event change
+        notifyMapDataChange({
+          type: input.id ? "event.updated" : "event.created",
+          eventId: result.id,
+        });
       }
 
       return { event: result ?? null };
@@ -977,14 +977,14 @@ export const eventRouter = {
           and(eq(schema.events.id, input.id), eq(schema.events.isActive, true)),
         );
 
-      // Notify webhooks and invalidate cache about the event deletion
-      notifyMapDataChange({ type: "event.deleted", eventId: input.id });
-
       // Cascade delete event instances for series events
       const { softDeleteFutureInstancesForSeries } = await import(
         "../lib/cascade-service"
       );
       await softDeleteFutureInstancesForSeries(ctx.db, input.id);
+
+      // Notify webhooks and invalidate cache about the event deletion
+      notifyMapDataChange({ type: "event.deleted", eventId: input.id });
 
       return { eventId: input.id };
     }),

--- a/packages/api/src/router/org.test.ts
+++ b/packages/api/src/router/org.test.ts
@@ -17,7 +17,7 @@ vi.mock("@orpc/experimental-ratelimit/memory", () => ({
   })),
 }));
 
-import { eq, schema } from "@acme/db";
+import { and, eq, gte, schema } from "@acme/db";
 import { afterAll, beforeEach, describe, expect, it } from "vitest";
 import {
   cleanup,
@@ -399,6 +399,137 @@ describe("Org Router", () => {
           id: f3Nation.id,
         }),
       ).rejects.toThrow();
+    });
+
+    it("should cascade soft delete series and future instances when deleting an AO", async () => {
+      const f3Nation = await getOrCreateF3NationOrg();
+      const session = await createAdminSession();
+      await mockAuthWithSession(session);
+
+      // Create region → AO hierarchy
+      const [region] = await db
+        .insert(schema.orgs)
+        .values({
+          name: `CascadeRegion ${uniqueId()}`,
+          orgType: "region",
+          parentId: f3Nation.id,
+          isActive: true,
+        })
+        .returning();
+      if (!region) return;
+      createdOrgIds.push(region.id);
+
+      const [ao] = await db
+        .insert(schema.orgs)
+        .values({
+          name: `CascadeAO ${uniqueId()}`,
+          orgType: "ao",
+          parentId: region.id,
+          isActive: true,
+        })
+        .returning();
+      if (!ao) return;
+      createdOrgIds.push(ao.id);
+
+      // Create a recurring series (event with recurrence pattern)
+      const [series] = await db
+        .insert(schema.events)
+        .values({
+          name: `CascadeSeries ${uniqueId()}`,
+          orgId: ao.id,
+          locationId: null,
+          dayOfWeek: "monday",
+          startTime: "0530",
+          recurrencePattern: "weekly",
+          recurrenceInterval: 1,
+          startDate: "2026-01-01",
+          isActive: true,
+          highlight: false,
+          isPrivate: false,
+        })
+        .returning();
+      if (!series) return;
+
+      // Create a past instance (should NOT be soft-deleted)
+      const [pastInstance] = await db
+        .insert(schema.eventInstances)
+        .values({
+          name: series.name,
+          orgId: ao.id,
+          seriesId: series.id,
+          startDate: "2025-01-06",
+          isActive: true,
+          highlight: false,
+          isPrivate: false,
+        })
+        .returning();
+
+      // Create future instances (should be soft-deleted)
+      const futureInstanceIds: number[] = [];
+      for (const date of ["2026-04-06", "2026-04-13", "2026-04-20"]) {
+        const [inst] = await db
+          .insert(schema.eventInstances)
+          .values({
+            name: series.name,
+            orgId: ao.id,
+            seriesId: series.id,
+            startDate: date,
+            isActive: true,
+            highlight: false,
+            isPrivate: false,
+          })
+          .returning();
+        if (inst) futureInstanceIds.push(inst.id);
+      }
+
+      expect(futureInstanceIds).toHaveLength(3);
+
+      // Delete the AO via the router
+      const client = createTestClient();
+      const result = await client.org.delete({ id: ao.id });
+      expect(result.orgId).toBe(ao.id);
+
+      // Assert the AO itself is inactive
+      const [deletedAo] = await db
+        .select()
+        .from(schema.orgs)
+        .where(eq(schema.orgs.id, ao.id));
+      expect(deletedAo?.isActive).toBe(false);
+
+      // Assert the series is soft-deleted
+      const [deletedSeries] = await db
+        .select()
+        .from(schema.events)
+        .where(eq(schema.events.id, series.id));
+      expect(deletedSeries?.isActive).toBe(false);
+
+      // Assert future instances are soft-deleted
+      const futureInstances = await db
+        .select()
+        .from(schema.eventInstances)
+        .where(
+          and(
+            eq(schema.eventInstances.orgId, ao.id),
+            gte(schema.eventInstances.startDate, "2026-03-25"),
+          ),
+        );
+      expect(futureInstances.length).toBeGreaterThanOrEqual(3);
+      expect(futureInstances.every((i) => i.isActive === false)).toBe(true);
+
+      // Assert past instance is NOT soft-deleted
+      if (pastInstance) {
+        const [past] = await db
+          .select()
+          .from(schema.eventInstances)
+          .where(eq(schema.eventInstances.id, pastInstance.id));
+        expect(past?.isActive).toBe(true);
+      }
+
+      // Cleanup: hard-delete test event instances, series, and orgs
+      await db
+        .delete(schema.eventInstances)
+        .where(eq(schema.eventInstances.orgId, ao.id));
+      await db.delete(schema.events).where(eq(schema.events.id, series.id));
     });
   });
 });

--- a/packages/api/src/router/org.ts
+++ b/packages/api/src/router/org.ts
@@ -1001,23 +1001,57 @@ export const orgRouter = {
           ),
         );
 
-      // Notify webhooks about the org deletion
-      notifyMapDataChange({ type: "org.deleted", orgId: input.id });
-
-      // Get the org type before deleting to determine if cascading is needed
+      // Get the org first to validate it exists and matches the provided type
       const [org] = await ctx.db
-        .select({ orgType: schema.orgs.orgType })
+        .select({
+          orgType: schema.orgs.orgType,
+          isActive: schema.orgs.isActive,
+        })
         .from(schema.orgs)
         .where(eq(schema.orgs.id, input.id));
 
+      if (!org) {
+        throw new ORPCError("NOT_FOUND", {
+          message: "Organization not found",
+        });
+      }
+
+      if (input.orgType && org.orgType !== input.orgType) {
+        throw new ORPCError("CONFLICT", {
+          message: `Organization type mismatch: expected ${input.orgType}, got ${org.orgType}`,
+        });
+      }
+
+      if (!org.isActive) {
+        throw new ORPCError("CONFLICT", {
+          message: "Organization is already inactive",
+        });
+      }
+
+      // Perform the soft delete with .returning() to confirm success
+      const [deletedOrg] = await ctx.db
+        .update(schema.orgs)
+        .set({ isActive: false })
+        .where(eq(schema.orgs.id, input.id))
+        .returning();
+
+      if (!deletedOrg) {
+        throw new ORPCError("CONFLICT", {
+          message: "Failed to delete organization",
+        });
+      }
+
       // If this is an AO, cascade soft-delete to series and event instances
-      if (org?.orgType === "ao") {
+      if (org.orgType === "ao") {
         const { softDeleteSeriesForOrg, softDeleteFutureInstancesForOrg } =
           await import("../lib/cascade-service");
 
         await softDeleteSeriesForOrg(ctx.db, input.id);
         await softDeleteFutureInstancesForOrg(ctx.db, input.id);
       }
+
+      // Notify webhooks about the org deletion
+      notifyMapDataChange({ type: "org.deleted", orgId: input.id });
 
       return { orgId: input.id };
     }),

--- a/packages/api/src/router/org.ts
+++ b/packages/api/src/router/org.ts
@@ -970,7 +970,8 @@ export const orgRouter = {
       path: "/delete/{id}",
       tags: ["org"],
       summary: "Delete organization",
-      description: "Soft delete an organization by marking it as inactive",
+      description:
+        "Soft delete an organization by marking it as inactive. This will also soft delete all associated event series and instances if the org is an AO.",
     })
     .output(
       z.object({
@@ -1002,6 +1003,21 @@ export const orgRouter = {
 
       // Notify webhooks about the org deletion
       notifyMapDataChange({ type: "org.deleted", orgId: input.id });
+
+      // Get the org type before deleting to determine if cascading is needed
+      const [org] = await ctx.db
+        .select({ orgType: schema.orgs.orgType })
+        .from(schema.orgs)
+        .where(eq(schema.orgs.id, input.id));
+
+      // If this is an AO, cascade soft-delete to series and event instances
+      if (org?.orgType === "ao") {
+        const { softDeleteSeriesForOrg, softDeleteFutureInstancesForOrg } =
+          await import("../lib/cascade-service");
+
+        await softDeleteSeriesForOrg(ctx.db, input.id);
+        await softDeleteFutureInstancesForOrg(ctx.db, input.id);
+      }
 
       return { orgId: input.id };
     }),

--- a/packages/api/src/router/org.ts
+++ b/packages/api/src/router/org.ts
@@ -990,16 +990,6 @@ export const orgRouter = {
           message: "You are not authorized to delete this org",
         });
       }
-      await ctx.db
-        .update(schema.orgs)
-        .set({ isActive: false })
-        .where(
-          and(
-            eq(schema.orgs.id, input.id),
-            input.orgType ? eq(schema.orgs.orgType, input.orgType) : undefined,
-            eq(schema.orgs.isActive, true),
-          ),
-        );
 
       // Get the org first to validate it exists and matches the provided type
       const [org] = await ctx.db


### PR DESCRIPTION
This pull request introduces a service to manage instances of a series as the series and org endpoints are used. Now, changes to recurring events (series) will automatically propagate to their future instances, and deleting an event or organization will also handle related series and instances appropriately. The most important changes are grouped below.

**Event Series Cascade Management:**

* When creating or updating an event with a recurrence pattern, future instances are now automatically created or updated based on the series' recurrence pattern. Structural changes to a series (such as changing the recurrence rule) will trigger deletion and recreation of future instances, while non-structural changes will update future instances in place (`event.ts`) [[1]](diffhunk://#diff-f858ca38b819c892d506404d508446641d57d94dc1f92879fe97ac87df30d446L681-R681) [[2]](diffhunk://#diff-f858ca38b819c892d506404d508446641d57d94dc1f92879fe97ac87df30d446R796-R863).
* Deleting an event that is part of a series will now also soft-delete all its future instances (`event.ts`) [[1]](diffhunk://#diff-f858ca38b819c892d506404d508446641d57d94dc1f92879fe97ac87df30d446L870-R938) [[2]](diffhunk://#diff-f858ca38b819c892d506404d508446641d57d94dc1f92879fe97ac87df30d446R972-R977).

**Organization Cascade Management:**

* Deleting an organization now includes a check for the organization type. If it is an AO (Area of Operation), all associated event series and their future instances will also be soft-deleted (`org.ts`) [[1]](diffhunk://#diff-1b2a5b360b761c88ed70c9d4b79da1b549d0981981e1045454880b307ea38779L973-R974) [[2]](diffhunk://#diff-1b2a5b360b761c88ed70c9d4b79da1b549d0981981e1045454880b307ea38779R1007-R1021).

### 👋 TL;DR

Added a service to `event` and `org` routes that manage underlying event instances.

### 🥜 GIF

<!-- GIFs are always optional but never forgotten -->

![lack-of-hustle](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExNWZ2enV5YXY5YXdzb2IwOWFtMGp1OTd0bGljdHBzNXpiYXVzM2Y2ZCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/3oKIPACZEWen2eaBm8/giphy.gif)
