### PR TITLE
fix(auth): preserve region selection on blur, fix tab order

### DIFF
--- a/apps/auth/src/app/register/page.tsx
+++ b/apps/auth/src/app/register/page.tsx
@@ -221,11 +221,18 @@ function RegisterForm() {
               onFocus={() => setRegionDropdownOpen(true)}
               onBlur={() => {
                 setTimeout(() => {
-                  if (!regionSelectedRef.current) {
+                  if (!regionSelectedRef.current && !homeRegionId) {
                     setRegionSearch("");
-                    setHomeRegionId("");
+                  }
+                  if (!regionSelectedRef.current && homeRegionId) {
+                    // Restore the selected region name if user didn't change selection
+                    const selected = regions.find((r) => r.id === homeRegionId);
+                    if (selected) {
+                      setRegionSearch(selected.name);
+                    }
                   }
                   regionSelectedRef.current = false;
+                  setRegionDropdownOpen(false);
                 }, 200);
               }}
               placeholder="Search for a region (optional)"

--- a/apps/auth/src/app/register/page.tsx
+++ b/apps/auth/src/app/register/page.tsx
@@ -221,14 +221,17 @@ function RegisterForm() {
               onFocus={() => setRegionDropdownOpen(true)}
               onBlur={() => {
                 setTimeout(() => {
-                  if (!regionSelectedRef.current && !homeRegionId) {
-                    setRegionSearch("");
-                  }
-                  if (!regionSelectedRef.current && homeRegionId) {
-                    // Restore the selected region name if user didn't change selection
-                    const selected = regions.find((r) => r.id === homeRegionId);
-                    if (selected) {
-                      setRegionSearch(selected.name);
+                  if (!regionSelectedRef.current) {
+                    if (homeRegionId) {
+                      // Restore the selected region name if user didn't change selection
+                      const selected = regions.find(
+                        (r) => r.id === homeRegionId,
+                      );
+                      if (selected) {
+                        setRegionSearch(selected.name);
+                      }
+                    } else {
+                      setRegionSearch("");
                     }
                   }
                   regionSelectedRef.current = false;


### PR DESCRIPTION
## Summary

- Fix onBlur handler that was clearing a previously selected region when the field lost focus
- Restore the selected region name when the user clicks into the field and blurs without changing selection
- Close dropdown on blur so Tab key navigates to the phone number field instead of cycling back
- Simplify region blur conditional logic into a cleaner if/else structure

## Test plan

- [x] Build passes
- [x] Typecheck passes
- [x] Lint clean
- [x] Select a region (e.g. MuleTown) → click elsewhere → region stays selected
- [x] Select a region → click into region field → blur by clicking outside → region name and ID preserved
- [x] Type partial region name → blur without selecting → search text clears (no phantom selection)
- [x] Select a region → press Tab → focus moves to phone number field
- [x] Select a region → type new text → blur without selecting new region → search clears, homeRegionId clears
- [x] Select a region from dropdown via keyboard/click → works as before