### PR TITLE
chore: add .claude/worktrees/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,6 @@ test-results/
 
 pr.md
 .eslintcache
+
+# claude code
+.claude/worktrees/


### PR DESCRIPTION
## Summary
- Adds `.claude/worktrees/` to `.gitignore` to prevent Claude Code agent worktrees from being tracked in version control

## Test plan
- [x] Verify `.claude/worktrees/` directory is ignored by git

🤖 Generated with [Claude Code](https://claude.com/claude-code)