### PR TITLE
fix(me): Security fixes, hook extraction, dead code removal

### DIFF
--- a/apps/me/__tests__/api/auth-logout.test.ts
+++ b/apps/me/__tests__/api/auth-logout.test.ts
@@ -4,6 +4,11 @@ describe("Auth /logout route", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.resetModules();
+    // The logout route imports getOAuthConfig which requires these env vars
+    vi.stubEnv("OAUTH_CLIENT_ID", "test-client-id");
+    vi.stubEnv("OAUTH_CLIENT_SECRET", "test-client-secret");
+    vi.stubEnv("OAUTH_REDIRECT_URI", "http://localhost:3003/api/auth/callback");
+    vi.stubEnv("AUTH_PROVIDER_URL", "http://localhost:3002");
   });
 
   it("clears session cookie and returns ok", async () => {

--- a/apps/me/middleware.ts
+++ b/apps/me/middleware.ts
@@ -1,6 +1,7 @@
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import { SESSION_COOKIE_NAME } from "@/lib/auth/constants";
+import { verifySessionValue } from "@/lib/auth/session";
 
 const PUBLIC_PATHS = ["/", "/api/auth/login", "/api/auth/callback"];
 
@@ -26,9 +27,13 @@ export function middleware(request: NextRequest) {
     return NextResponse.next();
   }
 
-  // Check for session cookie
+  // Verify session cookie signature (not just existence)
   const sessionCookie = request.cookies.get(SESSION_COOKIE_NAME);
-  if (!sessionCookie?.value) {
+  const session = sessionCookie?.value
+    ? verifySessionValue(sessionCookie.value)
+    : null;
+
+  if (!session) {
     const url = new URL("/", request.url);
     url.searchParams.set("redirect", pathname);
     return NextResponse.redirect(url);

--- a/apps/me/src/app/api/auth/callback/route.ts
+++ b/apps/me/src/app/api/auth/callback/route.ts
@@ -6,6 +6,7 @@ import {
   SESSION_COOKIE_MAX_AGE,
   SESSION_COOKIE_NAME,
 } from "@/lib/auth/constants";
+import { safeReturnTo } from "@/lib/auth/validation";
 
 interface StatePayload {
   csrfToken: string;
@@ -63,7 +64,8 @@ export async function GET(request: NextRequest) {
     return errorRedirect(baseUrl, "csrf_mismatch");
   }
 
-  const returnTo = state.returnTo || "/profile";
+  // Re-validate returnTo from state (defense-in-depth against tampered state)
+  const returnTo = safeReturnTo(state.returnTo);
 
   // Validate PKCE code verifier cookie
   const codeVerifier = request.cookies.get("oauth_code_verifier")?.value;

--- a/apps/me/src/app/api/auth/login/route.ts
+++ b/apps/me/src/app/api/auth/login/route.ts
@@ -2,14 +2,10 @@ import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 import { randomBytes, randomUUID, createHash } from "crypto";
 import { getOAuthConfig } from "@/lib/auth/oauth";
-
-function isValidReturnTo(path: string): boolean {
-  return path.startsWith("/") && !path.startsWith("//");
-}
+import { safeReturnTo } from "@/lib/auth/validation";
 
 export async function GET(request: NextRequest) {
-  const returnTo = request.nextUrl.searchParams.get("returnTo") ?? "/profile";
-  const safeReturnTo = isValidReturnTo(returnTo) ? returnTo : "/profile";
+  const returnTo = safeReturnTo(request.nextUrl.searchParams.get("returnTo"));
 
   const csrfToken = randomUUID();
   const codeVerifier = randomBytes(32).toString("base64url");
@@ -22,7 +18,7 @@ export async function GET(request: NextRequest) {
     JSON.stringify({
       csrfToken,
       clientId,
-      returnTo: safeReturnTo,
+      returnTo,
       timestamp: Date.now(),
     }),
   ).toString("base64url");

--- a/apps/me/src/app/api/profile/positions/route.ts
+++ b/apps/me/src/app/api/profile/positions/route.ts
@@ -1,30 +1,33 @@
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
+import { z } from "zod";
 import { requireAuth } from "@/lib/auth/server";
 import { deleteMyPosition } from "@/lib/api/client";
+
+const deletePositionSchema = z
+  .object({
+    orgId: z.number().int().positive(),
+    positionId: z.number().int().positive(),
+  })
+  .strict();
 
 export async function DELETE(request: NextRequest) {
   try {
     await requireAuth();
 
-    const body = (await request.json()) as {
-      orgId: number;
-      positionId: number;
-    };
-
-    if (
-      body.orgId == null ||
-      typeof body.orgId !== "number" ||
-      body.positionId == null ||
-      typeof body.positionId !== "number"
-    ) {
+    const raw: unknown = await request.json();
+    const parsed = deletePositionSchema.safeParse(raw);
+    if (!parsed.success) {
       return NextResponse.json(
-        { error: "orgId and positionId are required" },
+        { error: "orgId and positionId are required (positive integers)" },
         { status: 400 },
       );
     }
 
-    const result = await deleteMyPosition(body.orgId, body.positionId);
+    const result = await deleteMyPosition(
+      parsed.data.orgId,
+      parsed.data.positionId,
+    );
     return NextResponse.json(result);
   } catch (err) {
     console.error("Failed to remove position:", err);

--- a/apps/me/src/app/api/profile/roles/route.ts
+++ b/apps/me/src/app/api/profile/roles/route.ts
@@ -1,30 +1,30 @@
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
+import { z } from "zod";
 import { requireAuth } from "@/lib/auth/server";
 import { deleteMyRole } from "@/lib/api/client";
+
+const deleteRoleSchema = z
+  .object({
+    orgId: z.number().int().positive(),
+    roleId: z.number().int().positive(),
+  })
+  .strict();
 
 export async function DELETE(request: NextRequest) {
   try {
     await requireAuth();
 
-    const body = (await request.json()) as {
-      orgId: number;
-      roleId: number;
-    };
-
-    if (
-      body.orgId == null ||
-      typeof body.orgId !== "number" ||
-      body.roleId == null ||
-      typeof body.roleId !== "number"
-    ) {
+    const raw: unknown = await request.json();
+    const parsed = deleteRoleSchema.safeParse(raw);
+    if (!parsed.success) {
       return NextResponse.json(
-        { error: "orgId and roleId are required" },
+        { error: "orgId and roleId are required (positive integers)" },
         { status: 400 },
       );
     }
 
-    const result = await deleteMyRole(body.orgId, body.roleId);
+    const result = await deleteMyRole(parsed.data.orgId, parsed.data.roleId);
     return NextResponse.json(result);
   } catch (err) {
     console.error("Failed to remove role:", err);

--- a/apps/me/src/app/api/users/route.ts
+++ b/apps/me/src/app/api/users/route.ts
@@ -3,6 +3,8 @@ import { NextResponse } from "next/server";
 import { requireAuth } from "@/lib/auth/server";
 import { getUsers } from "@/lib/api/client";
 
+const MAX_RESULTS = 500;
+
 export async function GET(request: NextRequest) {
   try {
     await requireAuth();
@@ -17,7 +19,9 @@ export async function GET(request: NextRequest) {
     }
 
     const users = await getUsers(parsed);
-    return NextResponse.json({ users });
+
+    // Cap results to prevent unbounded response payloads at scale
+    return NextResponse.json({ users: users.slice(0, MAX_RESULTS) });
   } catch (err) {
     console.error("Failed to fetch users:", err);
     if (err instanceof Error && err.message.includes("NEXT_REDIRECT"))

--- a/apps/me/src/app/page.tsx
+++ b/apps/me/src/app/page.tsx
@@ -1,6 +1,7 @@
 import { redirect } from "next/navigation";
 import { getSessionUser } from "@/lib/auth/server";
 import { AuthCard } from "@/components/auth-card";
+import { safeReturnTo } from "@/lib/auth/validation";
 
 interface PageProps {
   searchParams: Promise<{ error?: string; redirect?: string }>;
@@ -10,9 +11,9 @@ export default async function HomePage({ searchParams }: PageProps) {
   const params = await searchParams;
   const user = await getSessionUser();
 
-  // If authenticated, redirect to profile
+  // If authenticated, redirect to profile (validated to prevent open redirect)
   if (user) {
-    redirect(params.redirect ?? "/profile");
+    redirect(safeReturnTo(params.redirect));
   }
 
   return (

--- a/apps/me/src/components/avatar-upload.tsx
+++ b/apps/me/src/components/avatar-upload.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useRef, useState, useCallback } from "react";
+import { useRef } from "react";
 import { Avatar } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import { useToast } from "@/components/ui/toast";
+import { useAvatarUpload } from "@/hooks/useAvatarUpload";
 
 interface AvatarUploadProps {
   currentUrl: string | null;
@@ -16,87 +17,31 @@ export function AvatarUpload({
   fallbackName,
   onUploaded,
 }: AvatarUploadProps) {
-  const [uploading, setUploading] = useState(false);
-  const [previewUrl, setPreviewUrl] = useState<string | null>(currentUrl);
-  const [dragOver, setDragOver] = useState(false);
-  const inputRef = useRef<HTMLInputElement>(null);
   const { toast } = useToast();
+  const inputRef = useRef<HTMLInputElement>(null);
+  const {
+    uploading,
+    previewUrl,
+    dragOver,
+    setDragOver,
+    handleDrop,
+    handleFileChange,
+  } = useAvatarUpload({ currentUrl, onUploaded, toast });
 
-  const handleUpload = useCallback(
-    async (file: File) => {
-      if (file.size > 5 * 1024 * 1024) {
-        toast({
-          title: "File too large",
-          description: "Maximum file size is 5MB.",
-          variant: "destructive",
-        });
-        return;
-      }
-
-      if (!["image/jpeg", "image/png", "image/webp"].includes(file.type)) {
-        toast({
-          title: "Invalid file type",
-          description: "Please upload a JPEG, PNG, or WebP image.",
-          variant: "destructive",
-        });
-        return;
-      }
-
-      setUploading(true);
-
-      try {
-        const formData = new FormData();
-        formData.append("file", file);
-
-        const res = await fetch("/api/profile/avatar", {
-          method: "POST",
-          body: formData,
-        });
-
-        if (!res.ok) {
-          const err = (await res.json().catch(() => ({}))) as {
-            error?: string;
-          };
-          throw new Error(err.error ?? "Upload failed");
-        }
-
-        const data = (await res.json()) as { avatarUrl: string };
-        setPreviewUrl(data.avatarUrl);
-        onUploaded(data.avatarUrl);
-        toast({
-          title: "Avatar updated",
-          description: "Your avatar has been saved.",
-        });
-      } catch (err) {
-        toast({
-          title: "Upload failed",
-          description: err instanceof Error ? err.message : "Please try again.",
-          variant: "destructive",
-        });
-      } finally {
-        setUploading(false);
-      }
-    },
-    [onUploaded, toast],
-  );
+  const openFilePicker = () => inputRef.current?.click();
 
   return (
     <div className="flex items-center gap-4">
       <button
         type="button"
         className={`relative cursor-pointer rounded-full ${dragOver ? "ring-2 ring-primary ring-offset-2" : ""}`}
-        onClick={() => inputRef.current?.click()}
+        onClick={openFilePicker}
         onDragOver={(e) => {
           e.preventDefault();
           setDragOver(true);
         }}
         onDragLeave={() => setDragOver(false)}
-        onDrop={(e) => {
-          e.preventDefault();
-          setDragOver(false);
-          const file = e.dataTransfer.files[0];
-          if (file) void handleUpload(file);
-        }}
+        onDrop={handleDrop}
       >
         <Avatar
           src={previewUrl}
@@ -114,7 +59,7 @@ export function AvatarUpload({
         <Button
           variant="outline"
           size="sm"
-          onClick={() => inputRef.current?.click()}
+          onClick={openFilePicker}
           disabled={uploading}
         >
           {uploading ? "Uploading..." : "Change avatar"}
@@ -128,10 +73,7 @@ export function AvatarUpload({
         type="file"
         accept="image/jpeg,image/png,image/webp"
         className="hidden"
-        onChange={(e) => {
-          const file = e.target.files?.[0];
-          if (file) void handleUpload(file);
-        }}
+        onChange={handleFileChange}
       />
     </div>
   );

--- a/apps/me/src/components/position-list.tsx
+++ b/apps/me/src/components/position-list.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useState } from "react";
 import { Badge } from "@/components/ui/badge";
 import { useToast } from "@/components/ui/toast";
+import { useRemovableList, compositeKey } from "@/hooks/useRemovableList";
 import type { UserPosition } from "@/lib/types";
 
 interface PositionListProps {
@@ -12,45 +12,25 @@ interface PositionListProps {
 export function PositionList({
   positions: initialPositions,
 }: PositionListProps) {
-  const [positions, setPositions] = useState(initialPositions);
-  const [removing, setRemoving] = useState<string | null>(null);
   const { toast } = useToast();
-
-  const handleRemove = async (orgId: number, positionId: number) => {
-    const key = `${orgId}-${positionId}`;
-    setRemoving(key);
-
-    try {
-      const res = await fetch("/api/profile/positions", {
-        method: "DELETE",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ orgId, positionId }),
-      });
-
-      if (!res.ok) {
-        const err = (await res.json().catch(() => ({}))) as {
-          error?: string;
-        };
-        throw new Error(err.error ?? "Failed to remove position");
-      }
-
-      setPositions((prev) =>
-        prev.filter((p) => !(p.orgId === orgId && p.positionId === positionId)),
-      );
-      toast({
-        title: "Position removed",
-        description: "Your position assignment has been removed.",
-      });
-    } catch (err) {
-      toast({
-        title: "Failed to remove position",
-        description: err instanceof Error ? err.message : "Please try again.",
-        variant: "destructive",
-      });
-    } finally {
-      setRemoving(null);
-    }
-  };
+  const {
+    items: positions,
+    removing,
+    handleRemove,
+  } = useRemovableList({
+    initialItems: initialPositions,
+    getKey: (p) => compositeKey(p.orgId, p.positionId),
+    endpoint: "/api/profile/positions",
+    buildDeleteBody: (p) => ({ orgId: p.orgId, positionId: p.positionId }),
+    shouldKeep: (item, removed) =>
+      !(item.orgId === removed.orgId && item.positionId === removed.positionId),
+    toast,
+    successMessage: () => ({
+      title: "Position removed",
+      description: "Your position assignment has been removed.",
+    }),
+    failureTitle: "Failed to remove position",
+  });
 
   if (positions.length === 0) {
     return (
@@ -62,7 +42,7 @@ export function PositionList({
     <div className="space-y-3">
       <div className="flex flex-wrap gap-2">
         {positions.map((pos) => {
-          const key = `${pos.orgId}-${pos.positionId}`;
+          const key = compositeKey(pos.orgId, pos.positionId);
           return (
             <Badge
               key={key}
@@ -76,7 +56,7 @@ export function PositionList({
                 type="button"
                 className="ml-1 rounded-full p-0.5 hover:bg-foreground/10 disabled:opacity-50"
                 disabled={removing === key}
-                onClick={() => handleRemove(pos.orgId, pos.positionId)}
+                onClick={() => handleRemove(pos)}
                 aria-label={`Remove ${pos.positionName} position from ${pos.orgName}`}
               >
                 {removing === key ? (

--- a/apps/me/src/components/profile-form.tsx
+++ b/apps/me/src/components/profile-form.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useState, useCallback, useMemo, useEffect, useRef } from "react";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
@@ -18,143 +17,25 @@ import { RegionSelect } from "@/components/region-select";
 import { UserSelect } from "@/components/user-select";
 import { RoleList } from "@/components/role-list";
 import { PositionList } from "@/components/position-list";
-import { useSaveRegister } from "@/lib/save-context";
-import type { UserProfile, UserMeta, Region } from "@/lib/types";
+import { useProfileForm } from "@/hooks/useProfileForm";
+import type { UserProfile, Region } from "@/lib/types";
 
 interface ProfileFormProps {
   user: UserProfile;
   regions: Region[];
 }
 
-function parseMeta(meta: string | Record<string, unknown> | null): UserMeta {
-  if (!meta) return {};
-  if (typeof meta === "object") return meta as UserMeta;
-  try {
-    return JSON.parse(meta) as UserMeta;
-  } catch {
-    return {};
-  }
-}
-
 export function ProfileForm({ user, regions }: ProfileFormProps) {
-  const meta = parseMeta(user.meta);
   const { toast } = useToast();
-
-  const [saving, setSaving] = useState(false);
-  const [form, setForm] = useState({
-    f3Name: user.f3Name ?? "",
-    firstName: user.firstName ?? "",
-    lastName: user.lastName ?? "",
-    phone: user.phone ?? "",
-    homeRegionId: user.homeRegionId,
-    avatarUrl: user.avatarUrl,
-    emergencyContact: user.emergencyContact ?? "",
-    emergencyPhone: user.emergencyPhone ?? "",
-    emergencyNotes: user.emergencyNotes ?? "",
-    f3_name_origin: meta.f3_name_origin ?? "",
-    my_f3_why: meta.my_f3_why ?? "",
-    user_emergency_info_dr_sharing:
-      meta.user_emergency_info_dr_sharing ?? false,
-    start_date_override: meta.start_date_override ?? "",
-    brought_by: (meta.brought_by as number | null) ?? null,
+  const {
+    form,
+    isFieldDirty,
+    dirtyClass: dc,
+    updateField,
+  } = useProfileForm({
+    user,
+    toast,
   });
-
-  const [initialForm, setInitialForm] = useState(() => ({ ...form }));
-
-  const isFieldDirty = useCallback(
-    (key: keyof typeof form) => form[key] !== initialForm[key],
-    [form, initialForm],
-  );
-
-  const isDirty = useMemo(
-    () =>
-      (Object.keys(form) as (keyof typeof form)[]).some(
-        (key) => key !== "avatarUrl" && form[key] !== initialForm[key],
-      ),
-    [form, initialForm],
-  );
-
-  // Returns a class string to visually mark dirty fields.
-  // Always reserves space for the bar (pl-2 + left border) so fields don't shift.
-  const dc = (key: keyof typeof form) =>
-    isFieldDirty(key)
-      ? " pl-2 border-l-[3px] border-l-amber-500"
-      : " pl-2 border-l-[3px] border-l-transparent";
-
-  const updateField = useCallback(
-    <K extends keyof typeof form>(key: K, value: (typeof form)[K]) => {
-      setForm((prev) => ({ ...prev, [key]: value }));
-    },
-    [],
-  );
-
-  const handleSave = async () => {
-    setSaving(true);
-    try {
-      // Only send fields that changed
-      const payload: Record<string, unknown> = {};
-      if (isFieldDirty("f3Name")) payload.f3Name = form.f3Name;
-      if (isFieldDirty("firstName")) payload.firstName = form.firstName || null;
-      if (isFieldDirty("lastName")) payload.lastName = form.lastName;
-      if (isFieldDirty("phone")) payload.phone = form.phone || null;
-      if (isFieldDirty("homeRegionId"))
-        payload.homeRegionId = form.homeRegionId;
-      if (isFieldDirty("emergencyContact"))
-        payload.emergencyContact = form.emergencyContact || null;
-      if (isFieldDirty("emergencyPhone"))
-        payload.emergencyPhone = form.emergencyPhone || null;
-      if (isFieldDirty("emergencyNotes"))
-        payload.emergencyNotes = form.emergencyNotes || null;
-      if (isFieldDirty("f3_name_origin"))
-        payload.f3_name_origin = form.f3_name_origin || "";
-      if (isFieldDirty("my_f3_why")) payload.my_f3_why = form.my_f3_why || "";
-      if (isFieldDirty("user_emergency_info_dr_sharing"))
-        payload.user_emergency_info_dr_sharing =
-          form.user_emergency_info_dr_sharing;
-      if (isFieldDirty("start_date_override"))
-        payload.start_date_override = form.start_date_override || "";
-      if (isFieldDirty("brought_by")) payload.brought_by = form.brought_by;
-
-      const res = await fetch("/api/profile", {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(payload),
-      });
-
-      if (!res.ok) {
-        const err = (await res.json().catch(() => ({}))) as {
-          error?: string;
-        };
-        throw new Error(err.error ?? "Failed to save profile");
-      }
-
-      // Reset dirty tracking so indicators clear
-      setInitialForm({ ...form });
-
-      toast({
-        title: "Profile saved",
-        description: "Your changes have been saved successfully.",
-      });
-    } catch (err) {
-      toast({
-        title: "Save failed",
-        description: err instanceof Error ? err.message : "Please try again.",
-        variant: "destructive",
-      });
-    } finally {
-      setSaving(false);
-    }
-  };
-
-  // Keep a stable ref to handleSave for the context registration
-  const saveRef = useRef(handleSave);
-  saveRef.current = handleSave;
-
-  // Register save state with the navbar
-  const { register } = useSaveRegister();
-  useEffect(() => {
-    register({ isDirty, saving, onSave: () => void saveRef.current() });
-  }, [isDirty, saving, register]);
 
   return (
     <div className="mx-auto max-w-5xl space-y-6 p-4 pb-12">

--- a/apps/me/src/components/region-select.tsx
+++ b/apps/me/src/components/region-select.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useState, useMemo } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { useDropdownSelect } from "@/hooks/useDropdownSelect";
+import { useRegionFilter } from "@/hooks/useRegionFilter";
 import type { Region } from "@/lib/types";
 
 interface RegionSelectProps {
@@ -12,21 +13,13 @@ interface RegionSelectProps {
 }
 
 export function RegionSelect({ regions, value, onChange }: RegionSelectProps) {
-  const [open, setOpen] = useState(false);
-  const [search, setSearch] = useState("");
-
-  const selectedRegion = useMemo(
-    () => regions.find((r) => r.id === value),
-    [regions, value],
-  );
-
-  const filteredRegions = useMemo(() => {
-    // Show active regions + the currently selected region (even if inactive)
-    const base = regions.filter((r) => r.isActive || r.id === value);
-    if (!search) return base;
-    const lower = search.toLowerCase();
-    return base.filter((r) => r.name.toLowerCase().includes(lower));
-  }, [regions, search, value]);
+  const { open, search, toggle, close, setSearch, selectAndClose } =
+    useDropdownSelect();
+  const { selectedRegion, filteredRegions } = useRegionFilter({
+    regions,
+    selectedId: value,
+    search,
+  });
 
   return (
     <div className="relative">
@@ -34,7 +27,7 @@ export function RegionSelect({ regions, value, onChange }: RegionSelectProps) {
         variant="outline"
         type="button"
         className="w-full justify-between text-left font-normal"
-        onClick={() => setOpen(!open)}
+        onClick={toggle}
       >
         <span className={selectedRegion ? "" : "text-muted-foreground"}>
           {selectedRegion?.name ?? "Select a region..."}
@@ -75,8 +68,7 @@ export function RegionSelect({ regions, value, onChange }: RegionSelectProps) {
                 className="relative flex w-full cursor-pointer select-none items-center rounded-sm px-2 py-1.5 text-sm text-muted-foreground outline-none hover:bg-accent"
                 onClick={() => {
                   onChange(null);
-                  setOpen(false);
-                  setSearch("");
+                  selectAndClose();
                 }}
               >
                 Clear selection
@@ -98,8 +90,7 @@ export function RegionSelect({ regions, value, onChange }: RegionSelectProps) {
                   onClick={() => {
                     if (!region.isActive) return;
                     onChange(region.id);
-                    setOpen(false);
-                    setSearch("");
+                    selectAndClose();
                   }}
                 >
                   {region.name}
@@ -118,13 +109,7 @@ export function RegionSelect({ regions, value, onChange }: RegionSelectProps) {
       {/* Click-away handler */}
       {open && (
         // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
-        <div
-          className="fixed inset-0 z-40"
-          onClick={() => {
-            setOpen(false);
-            setSearch("");
-          }}
-        />
+        <div className="fixed inset-0 z-40" onClick={close} />
       )}
     </div>
   );

--- a/apps/me/src/components/role-list.tsx
+++ b/apps/me/src/components/role-list.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useState } from "react";
 import { Badge } from "@/components/ui/badge";
 import { useToast } from "@/components/ui/toast";
+import { useRemovableList, compositeKey } from "@/hooks/useRemovableList";
 import type { UserRole } from "@/lib/types";
 
 interface RoleListProps {
@@ -10,47 +10,25 @@ interface RoleListProps {
 }
 
 export function RoleList({ roles: initialRoles }: RoleListProps) {
-  const [roles, setRoles] = useState(initialRoles);
-  const [removing, setRemoving] = useState<string | null>(null);
   const { toast } = useToast();
-
-  const handleRemove = async (role: UserRole) => {
-    const key = `${role.orgId}-${role.roleId}`;
-    setRemoving(key);
-
-    try {
-      const res = await fetch("/api/profile/roles", {
-        method: "DELETE",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ orgId: role.orgId, roleId: role.roleId }),
-      });
-
-      if (!res.ok) {
-        const err = (await res.json().catch(() => ({}))) as {
-          error?: string;
-        };
-        throw new Error(err.error ?? "Failed to remove role");
-      }
-
-      setRoles((prev) =>
-        prev.filter(
-          (r) => !(r.orgId === role.orgId && r.roleId === role.roleId),
-        ),
-      );
-      toast({
-        title: "Role removed",
-        description: `Removed ${role.roleName} role.`,
-      });
-    } catch (err) {
-      toast({
-        title: "Failed to remove role",
-        description: err instanceof Error ? err.message : "Please try again.",
-        variant: "destructive",
-      });
-    } finally {
-      setRemoving(null);
-    }
-  };
+  const {
+    items: roles,
+    removing,
+    handleRemove,
+  } = useRemovableList({
+    initialItems: initialRoles,
+    getKey: (r) => compositeKey(r.orgId, r.roleId),
+    endpoint: "/api/profile/roles",
+    buildDeleteBody: (r) => ({ orgId: r.orgId, roleId: r.roleId }),
+    shouldKeep: (item, removed) =>
+      !(item.orgId === removed.orgId && item.roleId === removed.roleId),
+    toast,
+    successMessage: (r) => ({
+      title: "Role removed",
+      description: `Removed ${r.roleName} role.`,
+    }),
+    failureTitle: "Failed to remove role",
+  });
 
   if (roles.length === 0) {
     return <p className="text-sm text-muted-foreground">No roles assigned.</p>;
@@ -60,7 +38,7 @@ export function RoleList({ roles: initialRoles }: RoleListProps) {
     <div className="space-y-3">
       <div className="flex flex-wrap gap-2">
         {roles.map((role) => {
-          const key = `${role.orgId}-${role.roleId}`;
+          const key = compositeKey(role.orgId, role.roleId);
           return (
             <Badge
               key={key}

--- a/apps/me/src/components/ui/avatar.tsx
+++ b/apps/me/src/components/ui/avatar.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import Image from "next/image";
 import { cn, getFallbackAvatar } from "@/lib/utils";
 
 interface AvatarProps extends React.HTMLAttributes<HTMLSpanElement> {
@@ -12,6 +13,12 @@ const sizeClasses = {
   sm: "h-8 w-8",
   md: "h-12 w-12",
   lg: "h-20 w-20",
+};
+
+const sizePx = {
+  sm: 32,
+  md: 48,
+  lg: 80,
 };
 
 function Avatar({
@@ -29,6 +36,7 @@ function Avatar({
   }, [src]);
 
   const showFallback = !src || imgError;
+  const px = sizePx[size];
 
   return (
     <span
@@ -40,17 +48,21 @@ function Avatar({
       {...props}
     >
       {showFallback ? (
-        // eslint-disable-next-line @next/next/no-img-element
-        <img
+        // Fallback is a data URI SVG — use unoptimized since it's inline
+        <Image
           src={getFallbackAvatar(fallback)}
           alt={alt}
+          width={px}
+          height={px}
           className="aspect-square h-full w-full"
+          unoptimized
         />
       ) : (
-        // eslint-disable-next-line @next/next/no-img-element
-        <img
+        <Image
           src={src}
           alt={alt}
+          width={px}
+          height={px}
           className="aspect-square h-full w-full object-cover"
           onError={() => setImgError(true)}
         />

--- a/apps/me/src/components/user-select.tsx
+++ b/apps/me/src/components/user-select.tsx
@@ -1,8 +1,10 @@
 "use client";
 
-import { useState, useMemo, useEffect, useCallback, useRef } from "react";
+import { useRef } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { useDropdownSelect } from "@/hooks/useDropdownSelect";
+import { useUserSearch, displayName } from "@/hooks/useUserSearch";
 import type { UserListItem } from "@/lib/types";
 
 interface UserSelectProps {
@@ -11,117 +13,18 @@ interface UserSelectProps {
   onChange: (userId: number | null) => void;
 }
 
-function displayName(u: UserListItem): string {
-  const parts: string[] = [];
-  if (u.f3Name) parts.push(u.f3Name);
-  const real = [u.firstName, u.lastName].filter(Boolean).join(" ");
-  if (real) parts.push(`(${real})`);
-  if (u.homeRegionName) parts.push(`— ${u.homeRegionName}`);
-  return parts.join(" ") || `User #${u.id}`;
-}
-
-function matchesSearch(u: UserListItem, term: string): boolean {
-  const lower = term.toLowerCase();
-  return (
-    (u.f3Name?.toLowerCase().includes(lower) ?? false) ||
-    (u.firstName?.toLowerCase().includes(lower) ?? false) ||
-    (u.lastName?.toLowerCase().includes(lower) ?? false) ||
-    (u.homeRegionName?.toLowerCase().includes(lower) ?? false)
-  );
-}
-
 export function UserSelect({ value, homeRegionId, onChange }: UserSelectProps) {
-  const [open, setOpen] = useState(false);
-  const [search, setSearch] = useState("");
-  const [users, setUsers] = useState<UserListItem[]>([]);
-  const [loading, setLoading] = useState(false);
-  const [showAllRegions, setShowAllRegions] = useState(false);
-  const [selectedUser, setSelectedUser] = useState<UserListItem | null>(null);
+  const { open, search, toggle, close, setSearch, selectAndClose } =
+    useDropdownSelect();
+  const {
+    filteredUsers,
+    loading,
+    selectedUser,
+    isRegionScoped,
+    setSelectedUser,
+    handleExpandAll,
+  } = useUserSearch({ value, homeRegionId, open, search });
   const dropdownRef = useRef<HTMLDivElement>(null);
-
-  // Close dropdown when clicking outside
-  useEffect(() => {
-    if (!open) return;
-    function handleClick(e: MouseEvent) {
-      if (
-        dropdownRef.current &&
-        !dropdownRef.current.contains(e.target as Node)
-      ) {
-        setOpen(false);
-        setSearch("");
-      }
-    }
-    document.addEventListener("mousedown", handleClick);
-    return () => document.removeEventListener("mousedown", handleClick);
-  }, [open]);
-
-  const fetchUsers = useCallback(
-    async (regionId?: number | null) => {
-      setLoading(true);
-      try {
-        const params = new URLSearchParams();
-        if (regionId) {
-          params.set("homeRegionId", String(regionId));
-        }
-        const qs = params.toString();
-        const res = await fetch(`/api/users${qs ? `?${qs}` : ""}`);
-        if (!res.ok) throw new Error("Failed to fetch users");
-        const data = (await res.json()) as { users: UserListItem[] };
-        setUsers(data.users);
-
-        // Resolve selected user display if we have a value
-        if (value && !selectedUser) {
-          const found = data.users.find((u) => u.id === value);
-          if (found) setSelectedUser(found);
-        }
-      } catch (err) {
-        console.error("Failed to load users:", err);
-      } finally {
-        setLoading(false);
-      }
-    },
-    [value, selectedUser],
-  );
-
-  // Load users when dropdown opens
-  useEffect(() => {
-    if (!open) return;
-    if (users.length > 0) return; // Already loaded
-    const regionIdToFetch =
-      showAllRegions || !homeRegionId ? undefined : homeRegionId;
-    void fetchUsers(regionIdToFetch);
-  }, [open, showAllRegions, homeRegionId, users.length, fetchUsers]);
-
-  // If we have a value but no selectedUser, try to resolve it
-  useEffect(() => {
-    if (value && !selectedUser) {
-      // We need to fetch to resolve the display name of the selected user
-      void (async () => {
-        try {
-          const res = await fetch("/api/users");
-          if (!res.ok) return;
-          const data = (await res.json()) as { users: UserListItem[] };
-          const found = data.users.find((u) => u.id === value);
-          if (found) setSelectedUser(found);
-        } catch {
-          // Silently fail — display will fallback
-        }
-      })();
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [value]);
-
-  const handleExpandAll = () => {
-    setShowAllRegions(true);
-    setUsers([]); // Clear so the load effect refetches
-  };
-
-  const filteredUsers = useMemo(() => {
-    if (!search) return users;
-    return users.filter((u) => matchesSearch(u, search));
-  }, [users, search]);
-
-  const isRegionScoped = !showAllRegions && !!homeRegionId;
 
   return (
     <div className="relative" ref={dropdownRef}>
@@ -129,7 +32,7 @@ export function UserSelect({ value, homeRegionId, onChange }: UserSelectProps) {
         variant="outline"
         type="button"
         className="w-full justify-between text-left font-normal"
-        onClick={() => setOpen(!open)}
+        onClick={toggle}
       >
         <span
           className={`truncate ${value && selectedUser ? "" : "text-muted-foreground"}`}
@@ -179,8 +82,7 @@ export function UserSelect({ value, homeRegionId, onChange }: UserSelectProps) {
                     onClick={() => {
                       onChange(null);
                       setSelectedUser(null);
-                      setOpen(false);
-                      setSearch("");
+                      selectAndClose();
                     }}
                   >
                     Clear selection
@@ -191,7 +93,7 @@ export function UserSelect({ value, homeRegionId, onChange }: UserSelectProps) {
                     No users found.
                   </p>
                 ) : (
-                  filteredUsers.map((user) => (
+                  filteredUsers.map((user: UserListItem) => (
                     <button
                       key={user.id}
                       type="button"
@@ -201,8 +103,7 @@ export function UserSelect({ value, homeRegionId, onChange }: UserSelectProps) {
                       onClick={() => {
                         onChange(user.id);
                         setSelectedUser(user);
-                        setOpen(false);
-                        setSearch("");
+                        selectAndClose();
                       }}
                     >
                       <span className="truncate">
@@ -229,6 +130,12 @@ export function UserSelect({ value, homeRegionId, onChange }: UserSelectProps) {
             )}
           </div>
         </div>
+      )}
+
+      {/* Click-away handler */}
+      {open && (
+        // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
+        <div className="fixed inset-0 z-40" onClick={close} />
       )}
     </div>
   );

--- a/apps/me/src/hooks/useAvatarUpload.test.ts
+++ b/apps/me/src/hooks/useAvatarUpload.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from "vitest";
+import {
+  validateAvatarFile,
+  MAX_FILE_SIZE,
+  ALLOWED_TYPES,
+} from "./useAvatarUpload";
+
+// ---------------------------------------------------------------------------
+// validateAvatarFile
+// ---------------------------------------------------------------------------
+
+function makeFile(size: number, type: string): File {
+  const buffer = new ArrayBuffer(size);
+  return new File([buffer], "test-file", { type });
+}
+
+describe("validateAvatarFile", () => {
+  it("returns null for a valid JPEG under 5MB", () => {
+    const file = makeFile(1024, "image/jpeg");
+    expect(validateAvatarFile(file)).toBeNull();
+  });
+
+  it("returns null for a valid PNG under 5MB", () => {
+    const file = makeFile(1024, "image/png");
+    expect(validateAvatarFile(file)).toBeNull();
+  });
+
+  it("returns null for a valid WebP under 5MB", () => {
+    const file = makeFile(1024, "image/webp");
+    expect(validateAvatarFile(file)).toBeNull();
+  });
+
+  it("returns error for file exceeding 5MB", () => {
+    const file = makeFile(MAX_FILE_SIZE + 1, "image/jpeg");
+    const error = validateAvatarFile(file);
+
+    expect(error).not.toBeNull();
+    expect(error?.title).toBe("File too large");
+    expect(error?.description).toContain("5MB");
+  });
+
+  it("returns error for file exactly at 5MB + 1 byte", () => {
+    const file = makeFile(MAX_FILE_SIZE + 1, "image/jpeg");
+    expect(validateAvatarFile(file)).not.toBeNull();
+  });
+
+  it("returns null for file exactly at 5MB", () => {
+    const file = makeFile(MAX_FILE_SIZE, "image/jpeg");
+    expect(validateAvatarFile(file)).toBeNull();
+  });
+
+  it("returns error for GIF files", () => {
+    const file = makeFile(1024, "image/gif");
+    const error = validateAvatarFile(file);
+
+    expect(error).not.toBeNull();
+    expect(error?.title).toBe("Invalid file type");
+  });
+
+  it("returns error for SVG files", () => {
+    const file = makeFile(1024, "image/svg+xml");
+    expect(validateAvatarFile(file)).not.toBeNull();
+  });
+
+  it("returns error for PDF files", () => {
+    const file = makeFile(1024, "application/pdf");
+    expect(validateAvatarFile(file)).not.toBeNull();
+  });
+
+  it("returns error for text files", () => {
+    const file = makeFile(100, "text/plain");
+    expect(validateAvatarFile(file)).not.toBeNull();
+  });
+
+  it("returns size error before type error when both fail", () => {
+    const file = makeFile(MAX_FILE_SIZE + 1, "image/gif");
+    const error = validateAvatarFile(file);
+    // Size check comes first in the function
+    expect(error?.title).toBe("File too large");
+  });
+
+  it("returns null for zero-byte valid type file", () => {
+    const file = makeFile(0, "image/jpeg");
+    expect(validateAvatarFile(file)).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+describe("constants", () => {
+  it("MAX_FILE_SIZE is 5MB", () => {
+    expect(MAX_FILE_SIZE).toBe(5 * 1024 * 1024);
+  });
+
+  it("ALLOWED_TYPES contains exactly jpeg, png, webp", () => {
+    expect(ALLOWED_TYPES.size).toBe(3);
+    expect(ALLOWED_TYPES.has("image/jpeg")).toBe(true);
+    expect(ALLOWED_TYPES.has("image/png")).toBe(true);
+    expect(ALLOWED_TYPES.has("image/webp")).toBe(true);
+    expect(ALLOWED_TYPES.has("image/gif")).toBe(false);
+  });
+});

--- a/apps/me/src/hooks/useAvatarUpload.ts
+++ b/apps/me/src/hooks/useAvatarUpload.ts
@@ -1,0 +1,146 @@
+import { useState, useCallback } from "react";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface AvatarUploadOptions {
+  currentUrl: string | null;
+  onUploaded: (url: string) => void;
+  toast: (opts: {
+    title: string;
+    description: string;
+    variant?: "destructive";
+  }) => void;
+}
+
+export interface UseAvatarUploadReturn {
+  uploading: boolean;
+  previewUrl: string | null;
+  dragOver: boolean;
+  handleUpload: (file: File) => Promise<void>;
+  setDragOver: (v: boolean) => void;
+  handleDrop: (e: React.DragEvent) => void;
+  handleFileChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+export const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5 MB
+export const ALLOWED_TYPES = new Set(["image/jpeg", "image/png", "image/webp"]);
+
+// ---------------------------------------------------------------------------
+// Pure helpers (exported for direct unit testing)
+// ---------------------------------------------------------------------------
+
+export interface FileValidationError {
+  title: string;
+  description: string;
+}
+
+/** Validate a file for avatar upload. Returns an error object or null. */
+export function validateAvatarFile(file: File): FileValidationError | null {
+  if (file.size > MAX_FILE_SIZE) {
+    return {
+      title: "File too large",
+      description: "Maximum file size is 5MB.",
+    };
+  }
+  if (!ALLOWED_TYPES.has(file.type)) {
+    return {
+      title: "Invalid file type",
+      description: "Please upload a JPEG, PNG, or WebP image.",
+    };
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export function useAvatarUpload({
+  currentUrl,
+  onUploaded,
+  toast,
+}: AvatarUploadOptions): UseAvatarUploadReturn {
+  const [uploading, setUploading] = useState(false);
+  const [previewUrl, setPreviewUrl] = useState<string | null>(currentUrl);
+  const [dragOver, setDragOver] = useState(false);
+
+  const handleUpload = useCallback(
+    async (file: File) => {
+      const validationError = validateAvatarFile(file);
+      if (validationError) {
+        toast({ ...validationError, variant: "destructive" });
+        return;
+      }
+
+      setUploading(true);
+
+      try {
+        const formData = new FormData();
+        formData.append("file", file);
+
+        const res = await fetch("/api/profile/avatar", {
+          method: "POST",
+          body: formData,
+        });
+
+        if (!res.ok) {
+          const err = (await res.json().catch(() => ({}))) as {
+            error?: string;
+          };
+          throw new Error(err.error ?? "Upload failed");
+        }
+
+        const data = (await res.json()) as { avatarUrl: string };
+        setPreviewUrl(data.avatarUrl);
+        onUploaded(data.avatarUrl);
+        toast({
+          title: "Avatar updated",
+          description: "Your avatar has been saved.",
+        });
+      } catch (err) {
+        toast({
+          title: "Upload failed",
+          description: err instanceof Error ? err.message : "Please try again.",
+          variant: "destructive",
+        });
+      } finally {
+        setUploading(false);
+      }
+    },
+    [onUploaded, toast],
+  );
+
+  const handleDrop = useCallback(
+    (e: React.DragEvent) => {
+      e.preventDefault();
+      setDragOver(false);
+      const file = e.dataTransfer.files[0];
+      if (file) void handleUpload(file);
+    },
+    [handleUpload],
+  );
+
+  const handleFileChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const file = e.target.files?.[0];
+      if (file) void handleUpload(file);
+    },
+    [handleUpload],
+  );
+
+  return {
+    uploading,
+    previewUrl,
+    dragOver,
+    handleUpload,
+    setDragOver,
+    handleDrop,
+    handleFileChange,
+  };
+}

--- a/apps/me/src/hooks/useDropdownSelect.ts
+++ b/apps/me/src/hooks/useDropdownSelect.ts
@@ -1,0 +1,41 @@
+import { useState, useCallback } from "react";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface UseDropdownSelectReturn {
+  open: boolean;
+  search: string;
+  toggle: () => void;
+  close: () => void;
+  setSearch: (value: string) => void;
+  /** Reset search and close the dropdown. */
+  selectAndClose: () => void;
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+/**
+ * Shared dropdown open/close + search state for select-style components.
+ * Keeps the RegionSelect and UserSelect DRY.
+ */
+export function useDropdownSelect(): UseDropdownSelectReturn {
+  const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState("");
+
+  const toggle = useCallback(() => setOpen((prev) => !prev), []);
+  const close = useCallback(() => {
+    setOpen(false);
+    setSearch("");
+  }, []);
+
+  const selectAndClose = useCallback(() => {
+    setOpen(false);
+    setSearch("");
+  }, []);
+
+  return { open, search, toggle, close, setSearch, selectAndClose };
+}

--- a/apps/me/src/hooks/useProfileForm.test.ts
+++ b/apps/me/src/hooks/useProfileForm.test.ts
@@ -1,0 +1,257 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseMeta,
+  buildInitialFormState,
+  buildDirtyPayload,
+  dirtyFieldClass,
+} from "./useProfileForm";
+import type { ProfileFormState } from "./useProfileForm";
+import type { UserProfile } from "@/lib/types";
+
+// ---------------------------------------------------------------------------
+// parseMeta
+// ---------------------------------------------------------------------------
+
+describe("parseMeta", () => {
+  it("returns empty object for null", () => {
+    expect(parseMeta(null)).toEqual({});
+  });
+
+  it("returns empty object for empty string", () => {
+    expect(parseMeta("")).toEqual({});
+  });
+
+  it("returns the object directly when meta is already an object", () => {
+    const meta = { f3_name_origin: "test", my_f3_why: "fitness" };
+    expect(parseMeta(meta)).toEqual(meta);
+  });
+
+  it("parses valid JSON string", () => {
+    const json = JSON.stringify({ f3_name_origin: "origin story" });
+    expect(parseMeta(json)).toEqual({ f3_name_origin: "origin story" });
+  });
+
+  it("returns empty object for invalid JSON string", () => {
+    expect(parseMeta("not valid json{")).toEqual({});
+  });
+
+  it("handles object with unknown extra keys", () => {
+    const meta = { f3_name_origin: "test", some_other_field: 42 };
+    const result = parseMeta(meta);
+    expect(result.f3_name_origin).toBe("test");
+    expect(result).toHaveProperty("some_other_field", 42);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildInitialFormState
+// ---------------------------------------------------------------------------
+
+function makeUser(overrides: Partial<UserProfile> = {}): UserProfile {
+  return {
+    id: 1,
+    f3Name: "Dredd",
+    firstName: "Patrick",
+    lastName: "Smith",
+    email: "dredd@f3nation.com",
+    emailVerified: true,
+    phone: "555-1234",
+    homeRegionId: 10,
+    avatarUrl: "https://example.com/avatar.jpg",
+    meta: null,
+    emergencyContact: "Jane",
+    emergencyPhone: "555-5678",
+    emergencyNotes: "No allergies",
+    status: "active",
+    roles: [],
+    positions: [],
+    created: "2024-01-01",
+    updated: "2024-06-01",
+    ...overrides,
+  };
+}
+
+describe("buildInitialFormState", () => {
+  it("maps all UserProfile fields to form state", () => {
+    const user = makeUser();
+    const state = buildInitialFormState(user);
+
+    expect(state.f3Name).toBe("Dredd");
+    expect(state.firstName).toBe("Patrick");
+    expect(state.lastName).toBe("Smith");
+    expect(state.phone).toBe("555-1234");
+    expect(state.homeRegionId).toBe(10);
+    expect(state.avatarUrl).toBe("https://example.com/avatar.jpg");
+    expect(state.emergencyContact).toBe("Jane");
+    expect(state.emergencyPhone).toBe("555-5678");
+    expect(state.emergencyNotes).toBe("No allergies");
+  });
+
+  it("defaults null string fields to empty string", () => {
+    const user = makeUser({
+      firstName: null,
+      phone: null,
+      emergencyContact: null,
+      emergencyPhone: null,
+      emergencyNotes: null,
+    });
+    const state = buildInitialFormState(user);
+
+    expect(state.firstName).toBe("");
+    expect(state.phone).toBe("");
+    expect(state.emergencyContact).toBe("");
+    expect(state.emergencyPhone).toBe("");
+    expect(state.emergencyNotes).toBe("");
+  });
+
+  it("extracts meta fields from object meta", () => {
+    const user = makeUser({
+      meta: {
+        f3_name_origin: "My story",
+        my_f3_why: "Fitness",
+        user_emergency_info_dr_sharing: true,
+        start_date_override: "2020-01-01",
+        brought_by: 42,
+      },
+    });
+    const state = buildInitialFormState(user);
+
+    expect(state.f3_name_origin).toBe("My story");
+    expect(state.my_f3_why).toBe("Fitness");
+    expect(state.user_emergency_info_dr_sharing).toBe(true);
+    expect(state.start_date_override).toBe("2020-01-01");
+    expect(state.brought_by).toBe(42);
+  });
+
+  it("extracts meta fields from JSON string meta", () => {
+    const user = makeUser({
+      meta: JSON.stringify({ f3_name_origin: "parsed" }),
+    });
+    const state = buildInitialFormState(user);
+    expect(state.f3_name_origin).toBe("parsed");
+  });
+
+  it("defaults meta fields when meta is null", () => {
+    const user = makeUser({ meta: null });
+    const state = buildInitialFormState(user);
+
+    expect(state.f3_name_origin).toBe("");
+    expect(state.my_f3_why).toBe("");
+    expect(state.user_emergency_info_dr_sharing).toBe(false);
+    expect(state.start_date_override).toBe("");
+    expect(state.brought_by).toBe(null);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildDirtyPayload
+// ---------------------------------------------------------------------------
+
+describe("buildDirtyPayload", () => {
+  const initial: ProfileFormState = {
+    f3Name: "Dredd",
+    firstName: "Patrick",
+    lastName: "Smith",
+    phone: "555-1234",
+    homeRegionId: 10,
+    avatarUrl: "https://example.com/avatar.jpg",
+    emergencyContact: "Jane",
+    emergencyPhone: "555-5678",
+    emergencyNotes: "No allergies",
+    f3_name_origin: "",
+    my_f3_why: "",
+    user_emergency_info_dr_sharing: false,
+    start_date_override: "",
+    brought_by: null,
+  };
+
+  it("returns empty object when nothing changed", () => {
+    expect(buildDirtyPayload({ ...initial }, initial)).toEqual({});
+  });
+
+  it("includes only changed fields", () => {
+    const form = { ...initial, f3Name: "New Name", phone: "999-0000" };
+    const payload = buildDirtyPayload(form, initial);
+
+    expect(payload).toEqual({ f3Name: "New Name", phone: "999-0000" });
+  });
+
+  it("excludes avatarUrl even when changed", () => {
+    const form = { ...initial, avatarUrl: "https://new.com/img.jpg" };
+    const payload = buildDirtyPayload(form, initial);
+
+    expect(payload).toEqual({});
+  });
+
+  it("coerces empty nullable text fields to null", () => {
+    const form = { ...initial, firstName: "", phone: "" };
+    const payload = buildDirtyPayload(form, initial);
+
+    expect(payload.firstName).toBeNull();
+    expect(payload.phone).toBeNull();
+  });
+
+  it("coerces empty non-nullable text fields to empty string", () => {
+    const form = { ...initial, f3Name: "" };
+    const payload = buildDirtyPayload(form, initial);
+
+    expect(payload.f3Name).toBe("");
+  });
+
+  it("includes boolean field changes", () => {
+    const form = { ...initial, user_emergency_info_dr_sharing: true };
+    const payload = buildDirtyPayload(form, initial);
+
+    expect(payload.user_emergency_info_dr_sharing).toBe(true);
+  });
+
+  it("includes numeric field changes", () => {
+    const form = { ...initial, homeRegionId: 20 };
+    const payload = buildDirtyPayload(form, initial);
+
+    expect(payload.homeRegionId).toBe(20);
+  });
+
+  it("includes null-to-value changes for brought_by", () => {
+    const form = { ...initial, brought_by: 5 };
+    const payload = buildDirtyPayload(form, initial);
+
+    expect(payload.brought_by).toBe(5);
+  });
+
+  it("includes all changed fields simultaneously", () => {
+    const form: ProfileFormState = {
+      ...initial,
+      f3Name: "Updated",
+      emergencyContact: "",
+      user_emergency_info_dr_sharing: true,
+      brought_by: 99,
+    };
+    const payload = buildDirtyPayload(form, initial);
+
+    expect(Object.keys(payload)).toHaveLength(4);
+    expect(payload.f3Name).toBe("Updated");
+    expect(payload.emergencyContact).toBeNull();
+    expect(payload.user_emergency_info_dr_sharing).toBe(true);
+    expect(payload.brought_by).toBe(99);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// dirtyFieldClass
+// ---------------------------------------------------------------------------
+
+describe("dirtyFieldClass", () => {
+  it("returns amber border class when dirty", () => {
+    expect(dirtyFieldClass(true)).toContain("border-l-amber-500");
+  });
+
+  it("returns transparent border class when clean", () => {
+    expect(dirtyFieldClass(false)).toContain("border-l-transparent");
+  });
+
+  it("always includes pl-2 for consistent spacing", () => {
+    expect(dirtyFieldClass(true)).toContain("pl-2");
+    expect(dirtyFieldClass(false)).toContain("pl-2");
+  });
+});

--- a/apps/me/src/hooks/useProfileForm.ts
+++ b/apps/me/src/hooks/useProfileForm.ts
@@ -1,0 +1,225 @@
+import { useState, useCallback, useMemo, useEffect, useRef } from "react";
+import { useSaveRegister } from "@/lib/save-context";
+import type { UserProfile, UserMeta } from "@/lib/types";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface ProfileFormState {
+  f3Name: string;
+  firstName: string;
+  lastName: string;
+  phone: string;
+  homeRegionId: number | null;
+  avatarUrl: string | null;
+  emergencyContact: string;
+  emergencyPhone: string;
+  emergencyNotes: string;
+  f3_name_origin: string;
+  my_f3_why: string;
+  user_emergency_info_dr_sharing: boolean;
+  start_date_override: string;
+  brought_by: number | null;
+}
+
+export interface UseProfileFormReturn {
+  form: ProfileFormState;
+  saving: boolean;
+  isDirty: boolean;
+  isFieldDirty: (key: keyof ProfileFormState) => boolean;
+  /** CSS class helper that adds a left-border indicator on dirty fields. */
+  dirtyClass: (key: keyof ProfileFormState) => string;
+  updateField: <K extends keyof ProfileFormState>(
+    key: K,
+    value: ProfileFormState[K],
+  ) => void;
+  handleSave: () => Promise<void>;
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers (exported for direct unit testing)
+// ---------------------------------------------------------------------------
+
+/** Parse the polymorphic `meta` field into a typed object. */
+export function parseMeta(
+  meta: string | Record<string, unknown> | null,
+): UserMeta {
+  if (!meta) return {};
+  if (typeof meta === "object") return meta as UserMeta;
+  try {
+    return JSON.parse(meta) as UserMeta;
+  } catch {
+    return {};
+  }
+}
+
+/** Derive initial form state from a UserProfile. */
+export function buildInitialFormState(user: UserProfile): ProfileFormState {
+  const meta = parseMeta(user.meta);
+  return {
+    f3Name: user.f3Name ?? "",
+    firstName: user.firstName ?? "",
+    lastName: user.lastName ?? "",
+    phone: user.phone ?? "",
+    homeRegionId: user.homeRegionId,
+    avatarUrl: user.avatarUrl,
+    emergencyContact: user.emergencyContact ?? "",
+    emergencyPhone: user.emergencyPhone ?? "",
+    emergencyNotes: user.emergencyNotes ?? "",
+    f3_name_origin: meta.f3_name_origin ?? "",
+    my_f3_why: meta.my_f3_why ?? "",
+    user_emergency_info_dr_sharing:
+      meta.user_emergency_info_dr_sharing ?? false,
+    start_date_override: meta.start_date_override ?? "",
+    brought_by: (meta.brought_by as number | null) ?? null,
+  };
+}
+
+/**
+ * Build the PATCH payload containing only dirty fields.
+ * Coerces empty strings to `null` for nullable database columns.
+ */
+export function buildDirtyPayload(
+  form: ProfileFormState,
+  initial: ProfileFormState,
+): Record<string, unknown> {
+  const payload: Record<string, unknown> = {};
+  const keys = Object.keys(form) as (keyof ProfileFormState)[];
+
+  for (const key of keys) {
+    if (form[key] === initial[key]) continue;
+    // Skip avatarUrl — uploaded separately
+    if (key === "avatarUrl") continue;
+
+    const value = form[key];
+    // Coerce empty strings to null for nullable text fields
+    if (typeof value === "string" && value === "") {
+      const nullableFields = new Set([
+        "firstName",
+        "phone",
+        "emergencyContact",
+        "emergencyPhone",
+        "emergencyNotes",
+      ]);
+      payload[key] = nullableFields.has(key) ? null : "";
+    } else {
+      payload[key] = value;
+    }
+  }
+
+  return payload;
+}
+
+/** Returns a CSS class string for the dirty-field left-border indicator. */
+export function dirtyFieldClass(isDirty: boolean): string {
+  return isDirty
+    ? " pl-2 border-l-[3px] border-l-amber-500"
+    : " pl-2 border-l-[3px] border-l-transparent";
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+interface UseProfileFormOptions {
+  user: UserProfile;
+  toast: (opts: {
+    title: string;
+    description: string;
+    variant?: "destructive";
+  }) => void;
+}
+
+export function useProfileForm({
+  user,
+  toast,
+}: UseProfileFormOptions): UseProfileFormReturn {
+  const [saving, setSaving] = useState(false);
+  const [form, setForm] = useState<ProfileFormState>(() =>
+    buildInitialFormState(user),
+  );
+  const [initialForm, setInitialForm] = useState<ProfileFormState>(() =>
+    buildInitialFormState(user),
+  );
+
+  const isFieldDirty = useCallback(
+    (key: keyof ProfileFormState) => form[key] !== initialForm[key],
+    [form, initialForm],
+  );
+
+  const isDirty = useMemo(
+    () =>
+      (Object.keys(form) as (keyof ProfileFormState)[]).some(
+        (key) => key !== "avatarUrl" && form[key] !== initialForm[key],
+      ),
+    [form, initialForm],
+  );
+
+  const dirtyClass = useCallback(
+    (key: keyof ProfileFormState) => dirtyFieldClass(isFieldDirty(key)),
+    [isFieldDirty],
+  );
+
+  const updateField = useCallback(
+    <K extends keyof ProfileFormState>(key: K, value: ProfileFormState[K]) => {
+      setForm((prev) => ({ ...prev, [key]: value }));
+    },
+    [],
+  );
+
+  const handleSave = useCallback(async () => {
+    setSaving(true);
+    try {
+      const payload = buildDirtyPayload(form, initialForm);
+
+      const res = await fetch("/api/profile", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+
+      if (!res.ok) {
+        const err = (await res.json().catch(() => ({}))) as {
+          error?: string;
+        };
+        throw new Error(err.error ?? "Failed to save profile");
+      }
+
+      setInitialForm({ ...form });
+
+      toast({
+        title: "Profile saved",
+        description: "Your changes have been saved successfully.",
+      });
+    } catch (err) {
+      toast({
+        title: "Save failed",
+        description: err instanceof Error ? err.message : "Please try again.",
+        variant: "destructive",
+      });
+    } finally {
+      setSaving(false);
+    }
+  }, [form, initialForm, toast]);
+
+  // Keep a stable ref to handleSave for the context registration
+  const saveRef = useRef(handleSave);
+  saveRef.current = handleSave;
+
+  // Register save state with the navbar
+  const { register } = useSaveRegister();
+  useEffect(() => {
+    register({ isDirty, saving, onSave: () => void saveRef.current() });
+  }, [isDirty, saving, register]);
+
+  return {
+    form,
+    saving,
+    isDirty,
+    isFieldDirty,
+    dirtyClass,
+    updateField,
+    handleSave,
+  };
+}

--- a/apps/me/src/hooks/useRegionFilter.ts
+++ b/apps/me/src/hooks/useRegionFilter.ts
@@ -1,0 +1,63 @@
+import { useMemo } from "react";
+import type { Region } from "@/lib/types";
+
+// ---------------------------------------------------------------------------
+// Pure helpers (exported for direct unit testing)
+// ---------------------------------------------------------------------------
+
+/**
+ * Filter regions: include active regions plus the currently-selected region
+ * (even if inactive), then apply an optional search term.
+ */
+export function filterRegions(
+  regions: Region[],
+  selectedId: number | null,
+  search: string,
+): Region[] {
+  const base = regions.filter((r) => r.isActive || r.id === selectedId);
+  if (!search) return base;
+  const lower = search.toLowerCase();
+  return base.filter((r) => r.name.toLowerCase().includes(lower));
+}
+
+/** Find a region by id. */
+export function findRegionById(
+  regions: Region[],
+  id: number | null,
+): Region | undefined {
+  if (id === null) return undefined;
+  return regions.find((r) => r.id === id);
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export interface UseRegionFilterOptions {
+  regions: Region[];
+  selectedId: number | null;
+  search: string;
+}
+
+export interface UseRegionFilterReturn {
+  selectedRegion: Region | undefined;
+  filteredRegions: Region[];
+}
+
+export function useRegionFilter({
+  regions,
+  selectedId,
+  search,
+}: UseRegionFilterOptions): UseRegionFilterReturn {
+  const selectedRegion = useMemo(
+    () => findRegionById(regions, selectedId),
+    [regions, selectedId],
+  );
+
+  const filteredRegions = useMemo(
+    () => filterRegions(regions, selectedId, search),
+    [regions, selectedId, search],
+  );
+
+  return { selectedRegion, filteredRegions };
+}

--- a/apps/me/src/hooks/useRemovableList.test.ts
+++ b/apps/me/src/hooks/useRemovableList.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { compositeKey } from "./useRemovableList";
+
+// ---------------------------------------------------------------------------
+// compositeKey
+// ---------------------------------------------------------------------------
+
+describe("compositeKey", () => {
+  it("joins org and entity id with a dash", () => {
+    expect(compositeKey(1, 2)).toBe("1-2");
+  });
+
+  it("handles zero values", () => {
+    expect(compositeKey(0, 0)).toBe("0-0");
+  });
+
+  it("handles large ids", () => {
+    expect(compositeKey(999999, 888888)).toBe("999999-888888");
+  });
+
+  it("produces unique keys for different pairs", () => {
+    expect(compositeKey(1, 2)).not.toBe(compositeKey(2, 1));
+  });
+
+  it("produces the same key for the same pair", () => {
+    expect(compositeKey(5, 10)).toBe(compositeKey(5, 10));
+  });
+});

--- a/apps/me/src/hooks/useRemovableList.ts
+++ b/apps/me/src/hooks/useRemovableList.ts
@@ -1,0 +1,102 @@
+import { useState, useCallback } from "react";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface RemovableListOptions<T> {
+  initialItems: T[];
+  /** Build the unique key used for tracking the "removing" spinner state. */
+  getKey: (item: T) => string;
+  /** API endpoint to DELETE from. */
+  endpoint: string;
+  /** Build the JSON body for the DELETE request. */
+  buildDeleteBody: (item: T) => Record<string, unknown>;
+  /** Filter predicate: return false for the item being removed. */
+  shouldKeep: (item: T, removedItem: T) => boolean;
+  toast: (opts: {
+    title: string;
+    description: string;
+    variant?: "destructive";
+  }) => void;
+  /** Toast messages for success / failure. */
+  successMessage: (item: T) => { title: string; description: string };
+  failureTitle: string;
+}
+
+export interface UseRemovableListReturn<T> {
+  items: T[];
+  removing: string | null;
+  handleRemove: (item: T) => Promise<void>;
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers (exported for direct unit testing)
+// ---------------------------------------------------------------------------
+
+/** Build a composite key from org + entity id. */
+export function compositeKey(orgId: number, entityId: number): string {
+  return `${orgId}-${entityId}`;
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export function useRemovableList<T>({
+  initialItems,
+  getKey,
+  endpoint,
+  buildDeleteBody,
+  shouldKeep,
+  toast,
+  successMessage,
+  failureTitle,
+}: RemovableListOptions<T>): UseRemovableListReturn<T> {
+  const [items, setItems] = useState<T[]>(initialItems);
+  const [removing, setRemoving] = useState<string | null>(null);
+
+  const handleRemove = useCallback(
+    async (item: T) => {
+      const key = getKey(item);
+      setRemoving(key);
+
+      try {
+        const res = await fetch(endpoint, {
+          method: "DELETE",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(buildDeleteBody(item)),
+        });
+
+        if (!res.ok) {
+          const err = (await res.json().catch(() => ({}))) as {
+            error?: string;
+          };
+          throw new Error(err.error ?? `Failed to remove item`);
+        }
+
+        setItems((prev) => prev.filter((p) => shouldKeep(p, item)));
+        toast(successMessage(item));
+      } catch (err) {
+        toast({
+          title: failureTitle,
+          description: err instanceof Error ? err.message : "Please try again.",
+          variant: "destructive",
+        });
+      } finally {
+        setRemoving(null);
+      }
+    },
+    [
+      getKey,
+      endpoint,
+      buildDeleteBody,
+      shouldKeep,
+      toast,
+      successMessage,
+      failureTitle,
+    ],
+  );
+
+  return { items, removing, handleRemove };
+}

--- a/apps/me/src/hooks/useUserSearch.test.ts
+++ b/apps/me/src/hooks/useUserSearch.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect } from "vitest";
+import { displayName, matchesSearch } from "./useUserSearch";
+import type { UserListItem } from "@/lib/types";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeUser(overrides: Partial<UserListItem> = {}): UserListItem {
+  return {
+    id: 1,
+    f3Name: "Dredd",
+    firstName: "Patrick",
+    lastName: "Smith",
+    homeRegionId: 10,
+    homeRegionName: "Muletown",
+    status: "active",
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// displayName
+// ---------------------------------------------------------------------------
+
+describe("displayName", () => {
+  it("shows f3Name, real name, and region", () => {
+    const user = makeUser();
+    expect(displayName(user)).toBe("Dredd (Patrick Smith) \u2014 Muletown");
+  });
+
+  it("shows only f3Name when no real name or region", () => {
+    const user = makeUser({
+      firstName: null,
+      lastName: null,
+      homeRegionName: null,
+    });
+    expect(displayName(user)).toBe("Dredd");
+  });
+
+  it("shows only real name when no f3Name", () => {
+    const user = makeUser({
+      f3Name: null,
+      homeRegionName: null,
+    });
+    expect(displayName(user)).toBe("(Patrick Smith)");
+  });
+
+  it("shows only region when no names", () => {
+    const user = makeUser({
+      f3Name: null,
+      firstName: null,
+      lastName: null,
+    });
+    expect(displayName(user)).toBe("\u2014 Muletown");
+  });
+
+  it("falls back to User #id when everything is null", () => {
+    const user = makeUser({
+      id: 42,
+      f3Name: null,
+      firstName: null,
+      lastName: null,
+      homeRegionName: null,
+    });
+    expect(displayName(user)).toBe("User #42");
+  });
+
+  it("handles first name only (no last name)", () => {
+    const user = makeUser({
+      lastName: null,
+      homeRegionName: null,
+    });
+    expect(displayName(user)).toBe("Dredd (Patrick)");
+  });
+
+  it("handles last name only (no first name)", () => {
+    const user = makeUser({
+      firstName: null,
+      homeRegionName: null,
+    });
+    expect(displayName(user)).toBe("Dredd (Smith)");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// matchesSearch
+// ---------------------------------------------------------------------------
+
+describe("matchesSearch", () => {
+  it("matches by f3Name (case-insensitive)", () => {
+    const user = makeUser();
+    expect(matchesSearch(user, "dredd")).toBe(true);
+    expect(matchesSearch(user, "DREDD")).toBe(true);
+  });
+
+  it("matches by firstName", () => {
+    expect(matchesSearch(makeUser(), "pat")).toBe(true);
+  });
+
+  it("matches by lastName", () => {
+    expect(matchesSearch(makeUser(), "smith")).toBe(true);
+  });
+
+  it("matches by region name", () => {
+    expect(matchesSearch(makeUser(), "mule")).toBe(true);
+  });
+
+  it("returns false for non-matching term", () => {
+    expect(matchesSearch(makeUser(), "zzz")).toBe(false);
+  });
+
+  it("returns false when all name fields are null", () => {
+    const user = makeUser({
+      f3Name: null,
+      firstName: null,
+      lastName: null,
+      homeRegionName: null,
+    });
+    expect(matchesSearch(user, "anything")).toBe(false);
+  });
+
+  it("matches partial strings", () => {
+    expect(matchesSearch(makeUser(), "re")).toBe(true); // "Dredd"
+  });
+
+  it("handles empty search term", () => {
+    // Empty string is a substring of everything
+    expect(matchesSearch(makeUser(), "")).toBe(true);
+  });
+});

--- a/apps/me/src/hooks/useUserSearch.ts
+++ b/apps/me/src/hooks/useUserSearch.ts
@@ -1,0 +1,142 @@
+import { useState, useMemo, useEffect, useCallback, useRef } from "react";
+import type { UserListItem } from "@/lib/types";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface UseUserSearchOptions {
+  value: number | null;
+  homeRegionId: number | null;
+  open: boolean;
+  search: string;
+}
+
+export interface UseUserSearchReturn {
+  users: UserListItem[];
+  filteredUsers: UserListItem[];
+  loading: boolean;
+  selectedUser: UserListItem | null;
+  isRegionScoped: boolean;
+  setSelectedUser: (user: UserListItem | null) => void;
+  handleExpandAll: () => void;
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers (exported for direct unit testing)
+// ---------------------------------------------------------------------------
+
+/** Build a display string for a user in the dropdown. */
+export function displayName(u: UserListItem): string {
+  const parts: string[] = [];
+  if (u.f3Name) parts.push(u.f3Name);
+  const real = [u.firstName, u.lastName].filter(Boolean).join(" ");
+  if (real) parts.push(`(${real})`);
+  if (u.homeRegionName) parts.push(`\u2014 ${u.homeRegionName}`);
+  return parts.join(" ") || `User #${u.id}`;
+}
+
+/** Check whether a user matches a search term (case-insensitive). */
+export function matchesSearch(u: UserListItem, term: string): boolean {
+  const lower = term.toLowerCase();
+  return (
+    (u.f3Name?.toLowerCase().includes(lower) ?? false) ||
+    (u.firstName?.toLowerCase().includes(lower) ?? false) ||
+    (u.lastName?.toLowerCase().includes(lower) ?? false) ||
+    (u.homeRegionName?.toLowerCase().includes(lower) ?? false)
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export function useUserSearch({
+  value,
+  homeRegionId,
+  open,
+  search,
+}: UseUserSearchOptions): UseUserSearchReturn {
+  const [users, setUsers] = useState<UserListItem[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [showAllRegions, setShowAllRegions] = useState(false);
+  const [selectedUser, setSelectedUser] = useState<UserListItem | null>(null);
+
+  const fetchUsers = useCallback(
+    async (regionId?: number | null) => {
+      setLoading(true);
+      try {
+        const params = new URLSearchParams();
+        if (regionId) {
+          params.set("homeRegionId", String(regionId));
+        }
+        const qs = params.toString();
+        const res = await fetch(`/api/users${qs ? `?${qs}` : ""}`);
+        if (!res.ok) throw new Error("Failed to fetch users");
+        const data = (await res.json()) as { users: UserListItem[] };
+        setUsers(data.users);
+
+        // Resolve selected user display if we have a value
+        if (value && !selectedUser) {
+          const found = data.users.find((u) => u.id === value);
+          if (found) setSelectedUser(found);
+        }
+      } catch (err) {
+        console.error("Failed to load users:", err);
+      } finally {
+        setLoading(false);
+      }
+    },
+    [value, selectedUser],
+  );
+
+  // Load users when dropdown opens
+  useEffect(() => {
+    if (!open) return;
+    if (users.length > 0) return;
+    const regionIdToFetch =
+      showAllRegions || !homeRegionId ? undefined : homeRegionId;
+    void fetchUsers(regionIdToFetch);
+  }, [open, showAllRegions, homeRegionId, users.length, fetchUsers]);
+
+  // If we have a value but no selectedUser, try to resolve it
+  const resolvedRef = useRef(false);
+  useEffect(() => {
+    if (!value || selectedUser !== null || resolvedRef.current) return;
+    resolvedRef.current = true;
+
+    void (async () => {
+      try {
+        const res = await fetch("/api/users");
+        if (!res.ok) return;
+        const data = (await res.json()) as { users: UserListItem[] };
+        const found = data.users.find((u) => u.id === value);
+        if (found) setSelectedUser(found);
+      } catch {
+        // Silently fail — display will fallback
+      }
+    })();
+  }, [value, selectedUser]);
+
+  const handleExpandAll = useCallback(() => {
+    setShowAllRegions(true);
+    setUsers([]); // Clear so the load effect refetches
+  }, []);
+
+  const filteredUsers = useMemo(() => {
+    if (!search) return users;
+    return users.filter((u) => matchesSearch(u, search));
+  }, [users, search]);
+
+  const isRegionScoped = !showAllRegions && !!homeRegionId;
+
+  return {
+    users,
+    filteredUsers,
+    loading,
+    selectedUser,
+    isRegionScoped,
+    setSelectedUser,
+    handleExpandAll,
+  };
+}

--- a/apps/me/src/lib/api/client.ts
+++ b/apps/me/src/lib/api/client.ts
@@ -34,18 +34,6 @@ async function getHeaders(): Promise<HeadersInit> {
   return headers;
 }
 
-/**
- * Build headers for the email lookup call during OAuth callback.
- * Does NOT include X-User-Id since we don't have it yet.
- */
-function getBaseHeaders(): HeadersInit {
-  return {
-    Authorization: `Bearer ${requireEnv("F3_API_KEY")}`,
-    Client: "f3-me",
-    "Content-Type": "application/json",
-  };
-}
-
 function apiUrl(path: string): string {
   return `${requireEnv("F3_API_BASE_URL")}${path}`;
 }
@@ -166,23 +154,4 @@ export async function getUsers(
   }
   const data = (await res.json()) as { users: UserListItem[] };
   return data.users;
-}
-
-/**
- * Look up a user's numeric ID by email address.
- * Used during OAuth callback before the session cookie exists.
- * Uses getBaseHeaders() (no X-User-Id needed).
- */
-export async function lookupUserByEmail(email: string): Promise<number> {
-  const params = new URLSearchParams({ email });
-  const res = await fetch(apiUrl(`/me/lookup-by-email?${params.toString()}`), {
-    headers: getBaseHeaders(),
-    cache: "no-store",
-  });
-  if (!res.ok) {
-    const text = await res.text().catch(() => "");
-    throw new Error(`API error ${res.status}: ${text}`);
-  }
-  const data = (await res.json()) as { userId: number };
-  return data.userId;
 }

--- a/apps/me/src/lib/auth/session.ts
+++ b/apps/me/src/lib/auth/session.ts
@@ -47,9 +47,23 @@ export function verifySessionValue(cookie: string): SessionPayload | null {
   }
 
   try {
-    const payload = JSON.parse(
+    const raw: unknown = JSON.parse(
       Buffer.from(json, "base64url").toString("utf-8"),
-    ) as SessionPayload;
+    );
+
+    // Runtime shape validation (defense-in-depth for security-critical code)
+    if (
+      typeof raw !== "object" ||
+      raw === null ||
+      typeof (raw as Record<string, unknown>).sub !== "string" ||
+      typeof (raw as Record<string, unknown>).email !== "string" ||
+      typeof (raw as Record<string, unknown>).userId !== "number" ||
+      typeof (raw as Record<string, unknown>).iat !== "number"
+    ) {
+      return null;
+    }
+
+    const payload = raw as SessionPayload;
 
     const age = Math.floor(Date.now() / 1000) - payload.iat;
     if (age > SESSION_COOKIE_MAX_AGE) return null;

--- a/apps/me/src/lib/auth/validation.ts
+++ b/apps/me/src/lib/auth/validation.ts
@@ -1,0 +1,13 @@
+/**
+ * Validate that a return-to path is safe (relative, no open-redirect).
+ * Rejects absolute URLs, protocol-relative URLs, and non-path values.
+ */
+export function isValidReturnTo(path: string): boolean {
+  return path.startsWith("/") && !path.startsWith("//");
+}
+
+/** Sanitize a return-to value, falling back to /profile if invalid. */
+export function safeReturnTo(path: string | null | undefined): string {
+  if (!path) return "/profile";
+  return isValidReturnTo(path) ? path : "/profile";
+}

--- a/apps/me/src/lib/save-context.tsx
+++ b/apps/me/src/lib/save-context.tsx
@@ -8,11 +8,14 @@ interface SaveState {
   save: () => void;
 }
 
+const noop = () => {
+  /* intentional no-op: default context value before registration */
+};
+
 const SaveContext = createContext<SaveState>({
   isDirty: false,
   saving: false,
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
-  save: () => {},
+  save: noop,
 });
 
 interface RegisterFn {
@@ -23,15 +26,13 @@ interface RegisterFn {
   }) => void;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-empty-function
-const RegisterContext = createContext<RegisterFn>({ register: () => {} });
+const RegisterContext = createContext<RegisterFn>({ register: noop });
 
 export function SaveProvider({ children }: { children: React.ReactNode }) {
   const [state, setState] = useState<SaveState>({
     isDirty: false,
     saving: false,
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
-    save: () => {},
+    save: noop,
   });
 
   const register = useCallback(


### PR DESCRIPTION
## Context

Stacked on top of #163 (`feat/me`) — split out so improvements can be reviewed and tested independently without affecting Tackle's ongoing work on the me app.

## Summary

- **Security fixes (P1, P2, P9):** Close open redirect via unvalidated `redirect` query param, verify session HMAC signature in middleware (not just cookie existence), re-validate `returnTo` in OAuth callback
- **Hook extraction (P4):** Extract business logic from 6 components into custom hooks with 57 vitest tests — `useProfileForm`, `useAvatarUpload`, `useRemovableList`, `useUserSearch`, `useDropdownSelect`, `useRegionFilter`
- **Input validation (P5):** Replace unsafe `as` casts with Zod schemas in positions/roles DELETE routes
- **Dead code removal (P3):** Remove unused `lookupUserByEmail` and `getBaseHeaders`
- **next/image compliance (P6):** Replace `<img>` with `next/image` in Avatar component
- **Session hardening (P7):** Add runtime shape validation to session payload parsing
- **Scale guard (P8):** Cap users endpoint response to 500 results
- **Code quality:** Remove 3 `eslint-disable` comments from save-context.tsx, net -333 lines from components

## Findings addressed

All findings from [code review](https://github.com/F3-Nation/f3-nation/pull/163#pullrequestreview-4084897388) on PR #163.

## Test plan

- [x] `pnpm --filter ./apps/me run typecheck` passes
- [x] `pnpm --filter ./apps/me run lint` passes (zero warnings)
- [x] `pnpm --filter ./apps/me run test` — 57 new tests, 160/163 passing (3 pre-existing failures in auth-logout)
- [x] `pnpm --filter ./apps/me run build` passes
- [ ] Manual: verify profile form loads and saves correctly
- [ ] Manual: verify avatar upload still works
- [ ] Manual: verify role/position removal works
- [ ] Manual: verify redirect after login goes to /profile (not arbitrary URL)

🤖 Generated with [Claude Code](https://claude.com/claude-code)