### PR TITLE
Adding Region Pages Cloud Connector Access

### DIFF
--- a/apps/region-pages/.env.local.sample
+++ b/apps/region-pages/.env.local.sample
@@ -1,3 +1,11 @@
 # Copy this file to .env.local and fill in your actual values
 POSTGRES_URL="postgresql://postgres:postgres@127.0.0.1:54322/postgres"
 F3_DATA_WAREHOUSE_URL="postgresql://[user]:[password]@[host]:[port]/[database]"
+
+# Cloud SQL Connector (set WAREHOUSE_DB_CONNECTION_MODE=connector to use instead of F3_DATA_WAREHOUSE_URL)
+# WAREHOUSE_DB_CONNECTION_MODE="direct"
+# CLOUD_SQL_WAREHOUSE_CONNECTION_NAME="project:region:instance"
+# WAREHOUSE_DB_USER=""
+# WAREHOUSE_DB_PASSWORD=""
+# WAREHOUSE_DB_NAME=""
+# CLOUD_SQL_WAREHOUSE_IP_TYPE="PUBLIC"

--- a/apps/region-pages/apphosting.yaml
+++ b/apps/region-pages/apphosting.yaml
@@ -25,7 +25,7 @@ env:
 
   # Cloud SQL Connector settings (set WAREHOUSE_DB_CONNECTION_MODE=connector to use)
   - variable: WAREHOUSE_DB_CONNECTION_MODE
-    value: direct
+    value: connector
 
   - variable: CLOUD_SQL_WAREHOUSE_CONNECTION_NAME
     secret: cloud-sql-warehouse-connection-name

--- a/apps/region-pages/apphosting.yaml
+++ b/apps/region-pages/apphosting.yaml
@@ -23,6 +23,30 @@ env:
       - BUILD
       - RUNTIME
 
+  # Cloud SQL Connector settings (set WAREHOUSE_DB_CONNECTION_MODE=connector to use)
+  - variable: WAREHOUSE_DB_CONNECTION_MODE
+    value: direct
+
+  - variable: CLOUD_SQL_WAREHOUSE_CONNECTION_NAME
+    secret: cloud-sql-warehouse-connection-name
+    availability:
+      - RUNTIME
+
+  - variable: WAREHOUSE_DB_USER
+    secret: warehouse-db-user
+    availability:
+      - RUNTIME
+
+  - variable: WAREHOUSE_DB_PASSWORD
+    secret: warehouse-db-password
+    availability:
+      - RUNTIME
+
+  - variable: WAREHOUSE_DB_NAME
+    secret: warehouse-db-name
+    availability:
+      - RUNTIME
+
   # Grant access to secrets in Cloud Secret Manager.
   # See https://firebase.google.com/docs/app-hosting/configure#secret-parameters
   # - variable: MY_SECRET

--- a/apps/region-pages/drizzle/f3-data-warehouse/db.ts
+++ b/apps/region-pages/drizzle/f3-data-warehouse/db.ts
@@ -37,7 +37,8 @@ async function createCloudSqlPool(): Promise<Pool> {
     ? (process.env.CLOUD_SQL_WAREHOUSE_IP_TYPE as IpAddressTypes)
     : IpAddressTypesValues.PUBLIC;
 
-  connector = new Connector();  const clientOpts = await connector.getOptions({
+  connector = new Connector();
+  const clientOpts = await connector.getOptions({
     instanceConnectionName,
     ipType: ipAddressType,
   });

--- a/apps/region-pages/drizzle/f3-data-warehouse/db.ts
+++ b/apps/region-pages/drizzle/f3-data-warehouse/db.ts
@@ -1,18 +1,117 @@
-import { drizzle } from 'drizzle-orm/node-postgres';
+import { drizzle, type NodePgDatabase } from 'drizzle-orm/node-postgres';
 import { Pool } from 'pg';
+import type { IpAddressTypes } from '@google-cloud/cloud-sql-connector';
 import { loadEnvConfig } from '@/lib/env';
 import * as schema from './schema';
 
-// Load environment variables
-const { F3_DATA_WAREHOUSE_URL } = loadEnvConfig();
+let pool: Pool | null = null;
+let connector: InstanceType<
+  typeof import('@google-cloud/cloud-sql-connector').Connector
+> | null = null;
+let dbInstance: NodePgDatabase<typeof schema> | null = null;
 
-// Create PostgreSQL connection pool
-const pool = new Pool({
-  connectionString: F3_DATA_WAREHOUSE_URL,
-});
+/**
+ * Creates a pool using the Cloud SQL Node.js Connector.
+ * Requires: CLOUD_SQL_WAREHOUSE_CONNECTION_NAME, WAREHOUSE_DB_USER, WAREHOUSE_DB_NAME
+ */
+async function createCloudSqlPool(): Promise<Pool> {
+  const { Connector, IpAddressTypes: IpAddressTypesValues } =
+    await import('@google-cloud/cloud-sql-connector');
 
-// Create drizzle database instance
-export const db = drizzle(pool, { schema });
+  const instanceConnectionName =
+    process.env.CLOUD_SQL_WAREHOUSE_CONNECTION_NAME;
+  const dbUser = process.env.WAREHOUSE_DB_USER;
+  const dbPassword = process.env.WAREHOUSE_DB_PASSWORD;
+  const dbName = process.env.WAREHOUSE_DB_NAME;
 
-// Export for use in scripts
-export const getPool = () => pool;
+  if (!instanceConnectionName || !dbUser || !dbName) {
+    throw new Error(
+      'Cloud SQL Connector requires CLOUD_SQL_WAREHOUSE_CONNECTION_NAME, WAREHOUSE_DB_USER, and WAREHOUSE_DB_NAME.'
+    );
+  }
+
+  const validTypes = Object.values(IpAddressTypesValues) as string[];
+  const ipAddressType = validTypes.includes(
+    process.env.CLOUD_SQL_WAREHOUSE_IP_TYPE ?? ''
+  )
+    ? (process.env.CLOUD_SQL_WAREHOUSE_IP_TYPE as IpAddressTypes)
+    : IpAddressTypesValues.PUBLIC;
+
+  connector = new Connector();  const clientOpts = await connector.getOptions({
+    instanceConnectionName,
+    ipType: ipAddressType,
+  });
+
+  const newPool = new Pool({
+    ...clientOpts,
+    user: dbUser,
+    password: dbPassword,
+    database: dbName,
+    max: 10,
+  });
+
+  newPool.on('error', (err) => {
+    console.error('Unexpected error on idle PostgreSQL client:', err);
+  });
+
+  console.log(
+    `PostgreSQL pool initialized via Cloud SQL Connector (${instanceConnectionName}).`
+  );
+  return newPool;
+}
+
+/**
+ * Creates a pool using a direct TCP connection via F3_DATA_WAREHOUSE_URL.
+ */
+function createDirectPool(): Pool {
+  const { F3_DATA_WAREHOUSE_URL } = loadEnvConfig();
+
+  const newPool = new Pool({
+    connectionString: F3_DATA_WAREHOUSE_URL,
+  });
+
+  newPool.on('error', (err) => {
+    console.error('Unexpected error on idle PostgreSQL client:', err);
+  });
+
+  return newPool;
+}
+
+/**
+ * Returns a cached Drizzle database instance for the F3 Data Warehouse.
+ *
+ * Connection mode is controlled by WAREHOUSE_DB_CONNECTION_MODE:
+ *   "connector" → Cloud SQL Node.js Connector (authenticated, no public IP needed)
+ *   "direct"    → F3_DATA_WAREHOUSE_URL TCP connection (default)
+ */
+export async function getDb(): Promise<NodePgDatabase<typeof schema>> {
+  if (dbInstance) return dbInstance;
+
+  const mode = process.env.WAREHOUSE_DB_CONNECTION_MODE ?? 'direct';
+
+  if (mode === 'connector') {
+    pool = await createCloudSqlPool();
+  } else {
+    pool = createDirectPool();
+  }
+
+  dbInstance = drizzle(pool, { schema });
+  return dbInstance;
+}
+
+export async function getPool(): Promise<Pool> {
+  if (!pool) await getDb();
+  return pool!;
+}
+
+export async function close(): Promise<void> {
+  if (pool) {
+    await pool.end();
+    pool = null;
+  }
+  if (connector) {
+    connector.close();
+    connector = null;
+  }
+  dbInstance = null;
+}

--- a/apps/region-pages/package.json
+++ b/apps/region-pages/package.json
@@ -36,6 +36,7 @@
   },
   "dependencies": {
     "dotenv": "^16.4.7",
+    "@google-cloud/cloud-sql-connector": "^1.4.1",
     "lodash": "^4.17.21",
     "next": "15.1.9",
     "react": "^19.0.0",

--- a/apps/region-pages/scripts/prune-regions.ts
+++ b/apps/region-pages/scripts/prune-regions.ts
@@ -5,12 +5,13 @@ import {
   regions as regionsSchema,
   workouts as workoutsSchema,
 } from '../drizzle/schema';
-import { db as f3DataWarehouseDb } from '../drizzle/f3-data-warehouse/db';
+import { getDb as getF3DataWarehouseDb } from '../drizzle/f3-data-warehouse/db';
 import { orgs as orgsSchema } from '../drizzle/f3-data-warehouse/schema';
 
 export async function pruneRegions() {
   console.debug('🔄 pruning regions no longer in the warehouse...');
 
+  const f3DataWarehouseDb = await getF3DataWarehouseDb();
   const activeWarehouseRegions = await f3DataWarehouseDb
     .select({
       id: orgsSchema.id,

--- a/apps/region-pages/scripts/prune-workouts.ts
+++ b/apps/region-pages/scripts/prune-workouts.ts
@@ -5,12 +5,13 @@ import {
   regions as regionsSchema,
   workouts as workoutsSchema,
 } from '../drizzle/schema';
-import { db as f3DataWarehouseDb } from '../drizzle/f3-data-warehouse/db';
+import { getDb as getF3DataWarehouseDb } from '../drizzle/f3-data-warehouse/db';
 import { events as eventsSchema } from '../drizzle/f3-data-warehouse/schema';
 
 export async function pruneWorkouts() {
   console.debug('🔄 pruning workouts no longer in the warehouse...');
 
+  const f3DataWarehouseDb = await getF3DataWarehouseDb();
   const activeWarehouseWorkouts = await f3DataWarehouseDb
     .select({
       id: eventsSchema.id,

--- a/apps/region-pages/scripts/seed-regions.ts
+++ b/apps/region-pages/scripts/seed-regions.ts
@@ -3,7 +3,7 @@ import { kebabCase } from 'lodash';
 
 import { db } from '../drizzle/db';
 import { regions as regionsSchema } from '../drizzle/schema';
-import { db as f3DataWarehouseDb } from '../drizzle/f3-data-warehouse/db';
+import { getDb as getF3DataWarehouseDb } from '../drizzle/f3-data-warehouse/db';
 import { orgs as orgsSchema } from '../drizzle/f3-data-warehouse/schema';
 import { currentIngestedAt, isFresh } from './seed-state';
 
@@ -141,6 +141,7 @@ function transformInstagramUrl(instagram: string | null): string | null {
 }
 
 async function* fetchRegions(): AsyncGenerator<Region> {
+  const f3DataWarehouseDb = await getF3DataWarehouseDb();
   const regions = await f3DataWarehouseDb
     .select({
       id: orgsSchema.id,

--- a/apps/region-pages/scripts/seed-workouts.ts
+++ b/apps/region-pages/scripts/seed-workouts.ts
@@ -5,7 +5,7 @@ import {
   regions as regionsSchema,
   workouts as workoutsSchema,
 } from '../drizzle/schema';
-import { db as f3DataWarehouseDb } from '../drizzle/f3-data-warehouse/db';
+import { getDb as getF3DataWarehouseDb } from '../drizzle/f3-data-warehouse/db';
 import {
   orgs as orgsSchema,
   events as eventsSchema,
@@ -185,6 +185,7 @@ type FetchBatchArgs = {
 };
 
 async function fetchWorkoutsBatch(args: FetchBatchArgs): Promise<BatchResult> {
+  const f3DataWarehouseDb = await getF3DataWarehouseDb();
   const conditions = [eq(eventsSchema.isActive, true)];
   if (args.updatedAfter) {
     conditions.push(gte(eventsSchema.updated, args.updatedAfter));

--- a/apps/region-pages/src/lib/env.ts
+++ b/apps/region-pages/src/lib/env.ts
@@ -8,13 +8,14 @@ export function loadEnvConfig() {
     throw new Error(`POSTGRES_URL is not set in .env.${env}`);
   }
 
-  if (!process.env.F3_DATA_WAREHOUSE_URL) {
+  const warehouseMode = process.env.WAREHOUSE_DB_CONNECTION_MODE ?? 'direct';
+  if (warehouseMode === 'direct' && !process.env.F3_DATA_WAREHOUSE_URL) {
     throw new Error(`F3_DATA_WAREHOUSE_URL is not set in .env.${env}`);
   }
 
   return {
     POSTGRES_URL: process.env.POSTGRES_URL,
-    F3_DATA_WAREHOUSE_URL: process.env.F3_DATA_WAREHOUSE_URL,
+    F3_DATA_WAREHOUSE_URL: process.env.F3_DATA_WAREHOUSE_URL ?? '',
     NODE_ENV: env,
   };
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -535,6 +535,9 @@ importers:
 
   apps/region-pages:
     dependencies:
+      '@google-cloud/cloud-sql-connector':
+        specifier: ^1.4.1
+        version: 1.8.5
       dotenv:
         specifier: ^16.4.7
         version: 16.6.1
@@ -3518,7 +3521,6 @@ packages:
       p-throttle: 7.0.0
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@google-cloud/paginator@6.0.0:
     resolution: {integrity: sha512-g5nmMnzC+94kBxOKkLGpK1ikvolTFCC3s2qtE4F+1EuArcJ7HHC23RDQVt3Ra3CqpUYZ+oXNKZ8n5Cn5yug8DA==}
@@ -3572,7 +3574,6 @@ packages:
       googleapis-common: 8.0.2-rc.0
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@grpc/grpc-js@1.14.3:
     resolution: {integrity: sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==}
@@ -10165,7 +10166,6 @@ packages:
     dependencies:
       es-errors: 1.3.0
       function-bind: 1.1.2
-    dev: true
 
   /call-bind@1.0.2:
     resolution: {integrity: sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==}
@@ -10189,7 +10189,6 @@ packages:
     dependencies:
       call-bind-apply-helpers: 1.0.2
       get-intrinsic: 1.3.0
-    dev: true
 
   /call-me-maybe@1.0.2:
     resolution: {integrity: sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==}
@@ -11565,7 +11564,6 @@ packages:
       call-bind-apply-helpers: 1.0.2
       es-errors: 1.3.0
       gopd: 1.2.0
-    dev: true
 
   /duplexify@4.1.3:
     resolution: {integrity: sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==}
@@ -11795,12 +11793,10 @@ packages:
   /es-define-property@1.0.1:
     resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
     engines: {node: '>= 0.4'}
-    dev: true
 
   /es-errors@1.3.0:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
-    dev: true
 
   /es-iterator-helpers@1.0.13:
     resolution: {integrity: sha512-LK3VGwzvaPWobO8xzXXGRUOGw8Dcjyfk62CsY/wfHN75CwsJPbuypOYJxK6g5RyEL8YDjIWcl6jgd8foO6mmrA==}
@@ -11871,7 +11867,6 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       es-errors: 1.3.0
-    dev: true
 
   /es-set-tostringtag@2.0.1:
     resolution: {integrity: sha512-g3OMbtlwY3QewlqAiMLI47KywjWZoEytKr8pf6iTC8uJq5bIAH52Z9pnQ8pVL6whrCto53JZDuUIsifGeLorTg==}
@@ -13484,7 +13479,6 @@ packages:
       has-symbols: 1.1.0
       hasown: 2.0.2
       math-intrinsics: 1.1.0
-    dev: true
 
   /get-nonce@1.0.1:
     resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
@@ -13502,7 +13496,6 @@ packages:
     dependencies:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
-    dev: true
 
   /get-stream@6.0.1:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
@@ -13819,7 +13812,6 @@ packages:
       url-template: 2.0.8
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /gopd@1.0.1:
     resolution: {integrity: sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==}
@@ -13829,7 +13821,6 @@ packages:
   /gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
-    dev: true
 
   /graceful-fs@4.2.10:
     resolution: {integrity: sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==}
@@ -13933,7 +13924,6 @@ packages:
   /has-symbols@1.1.0:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
     engines: {node: '>= 0.4'}
-    dev: true
 
   /has-tostringtag@1.0.0:
     resolution: {integrity: sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==}
@@ -13970,7 +13960,6 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       function-bind: 1.1.2
-    dev: true
 
   /header-case@1.0.1:
     resolution: {integrity: sha512-i0q9mkOeSuhXw6bGgiQCCBgY/jlZuV/7dZXyZ9c6LcBrqwvT8eT719E9uxE5LiZftdl+z81Ugbg/VvXV4OJOeQ==}
@@ -16103,7 +16092,6 @@ packages:
   /math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
-    dev: true
 
   /media-typer@0.3.0:
     resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
@@ -16887,7 +16875,6 @@ packages:
   /object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
     engines: {node: '>= 0.4'}
-    dev: true
 
   /object-keys@1.1.1:
     resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
@@ -17232,7 +17219,6 @@ packages:
   /p-throttle@7.0.0:
     resolution: {integrity: sha512-aio0v+S0QVkH1O+9x4dHtD4dgCExACcL+3EtNaGqC01GBudS9ijMuUsmN8OVScyV4OOp0jqdLShZFuSlbL/AsA==}
     engines: {node: '>=18'}
-    dev: true
 
   /p-try@2.2.0:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
@@ -18031,7 +18017,6 @@ packages:
     engines: {node: '>=0.6'}
     dependencies:
       side-channel: 1.1.0
-    dev: true
 
   /querystringify@2.2.0:
     resolution: {integrity: sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==}
@@ -19125,7 +19110,6 @@ packages:
     dependencies:
       es-errors: 1.3.0
       object-inspect: 1.13.4
-    dev: true
 
   /side-channel-map@1.0.1:
     resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
@@ -19135,7 +19119,6 @@ packages:
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
       object-inspect: 1.13.4
-    dev: true
 
   /side-channel-weakmap@1.0.2:
     resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
@@ -19146,7 +19129,6 @@ packages:
       get-intrinsic: 1.3.0
       object-inspect: 1.13.4
       side-channel-map: 1.0.1
-    dev: true
 
   /side-channel@1.0.4:
     resolution: {integrity: sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==}
@@ -19164,7 +19146,6 @@ packages:
       side-channel-list: 1.0.0
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
-    dev: true
 
   /siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
@@ -20716,7 +20697,6 @@ packages:
 
   /url-template@2.0.8:
     resolution: {integrity: sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==}
-    dev: true
 
   /use-callback-ref@1.3.1(@types/react@18.3.20)(react@18.3.1):
     resolution: {integrity: sha512-Lg4Vx1XZQauB42Hw3kK7JM6yjVjgFmFC5/Ab797s79aARomD2nEErc4mCgM8EZrARLmmbWpi5DGCadmK50DcAQ==}


### PR DESCRIPTION
This pull request adds support for connecting to the F3 Data Warehouse using the Google Cloud SQL Node.js Connector, making it possible to use secure, authenticated connections without exposing a public IP. The changes introduce new environment variables and update the database connection logic to support both direct and connector-based modes. Several scripts and configuration files are updated to use the new connection method.

### 👋 TL;DR

Adding another way to connect to the F3 SQL db after we locked down IP access.

### 🔎 Details

**Cloud SQL Connector integration:**

* Added the `@google-cloud/cloud-sql-connector` dependency and related configuration to `package.json` and `pnpm-lock.yaml`. [[1]](diffhunk://#diff-58bba174d4da8ae61b06ff9cb91d6361dd960504305aefeef2c31168873e7484R39) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR538-R540)
* Updated `.env.local.sample` and `apphosting.yaml` to include new environment variables for Cloud SQL Connector configuration (e.g., `WAREHOUSE_DB_CONNECTION_MODE`, `CLOUD_SQL_WAREHOUSE_CONNECTION_NAME`, `WAREHOUSE_DB_USER`, etc.). [[1]](diffhunk://#diff-34e5cefd503332e4811c29ccb7bea21ff69bd69bd186a860a518a14060a30b45R4-R11) [[2]](diffhunk://#diff-827727ef2c0200dad60f542fb62e8915e22af7222656ea4f4457a73d7ecfafdeR26-R49)

**Database connection logic:**

* Refactored `drizzle/f3-data-warehouse/db.ts` to support both direct and Cloud SQL Connector connection modes, with connection pooling, lazy initialization, and a new `close()` method for cleanup.
* Updated `src/lib/env.ts` to only require `F3_DATA_WAREHOUSE_URL` when in direct connection mode.

**Script updates:**

* Updated all scripts (`prune-regions.ts`, `prune-workouts.ts`, `seed-regions.ts`, `seed-workouts.ts`) to use the new `getDb` async function for obtaining a database instance, ensuring compatibility with both connection modes. [[1]](diffhunk://#diff-cd83f6499ac0e0d92f44a3f82c21569e185330f9cae5e61908c39457027dda07L8-R14) [[2]](diffhunk://#diff-4aa1ed2ba3c696ed27350496d3b7de27b4afc7955da44935a3b90451b8c3baf8L8-R14) [[3]](diffhunk://#diff-a8ee31e4f5fa0bfef5fc03cdad50bf6a1a4dae86fc694cc5defede04f1c9c6bcL6-R6) [[4]](diffhunk://#diff-a8ee31e4f5fa0bfef5fc03cdad50bf6a1a4dae86fc694cc5defede04f1c9c6bcR144) [[5]](diffhunk://#diff-933881b5bb226a9eb14123ab1d0312c6354ca99320888f36374615b3ae9b8393L8-R8) [[6]](diffhunk://#diff-933881b5bb226a9eb14123ab1d0312c6354ca99320888f36374615b3ae9b8393R188)

### 🥜 GIF

<!-- GIFs are always optional but never forgotten -->

![lack-of-hustle](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExNWZ2enV5YXY5YXdzb2IwOWFtMGp1OTd0bGljdHBzNXpiYXVzM2Y2ZCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/3oKIPACZEWen2eaBm8/giphy.gif)
