### PR TITLE
Auth app: SSO logout endpoint, onboarding prefill, and fixes

### DIFF
--- a/apps/auth/package.json
+++ b/apps/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "f3-auth",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/auth/scripts/add-client.ts
+++ b/apps/auth/scripts/add-client.ts
@@ -15,7 +15,12 @@ import { drizzle } from "drizzle-orm/postgres-js";
 import { eq } from "drizzle-orm";
 import postgres from "postgres";
 
-import { oauthClients } from "@acme/db/schema/schema";
+import * as _schema from "@acme/db/schema/schema";
+
+// CJS/ESM interop: when loaded as CJS, named exports are under .default
+const { oauthClients } = (
+  "default" in _schema ? _schema.default : _schema
+) as typeof _schema;
 
 // ---------------------------------------------------------------------------
 // CLI helpers
@@ -81,6 +86,7 @@ async function main() {
   }
 
   const databaseHost = process.env.DATABASE_HOST;
+  const databasePort = parseInt(process.env.DATABASE_PORT ?? "5432", 10);
   const databaseUser = process.env.DATABASE_USER;
   const databasePassword = process.env.DATABASE_PASSWORD;
   const databaseName = process.env.DATABASE_NAME;
@@ -101,7 +107,7 @@ async function main() {
 
   const sql = postgres({
     host: databaseHost,
-    port: 5432,
+    port: databasePort,
     user: databaseUser,
     password: databasePassword,
     database: databaseName,

--- a/apps/auth/src/app/api/oauth/authorize/route.ts
+++ b/apps/auth/src/app/api/oauth/authorize/route.ts
@@ -71,7 +71,7 @@ export async function GET(request: NextRequest) {
   if (!session?.user?.id) {
     // Redirect to login with callback to this authorize URL
     const callbackUrl = request.url;
-    const loginUrl = new URL("/login", request.url);
+    const loginUrl = new URL("/login/email", request.url);
     loginUrl.searchParams.set("callbackUrl", callbackUrl);
     return NextResponse.redirect(loginUrl);
   }

--- a/apps/auth/src/app/api/oauth/logout/route.ts
+++ b/apps/auth/src/app/api/oauth/logout/route.ts
@@ -13,17 +13,13 @@ import { revokeAllUserTokens } from "~/lib/oauth";
  */
 export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url);
-  const postLogoutRedirectUri =
   const postLogoutRedirectUri = searchParams.get("post_logout_redirect_uri");
 
   // Build a safe redirect URL — only allow same-origin redirects.
   const requestOrigin = new URL(request.url).origin;
   let redirectUrl: URL;
   try {
-    const candidate = new URL(
-      postLogoutRedirectUri ?? "/login",
-      request.url,
-    );
+    const candidate = new URL(postLogoutRedirectUri ?? "/login", request.url);
     redirectUrl =
       candidate.origin === requestOrigin
         ? candidate

--- a/apps/auth/src/app/api/oauth/logout/route.ts
+++ b/apps/auth/src/app/api/oauth/logout/route.ts
@@ -14,7 +14,23 @@ import { revokeAllUserTokens } from "~/lib/oauth";
 export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url);
   const postLogoutRedirectUri =
-    searchParams.get("post_logout_redirect_uri") ?? "/login";
+  const postLogoutRedirectUri = searchParams.get("post_logout_redirect_uri");
+
+  // Build a safe redirect URL — only allow same-origin redirects.
+  const requestOrigin = new URL(request.url).origin;
+  let redirectUrl: URL;
+  try {
+    const candidate = new URL(
+      postLogoutRedirectUri ?? "/login",
+      request.url,
+    );
+    redirectUrl =
+      candidate.origin === requestOrigin
+        ? candidate
+        : new URL("/login", request.url);
+  } catch {
+    redirectUrl = new URL("/login", request.url);
+  }
 
   // Revoke tokens if user is authenticated
   const session = await auth();
@@ -37,5 +53,5 @@ export async function GET(request: NextRequest) {
     }
   }
 
-  return NextResponse.redirect(postLogoutRedirectUri);
+  return NextResponse.redirect(redirectUrl);
 }

--- a/apps/auth/src/app/api/oauth/logout/route.ts
+++ b/apps/auth/src/app/api/oauth/logout/route.ts
@@ -2,8 +2,46 @@ import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 import { cookies } from "next/headers";
 
+import { eq } from "@acme/db";
+import { oauthClients } from "@acme/db/schema/schema";
+
 import { auth } from "~/lib/auth";
+import { db } from "~/lib/db";
 import { revokeAllUserTokens } from "~/lib/oauth";
+
+/**
+ * Collect every origin that appears in the redirect_uris of active
+ * OAuth clients.  These are the origins we allow for
+ * post_logout_redirect_uri so that cross-origin SSO clients (e.g.
+ * me.f3nation.com → auth.f3nation.com) can be redirected back after
+ * logout without being blocked by a same-origin check.
+ */
+async function getAllowedOrigins(): Promise<Set<string>> {
+  const clients = await db
+    .select({ redirectUris: oauthClients.redirectUris })
+    .from(oauthClients)
+    .where(eq(oauthClients.isActive, true));
+
+  const origins = new Set<string>();
+  for (const c of clients) {
+    try {
+      const uris: unknown = JSON.parse(c.redirectUris);
+      if (!Array.isArray(uris)) continue;
+      for (const u of uris) {
+        if (typeof u === "string") {
+          try {
+            origins.add(new URL(u).origin);
+          } catch {
+            // skip malformed URIs
+          }
+        }
+      }
+    } catch {
+      // skip unparseable JSON
+    }
+  }
+  return origins;
+}
 
 /**
  * SSO logout endpoint.
@@ -15,15 +53,17 @@ export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url);
   const postLogoutRedirectUri = searchParams.get("post_logout_redirect_uri");
 
-  // Build a safe redirect URL — only allow same-origin redirects.
+  // Validate the redirect target against registered client origins.
+  const allowedOrigins = await getAllowedOrigins();
   const requestOrigin = new URL(request.url).origin;
+  allowedOrigins.add(requestOrigin); // always allow same-origin
+
   let redirectUrl: URL;
   try {
     const candidate = new URL(postLogoutRedirectUri ?? "/login", request.url);
-    redirectUrl =
-      candidate.origin === requestOrigin
-        ? candidate
-        : new URL("/login", request.url);
+    redirectUrl = allowedOrigins.has(candidate.origin)
+      ? candidate
+      : new URL("/login", request.url);
   } catch {
     redirectUrl = new URL("/login", request.url);
   }

--- a/apps/auth/src/app/api/oauth/logout/route.ts
+++ b/apps/auth/src/app/api/oauth/logout/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { cookies } from "next/headers";
+
+import { auth } from "~/lib/auth";
+import { revokeAllUserTokens } from "~/lib/oauth";
+
+/**
+ * SSO logout endpoint.
+ * Clears the auth session and redirects back to the client.
+ *
+ * GET /api/oauth/logout?post_logout_redirect_uri=http://localhost:3003
+ */
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  const postLogoutRedirectUri =
+    searchParams.get("post_logout_redirect_uri") ?? "/login";
+
+  // Revoke tokens if user is authenticated
+  const session = await auth();
+  if (session?.user?.id) {
+    const userId = Number(session.user.id);
+    if (userId) {
+      await revokeAllUserTokens(userId);
+    }
+  }
+
+  // Clear the NextAuth session cookie
+  const cookieStore = await cookies();
+  for (const cookie of cookieStore.getAll()) {
+    if (
+      cookie.name.startsWith("next-auth") ||
+      cookie.name.startsWith("__Secure-next-auth") ||
+      cookie.name.startsWith("authjs")
+    ) {
+      cookieStore.delete(cookie.name);
+    }
+  }
+
+  return NextResponse.redirect(postLogoutRedirectUri);
+}

--- a/apps/auth/src/app/api/onboarding/route.ts
+++ b/apps/auth/src/app/api/onboarding/route.ts
@@ -24,7 +24,7 @@ export async function GET() {
     .where(eq(users.id, userId))
     .limit(1);
 
-  const isExistingUser = !!(user?.f3Name || user?.firstName || user?.lastName);
+  const isExistingUser = !!(user?.f3Name ?? user?.firstName ?? user?.lastName);
 
   return NextResponse.json({
     f3Name: user?.f3Name ?? "",

--- a/apps/auth/src/app/api/onboarding/route.ts
+++ b/apps/auth/src/app/api/onboarding/route.ts
@@ -7,6 +7,33 @@ import { users } from "@acme/db/schema/schema";
 import { auth } from "~/lib/auth";
 import { db } from "~/lib/db";
 
+export async function GET() {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const userId = Number(session.user.id);
+  const [user] = await db
+    .select({
+      f3Name: users.f3Name,
+      firstName: users.firstName,
+      lastName: users.lastName,
+    })
+    .from(users)
+    .where(eq(users.id, userId))
+    .limit(1);
+
+  const isExistingUser = !!(user?.f3Name || user?.firstName || user?.lastName);
+
+  return NextResponse.json({
+    f3Name: user?.f3Name ?? "",
+    firstName: user?.firstName ?? "",
+    lastName: user?.lastName ?? "",
+    isExistingUser,
+  });
+}
+
 export async function POST(request: NextRequest) {
   const session = await auth();
   if (!session?.user?.id) {

--- a/apps/auth/src/app/onboarding/page.tsx
+++ b/apps/auth/src/app/onboarding/page.tsx
@@ -29,7 +29,31 @@ function OnboardingForm() {
 
   useEffect(() => {
     if (!session?.user) return;
+    if (!session?.user?.id) return;
     fetch("/api/onboarding")
+      .then((res) => {
+        if (!res.ok) return;
+        return res.json();
+      })
+      .then(
+        (data?: {
+          f3Name?: string;
+          firstName?: string;
+          lastName?: string;
+          isExistingUser?: boolean;
+        }) => {
+          if (!data) return;
+          if (data.f3Name) setF3Name(data.f3Name);
+          if (data.firstName) setFirstName(data.firstName);
+          if (data.lastName) setLastName(data.lastName);
+          if (data.isExistingUser) setIsExistingUser(true);
+        },
+      )
+      .catch(() => {
+        // Ignore — fields will just be empty
+      })
+      .finally(() => setPrefilling(false));
+  }, [session?.user?.id]);
       .then((res) => res.json())
       .then(
         (data: {

--- a/apps/auth/src/app/onboarding/page.tsx
+++ b/apps/auth/src/app/onboarding/page.tsx
@@ -54,25 +54,6 @@ function OnboardingForm() {
       })
       .finally(() => setPrefilling(false));
   }, [session?.user?.id]);
-      .then((res) => res.json())
-      .then(
-        (data: {
-          f3Name?: string;
-          firstName?: string;
-          lastName?: string;
-          isExistingUser?: boolean;
-        }) => {
-          if (data.f3Name) setF3Name(data.f3Name);
-          if (data.firstName) setFirstName(data.firstName);
-          if (data.lastName) setLastName(data.lastName);
-          if (data.isExistingUser) setIsExistingUser(true);
-        },
-      )
-      .catch(() => {
-        // Ignore — fields will just be empty
-      })
-      .finally(() => setPrefilling(false));
-  }, [session?.user]);
 
   if (!session?.user || prefilling) {
     return (

--- a/apps/auth/src/app/onboarding/page.tsx
+++ b/apps/auth/src/app/onboarding/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Suspense, useState } from "react";
+import { Suspense, useEffect, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useSession } from "next-auth/react";
 
@@ -20,12 +20,37 @@ function OnboardingForm() {
   const [firstName, setFirstName] = useState("");
   const [lastName, setLastName] = useState("");
   const [loading, setLoading] = useState(false);
+  const [prefilling, setPrefilling] = useState(true);
+  const [isExistingUser, setIsExistingUser] = useState(false);
   const [error, setError] = useState("");
   const router = useRouter();
   const searchParams = useSearchParams();
   const callbackUrl = searchParams.get("callbackUrl") ?? "/";
 
-  if (!session?.user) {
+  useEffect(() => {
+    if (!session?.user) return;
+    fetch("/api/onboarding")
+      .then((res) => res.json())
+      .then(
+        (data: {
+          f3Name?: string;
+          firstName?: string;
+          lastName?: string;
+          isExistingUser?: boolean;
+        }) => {
+          if (data.f3Name) setF3Name(data.f3Name);
+          if (data.firstName) setFirstName(data.firstName);
+          if (data.lastName) setLastName(data.lastName);
+          if (data.isExistingUser) setIsExistingUser(true);
+        },
+      )
+      .catch(() => {
+        // Ignore — fields will just be empty
+      })
+      .finally(() => setPrefilling(false));
+  }, [session?.user]);
+
+  if (!session?.user || prefilling) {
     return (
       <div className="flex min-h-screen items-center justify-center">
         <p className="text-muted-foreground">Loading...</p>
@@ -71,9 +96,13 @@ function OnboardingForm() {
             height={96}
             priority
           />
-          <h1 className="text-3xl font-bold">Welcome to F3 Nation!</h1>
+          <h1 className="text-3xl font-bold">
+            {isExistingUser ? "Welcome Back!" : "Welcome to F3 Nation!"}
+          </h1>
           <p className="text-base text-muted-foreground">
-            Let&apos;s set up your profile before continuing
+            {isExistingUser
+              ? "Since this is your first time logging in with F3 Nation SSO, please take this opportunity to confirm your details."
+              : "Let\u2019s get you set up since this is your first time."}
           </p>
         </div>
 

--- a/apps/auth/src/app/onboarding/page.tsx
+++ b/apps/auth/src/app/onboarding/page.tsx
@@ -20,7 +20,7 @@ function OnboardingForm() {
   const [firstName, setFirstName] = useState("");
   const [lastName, setLastName] = useState("");
   const [loading, setLoading] = useState(false);
-  const [prefilling, setPrefilling] = useState(true);
+  const [prefilling, setPrefilling] = useState(false);
   const [isExistingUser, setIsExistingUser] = useState(false);
   const [error, setError] = useState("");
   const router = useRouter();
@@ -28,8 +28,8 @@ function OnboardingForm() {
   const callbackUrl = searchParams.get("callbackUrl") ?? "/";
 
   useEffect(() => {
-    if (!session?.user) return;
     if (!session?.user?.id) return;
+    setPrefilling(true);
     fetch("/api/onboarding")
       .then((res) => {
         if (!res.ok) return;

--- a/apps/auth/src/lib/jwt.ts
+++ b/apps/auth/src/lib/jwt.ts
@@ -8,7 +8,9 @@ let _jwks: { keys: JWK[] } | null = null;
 
 async function getPrivateKey(): Promise<CryptoKey> {
   if (!_privateKey) {
-    _privateKey = await importPKCS8(env.AUTH_JWT_PRIVATE_KEY, "RS256");
+    _privateKey = await importPKCS8(env.AUTH_JWT_PRIVATE_KEY, "RS256", {
+      extractable: true,
+    });
   }
   return _privateKey;
 }


### PR DESCRIPTION
## Summary

This PR adds several improvements to the **f3-auth** app (v1.1.1) needed to support SSO client applications (specifically the new **f3-me** app). These changes address real issues encountered during local development and end-to-end testing of the OAuth/SSO flow.

---

## Changes

### 1. New SSO Logout Endpoint (`/api/oauth/logout`)

**Why:** When an SSO client app (e.g. f3-me) signs a user out, it only clears its own session cookie. But the auth app's NextAuth session remains active. So when the user clicks "Sign in" again, the OAuth authorize endpoint finds the existing auth session and immediately issues a new authorization code — the user is never prompted to re-authenticate.

**What:** Added `GET /api/oauth/logout?post_logout_redirect_uri=<url>`. This endpoint:
- Revokes all refresh tokens for the authenticated user (via `revokeAllUserTokens`)
- Clears all NextAuth/AuthJS session cookies
- Redirects back to the client app's `post_logout_redirect_uri`

This follows the OIDC RP-Initiated Logout pattern. Client apps redirect here during sign-out so that both the client session **and** the SSO session are fully terminated.

### 2. Onboarding GET Endpoint + Prefill (`/api/onboarding`)

**Why:** When an existing F3 user logs in via SSO for the first time, the authorize endpoint checks `meta.onboarding_completed` and redirects to `/onboarding` if it's not set. But the onboarding form was always blank with "Welcome to F3 Nation!" messaging — even for users who already have an f3Name, firstName, and lastName in the database. This was confusing for existing users.

**What:**
- Added a `GET /api/onboarding` endpoint that returns the user's existing `f3Name`, `firstName`, `lastName`, and an `isExistingUser` boolean
- Updated the onboarding page to prefill form fields from the GET response
- Conditional messaging: existing users see "Welcome Back!" and "confirm your details" instead of the new-user onboarding copy

### 3. JWT Extractable Key Fix (`jwt.ts`)

**Why:** The `/api/oauth/userinfo` endpoint and JWKS endpoint need to export the public key as a JWK. Node.js `importPKCS8` creates a non-extractable `CryptoKey` by default, which causes `non-extractable CryptoKey cannot be exported as a JWK` at runtime.

**What:** Added `{ extractable: true }` to the `importPKCS8` call so the key can be exported for JWKS discovery.

### 4. Authorize Redirect to `/login/email`

**Why:** The generic `/login` page may show multiple login options. For the SSO OAuth flow, we want users to go directly to email-based authentication.

**What:** Changed the authorize endpoint's unauthenticated redirect from `/login` to `/login/email`.

### 5. `add-client.ts` CJS/ESM Interop Fix

**Why:** The `apps/auth` package has `"type": "module"` but `@acme/db` does not. When `add-client.ts` does `import { oauthClients } from "@acme/db/schema/schema"`, Node.js ESM/CJS interop wraps the CJS module's exports under a `.default` property, so named imports resolve to `undefined` at runtime.

**What:** Changed to `import * as _schema` with a runtime check: `"default" in _schema ? _schema.default : _schema`. Also added `DATABASE_PORT` env var support (was hardcoded to 5432).

---

## Version

Bumped `f3-auth` from `1.1.0` → `1.1.1`.

## Testing

All changes were tested locally with the f3-me app running on port 3003 and f3-auth on port 3004:
- Sign in → callback → session creation ✅
- Sign out → auth session cleared → re-login prompts authentication ✅
- Onboarding prefill for existing users ✅
- JWT/JWKS export works ✅
- add-client.ts runs successfully with custom DATABASE_PORT ✅