### PR TITLE
fix(auth): converting literal new line characters

### DIFF
--- a/apps/auth/src/lib/jwt.ts
+++ b/apps/auth/src/lib/jwt.ts
@@ -8,7 +8,8 @@ let _jwks: { keys: JWK[] } | null = null;
 
 async function getPrivateKey(): Promise<CryptoKey> {
   if (!_privateKey) {
-    _privateKey = await importPKCS8(env.AUTH_JWT_PRIVATE_KEY, "RS256", {
+    const pem = env.AUTH_JWT_PRIVATE_KEY.replace(/\\n/g, "\n");
+    _privateKey = await importPKCS8(pem, "RS256", {
       extractable: true,
     });
   }


### PR DESCRIPTION
This pull request makes a small but important fix to the way the private key is imported in the JWT library. It ensures that the private key string from the environment variable is correctly formatted by replacing escaped newline characters with actual newlines before importing.

- Fixed the import of the JWT private key in `jwt.ts` by replacing escaped `\n` characters with real newlines, ensuring proper parsing of PEM-formatted keys.