### PR TITLE
Bug/auth internal redirect clean

### DIFF
--- a/apps/auth/package.json
+++ b/apps/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "f3-auth",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/auth/src/app/api/oauth/authorize/route.ts
+++ b/apps/auth/src/app/api/oauth/authorize/route.ts
@@ -13,6 +13,7 @@ import {
   validateScopes,
 } from "~/lib/oauth";
 import { rateLimit } from "~/lib/rate-limit";
+import { env } from "~/env";
 
 export async function GET(request: NextRequest) {
   const ip = request.headers.get("x-forwarded-for") ?? "unknown";
@@ -21,7 +22,9 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: "Too many requests" }, { status: 429 });
   }
 
-  const { searchParams } = new URL(request.url);
+  const publicUrl = env.NEXT_PUBLIC_AUTH_URL;
+  const reqUrl = new URL(request.url);
+  const { searchParams } = reqUrl;
   const responseType = searchParams.get("response_type");
   const clientId = searchParams.get("client_id");
   const redirectUri = searchParams.get("redirect_uri");
@@ -70,8 +73,8 @@ export async function GET(request: NextRequest) {
   const session = await auth();
   if (!session?.user?.id) {
     // Redirect to login with callback to this authorize URL
-    const callbackUrl = request.url;
-    const loginUrl = new URL("/login/email", request.url);
+    const callbackUrl = `${publicUrl}${reqUrl.pathname}${reqUrl.search}`;
+    const loginUrl = new URL("/login/email", publicUrl);
     loginUrl.searchParams.set("callbackUrl", callbackUrl);
     return NextResponse.redirect(loginUrl);
   }
@@ -87,8 +90,8 @@ export async function GET(request: NextRequest) {
 
   const meta = (dbUser?.meta ?? {}) as Record<string, unknown>;
   if (!meta.onboarding_completed) {
-    const callbackUrl = request.url;
-    const onboardingUrl = new URL("/onboarding", request.url);
+    const callbackUrl = `${publicUrl}${reqUrl.pathname}${reqUrl.search}`;
+    const onboardingUrl = new URL("/onboarding", publicUrl);
     onboardingUrl.searchParams.set("callbackUrl", callbackUrl);
     return NextResponse.redirect(onboardingUrl);
   }

--- a/apps/auth/src/app/api/oauth/logout/route.ts
+++ b/apps/auth/src/app/api/oauth/logout/route.ts
@@ -8,6 +8,7 @@ import { oauthClients } from "@acme/db/schema/schema";
 import { auth } from "~/lib/auth";
 import { db } from "~/lib/db";
 import { revokeAllUserTokens } from "~/lib/oauth";
+import { env } from "~/env";
 
 /**
  * Collect every origin that appears in the redirect_uris of active
@@ -53,19 +54,21 @@ export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url);
   const postLogoutRedirectUri = searchParams.get("post_logout_redirect_uri");
 
+  const publicUrl = env.NEXT_PUBLIC_AUTH_URL;
+
   // Validate the redirect target against registered client origins.
   const allowedOrigins = await getAllowedOrigins();
-  const requestOrigin = new URL(request.url).origin;
+  const requestOrigin = new URL(publicUrl).origin;
   allowedOrigins.add(requestOrigin); // always allow same-origin
 
   let redirectUrl: URL;
   try {
-    const candidate = new URL(postLogoutRedirectUri ?? "/login", request.url);
+    const candidate = new URL(postLogoutRedirectUri ?? "/login", publicUrl);
     redirectUrl = allowedOrigins.has(candidate.origin)
       ? candidate
-      : new URL("/login", request.url);
+      : new URL("/login", publicUrl);
   } catch {
-    redirectUrl = new URL("/login", request.url);
+    redirectUrl = new URL("/login", publicUrl);
   }
 
   // Revoke tokens if user is authenticated


### PR DESCRIPTION
This pull request updates the `apps/auth` service to consistently use the configured public authentication URL (`NEXT_PUBLIC_AUTH_URL`) for all OAuth-related redirects and URL constructions. This improves reliability in environments where the service may be accessed behind proxies or from multiple domains.

**OAuth Redirect Handling Improvements:**

* Updated the `/api/oauth/authorize` route to construct all redirect URLs (login and onboarding) using `env.NEXT_PUBLIC_AUTH_URL` instead of the incoming request URL, ensuring users are always redirected to the correct public-facing URL. [[1]](diffhunk://#diff-d8bfd6158a5810fd98ba8478d25cafb30be79643330e1b4f7f2efd0d0f49d7eeR16) [[2]](diffhunk://#diff-d8bfd6158a5810fd98ba8478d25cafb30be79643330e1b4f7f2efd0d0f49d7eeL24-R27) [[3]](diffhunk://#diff-d8bfd6158a5810fd98ba8478d25cafb30be79643330e1b4f7f2efd0d0f49d7eeL73-R77) [[4]](diffhunk://#diff-d8bfd6158a5810fd98ba8478d25cafb30be79643330e1b4f7f2efd0d0f49d7eeL90-R94)
* Updated the `/api/oauth/logout` route to use `env.NEXT_PUBLIC_AUTH_URL` for origin validation and construction of redirect URLs, preventing potential issues with incorrect origins or redirect targets. [[1]](diffhunk://#diff-6f9ccfdb05243121febfe49cd999076fe86db8e9e47786fe5658bd1c90efcd7aR11) [[2]](diffhunk://#diff-6f9ccfdb05243121febfe49cd999076fe86db8e9e47786fe5658bd1c90efcd7aR57-R71)

**Dependency Update:**

* Bumped the `f3-auth` package version from `1.1.1` to `1.1.2` to reflect these changes.