### PR TITLE
Add workflow to recreate staging from main after merge

### DIFF
--- a/.github/workflows/recreate-staging.yml
+++ b/.github/workflows/recreate-staging.yml
@@ -1,0 +1,21 @@
+name: Recreate staging branch
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+jobs:
+  recreate-staging:
+    if: github.event.pull_request.merged == true && github.event.pull_request.head.ref == 'staging'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+      - name: Recreate staging branch from main
+        run: |
+          git push origin main:staging --force


### PR DESCRIPTION
Adds a GitHub Actions workflow that automatically recreates the `staging` branch from `main` after a PR from `staging` is merged into `main`.

This prevents `staging` from being deleted by the "Automatically delete head branches" repo setting.

**How it works:**
- Triggers on PR close events targeting `main`
- Only runs when the merged PR's head branch was `staging`
- Force-pushes `main` to `staging`, effectively recreating it in sync with `main`