### PR TITLE
Bump auth version to 1.1.0

### DIFF
--- a/apps/auth/package.json
+++ b/apps/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "f3-auth",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary
- Bumps `apps/auth` from `1.0.3` → `1.1.0` (minor version)
- Reflects the new OAuth/SSO feature set merged in #183: registration flow, RS256 JWT signing, `packages/sso` SDK, Cloud SQL migration, and expanded API surface

## Test plan
- [x] Verify `apps/auth/package.json` shows `1.1.0`
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)