### PR TITLE
R5 Phase 1: internal region-binding validator endpoint

### DIFF
--- a/apps/api/src/app/api/internal/region-binding/validate/route.test.ts
+++ b/apps/api/src/app/api/internal/region-binding/validate/route.test.ts
@@ -1,0 +1,212 @@
+/**
+ * Route-handler tests for the internal region-binding validator.
+ *
+ * We mock `@acme/db/client` (to avoid booting a real connection pool), the
+ * validator service (to avoid needing a database at all), the rate limiter
+ * (to exercise 429 paths deterministically), and the s2s auth shim.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const SECRET = "test-s2s-secret";
+
+// --- Module mocks must be hoisted so they apply to `route.ts`'s imports. ---
+
+vi.mock("@acme/db/client", () => ({
+  db: {} as unknown,
+}));
+
+const mockRunValidator = vi.hoisted(() => vi.fn());
+vi.mock("../../../../../lib/region-binding-validator-service", () => ({
+  runRegionBindingValidator: mockRunValidator,
+}));
+
+const mockRateLimiterCheck = vi.hoisted(() => vi.fn());
+vi.mock("../../../../../lib/region-binding-rate-limiter", () => ({
+  regionBindingRateLimiter: { check: mockRateLimiterCheck },
+  createRegionBindingRateLimiter: vi.fn(),
+}));
+
+// Import AFTER mocks have been registered.
+import { GET } from "./route";
+
+const authHeader = (token: string = SECRET) => `Bearer ${token}`;
+
+const fullUrl =
+  "http://localhost/api/internal/region-binding/validate" +
+  "?org_id=123&pax_vault_region_id=35838&region_slug=muletown&calling_user_id=7";
+
+const makeRequest = (
+  url: string = fullUrl,
+  headers: Record<string, string> = {},
+): Request =>
+  new Request(url, { headers: { authorization: authHeader(), ...headers } });
+
+const okBody = () => ({
+  org: {
+    id: 123,
+    name: "F3 Muletown",
+    last_modified: "2025-12-01T00:00:00.000Z",
+    admin_count: 4,
+    caller_roles: ["admin"],
+  },
+  pax_vault: {
+    region_id: "35838",
+    region_name: "F3 Muletown",
+    pax_count: 142,
+    most_recent_beatdown: "2026-04-13",
+    thumbnail_url:
+      "https://pax-vault.f3nation.com/api/regions/35838/thumbnail.png",
+  },
+  f3_region_pages: {
+    slug: "muletown",
+    point_of_contact: "Slider",
+    page_url: "https://regions.f3nation.com/muletown",
+  },
+  cross_check: { triple_matches: true, match_strategy: "exact" as const },
+  validated_at: "2026-04-14T18:23:00.000Z",
+});
+
+describe("GET /api/internal/region-binding/validate", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.REGION_BINDING_VALIDATOR_S2S_SECRET = SECRET;
+    mockRateLimiterCheck.mockReturnValue({
+      allowed: true,
+      retryAfterSeconds: 0,
+    });
+  });
+
+  it("returns 200 with the validator body on the happy path", async () => {
+    mockRunValidator.mockResolvedValue({ kind: "ok", body: okBody() });
+
+    const response = await GET(makeRequest());
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as ReturnType<typeof okBody>;
+    expect(body.cross_check.triple_matches).toBe(true);
+    expect(body.org.name).toBe("F3 Muletown");
+  });
+
+  it("returns 401 invalid_s2s_token when the Authorization header is missing", async () => {
+    const response = await GET(new Request(fullUrl));
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({ error: "invalid_s2s_token" });
+    expect(mockRunValidator).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 invalid_s2s_token when the token is wrong", async () => {
+    const response = await GET(
+      new Request(fullUrl, {
+        headers: { authorization: "Bearer wrong-token" },
+      }),
+    );
+    expect(response.status).toBe(401);
+    expect(mockRunValidator).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when query params are missing", async () => {
+    const response = await GET(
+      new Request(
+        "http://localhost/api/internal/region-binding/validate?org_id=1",
+        { headers: { authorization: authHeader() } },
+      ),
+    );
+    expect(response.status).toBe(400);
+    const body = (await response.json()) as { error: string };
+    expect(body.error).toBe("invalid_query");
+  });
+
+  it("returns 400 when org_id is not a positive integer", async () => {
+    const response = await GET(
+      new Request(
+        "http://localhost/api/internal/region-binding/validate" +
+          "?org_id=abc&pax_vault_region_id=35838&region_slug=muletown&calling_user_id=7",
+        { headers: { authorization: authHeader() } },
+      ),
+    );
+    expect(response.status).toBe(400);
+  });
+
+  it("returns 429 with Retry-After when the rate limiter denies", async () => {
+    mockRateLimiterCheck.mockReturnValue({
+      allowed: false,
+      retryAfterSeconds: 42,
+    });
+
+    const response = await GET(makeRequest());
+    expect(response.status).toBe(429);
+    expect(response.headers.get("retry-after")).toBe("42");
+    expect(mockRunValidator).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 when the validator reports forbidden", async () => {
+    mockRunValidator.mockResolvedValue({
+      kind: "forbidden",
+      reason: "caller_not_authorized_on_org",
+    });
+
+    const response = await GET(makeRequest());
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({
+      error: "caller_not_authorized_on_org",
+    });
+  });
+
+  it("returns 422 with detail when the validator reports mismatch", async () => {
+    mockRunValidator.mockResolvedValue({
+      kind: "mismatch",
+      detail: {
+        mismatches: [
+          {
+            field: "region_slug",
+            sources: { query_param: "a", f3_region_pages_response: "b" },
+            reason: "no",
+          },
+        ],
+      },
+    });
+
+    const response = await GET(makeRequest());
+    expect(response.status).toBe(422);
+    const body = (await response.json()) as { error: string; detail: unknown };
+    expect(body.error).toBe("triple_mismatch");
+    expect(body.detail).toBeDefined();
+  });
+
+  it("returns 503 with source when pax_vault is unavailable", async () => {
+    mockRunValidator.mockResolvedValue({
+      kind: "source_unavailable",
+      source: "pax_vault",
+      message: "down",
+    });
+
+    const response = await GET(makeRequest());
+    expect(response.status).toBe(503);
+    expect(await response.json()).toEqual({
+      error: "source_unavailable",
+      source: "pax_vault",
+    });
+  });
+
+  it("returns 503 with source when f3_region_pages is unavailable", async () => {
+    mockRunValidator.mockResolvedValue({
+      kind: "source_unavailable",
+      source: "f3_region_pages",
+      message: "down",
+    });
+
+    const response = await GET(makeRequest());
+    expect(response.status).toBe(503);
+    expect((await response.json()) as { source: string }).toEqual({
+      error: "source_unavailable",
+      source: "f3_region_pages",
+    });
+  });
+
+  it("returns 404 when the org does not exist", async () => {
+    mockRunValidator.mockResolvedValue({ kind: "org_not_found" });
+
+    const response = await GET(makeRequest());
+    expect(response.status).toBe(404);
+  });
+});

--- a/apps/api/src/app/api/internal/region-binding/validate/route.ts
+++ b/apps/api/src/app/api/internal/region-binding/validate/route.ts
@@ -1,0 +1,165 @@
+/**
+ * Internal region-binding validator endpoint (R5 Decision 11).
+ *
+ * GET /api/internal/region-binding/validate
+ *   ?org_id=<int>&pax_vault_region_id=<string>&region_slug=<string>&calling_user_id=<int>
+ *
+ * Triangulates three sources (Supabase orgs/users via @acme/db, pax-vault
+ * internal API, f3-region-pages) and returns a snapshot-ready validator
+ * response. Called by apps/redirect-admin when creating or re-verifying a
+ * row in `org_region_bindings` on Neon.
+ *
+ * This route sits ALONGSIDE the oRPC catch-all at `app/[[...rest]]/route.ts`.
+ * Next.js App Router resolves static segments before catch-all segments, so
+ * this file handles the path without touching the oRPC router.
+ */
+
+import { db } from "@acme/db/client";
+
+import { regionBindingRateLimiter } from "../../../../../lib/region-binding-rate-limiter";
+import { verifyRegionBindingS2sToken } from "../../../../../lib/region-binding-s2s-auth";
+import { runRegionBindingValidator } from "../../../../../lib/region-binding-validator-service";
+
+// Route is dynamic — it reads query params per request.
+export const dynamic = "force-dynamic";
+
+interface ParsedQuery {
+  orgId: number;
+  paxVaultRegionId: string;
+  regionSlug: string;
+  callingUserId: number;
+}
+
+interface ParseError {
+  error: "invalid_query";
+  detail: string;
+}
+
+const parseQuery = (
+  url: URL,
+): { ok: true; value: ParsedQuery } | { ok: false; error: ParseError } => {
+  const orgIdRaw = url.searchParams.get("org_id");
+  const paxVaultRegionId = url.searchParams.get("pax_vault_region_id");
+  const regionSlug = url.searchParams.get("region_slug");
+  const callingUserIdRaw = url.searchParams.get("calling_user_id");
+
+  if (!orgIdRaw) {
+    return {
+      ok: false,
+      error: { error: "invalid_query", detail: "org_id is required" },
+    };
+  }
+  if (!paxVaultRegionId) {
+    return {
+      ok: false,
+      error: {
+        error: "invalid_query",
+        detail: "pax_vault_region_id is required",
+      },
+    };
+  }
+  if (!regionSlug) {
+    return {
+      ok: false,
+      error: { error: "invalid_query", detail: "region_slug is required" },
+    };
+  }
+  if (!callingUserIdRaw) {
+    return {
+      ok: false,
+      error: {
+        error: "invalid_query",
+        detail: "calling_user_id is required",
+      },
+    };
+  }
+
+  const orgId = Number(orgIdRaw);
+  if (!Number.isInteger(orgId) || orgId <= 0) {
+    return {
+      ok: false,
+      error: {
+        error: "invalid_query",
+        detail: "org_id must be a positive integer",
+      },
+    };
+  }
+
+  const callingUserId = Number(callingUserIdRaw);
+  if (!Number.isInteger(callingUserId) || callingUserId <= 0) {
+    return {
+      ok: false,
+      error: {
+        error: "invalid_query",
+        detail: "calling_user_id must be a positive integer",
+      },
+    };
+  }
+
+  return {
+    ok: true,
+    value: { orgId, paxVaultRegionId, regionSlug, callingUserId },
+  };
+};
+
+const jsonResponse = (
+  status: number,
+  body: unknown,
+  extraHeaders?: Record<string, string>,
+): Response =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      "content-type": "application/json",
+      ...extraHeaders,
+    },
+  });
+
+export const GET = async (request: Request): Promise<Response> => {
+  // --- 1. s2s token ---
+  const authResult = verifyRegionBindingS2sToken({
+    authorizationHeader: request.headers.get("authorization"),
+  });
+  if (!authResult.ok) {
+    return jsonResponse(401, { error: "invalid_s2s_token" });
+  }
+
+  // --- 2. parse and validate query ---
+  const url = new URL(request.url);
+  const parsed = parseQuery(url);
+  if (!parsed.ok) {
+    return jsonResponse(400, parsed.error);
+  }
+
+  // --- 3. per-caller rate limit (60 rpm) ---
+  const rl = regionBindingRateLimiter.check(parsed.value.callingUserId);
+  if (!rl.allowed) {
+    return jsonResponse(
+      429,
+      { error: "rate_limited" },
+      { "retry-after": String(rl.retryAfterSeconds) },
+    );
+  }
+
+  // --- 4. run the validator ---
+  const outcome = await runRegionBindingValidator(parsed.value, { db });
+
+  switch (outcome.kind) {
+    case "ok":
+      return jsonResponse(200, outcome.body);
+    case "org_not_found":
+      return jsonResponse(404, { error: "org_not_found" });
+    case "forbidden":
+      return jsonResponse(403, { error: outcome.reason });
+    case "mismatch":
+      return jsonResponse(422, {
+        error: "triple_mismatch",
+        detail: outcome.detail,
+      });
+    case "source_unavailable":
+      return jsonResponse(503, {
+        error: "source_unavailable",
+        source: outcome.source,
+      });
+  }
+};

--- a/apps/api/src/lib/f3-region-pages-client.ts
+++ b/apps/api/src/lib/f3-region-pages-client.ts
@@ -1,0 +1,102 @@
+/**
+ * f3-region-pages client stub.
+ *
+ * TODO(F3R5_014-followup): Replace this stub with a real read against the
+ * f3-region-pages Postgres database. The real implementation should:
+ *   1. Read `F3_REGION_PAGES_DATABASE_URL` from env
+ *   2. Use a connection pool (same shape as `apps/me` uses for its direct
+ *      f3-region-pages reads — confirm pattern before wiring)
+ *   3. Query `SELECT slug, point_of_contact, page_url FROM regions WHERE slug = $1`
+ *   4. Throw `F3RegionPagesUnavailableError` on connection failure or timeout
+ *
+ * Until then, this stub returns failure whenever the env var is unset so the
+ * validator route returns 503. When the env var IS set it attempts an HTTP
+ * fallback to an internal JSON endpoint — allowing integration tests to
+ * mock-serve the response without wiring a real Postgres pool.
+ */
+
+export interface F3RegionPage {
+  slug: string;
+  point_of_contact: string;
+  page_url: string;
+}
+
+export class F3RegionPagesUnavailableError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "F3RegionPagesUnavailableError";
+  }
+}
+
+export interface FetchF3RegionPageOptions {
+  slug: string;
+  signal?: AbortSignal;
+}
+
+const F3_REGION_PAGES_TIMEOUT_MS = 3_000;
+
+export const fetchF3RegionPage = async ({
+  slug,
+  signal,
+}: FetchF3RegionPageOptions): Promise<F3RegionPage> => {
+  const baseUrl = process.env.F3_REGION_PAGES_DATABASE_URL;
+  if (!baseUrl) {
+    throw new F3RegionPagesUnavailableError(
+      "F3_REGION_PAGES_DATABASE_URL is not configured",
+    );
+  }
+
+  // TODO(F3R5_014-followup): swap this HTTP fallback for a real Postgres read.
+  const controller = new AbortController();
+  const timeout = setTimeout(
+    () => controller.abort(),
+    F3_REGION_PAGES_TIMEOUT_MS,
+  );
+
+  if (signal) {
+    if (signal.aborted) {
+      controller.abort();
+    } else {
+      signal.addEventListener("abort", () => controller.abort(), {
+        once: true,
+      });
+    }
+  }
+
+  try {
+    const response = await fetch(
+      `${baseUrl.replace(/\/$/, "")}/internal/regions/${encodeURIComponent(slug)}`,
+      { signal: controller.signal, headers: { accept: "application/json" } },
+    );
+
+    if (!response.ok) {
+      throw new F3RegionPagesUnavailableError(
+        `f3-region-pages returned HTTP ${response.status}`,
+      );
+    }
+
+    const raw = (await response.json()) as Partial<F3RegionPage>;
+    if (
+      typeof raw.slug !== "string" ||
+      typeof raw.point_of_contact !== "string" ||
+      typeof raw.page_url !== "string"
+    ) {
+      throw new F3RegionPagesUnavailableError(
+        "f3-region-pages response missing required fields",
+      );
+    }
+
+    return {
+      slug: raw.slug,
+      point_of_contact: raw.point_of_contact,
+      page_url: raw.page_url,
+    };
+  } catch (error) {
+    if (error instanceof F3RegionPagesUnavailableError) throw error;
+    throw new F3RegionPagesUnavailableError(
+      error instanceof Error ? error.message : "f3-region-pages fetch failed",
+    );
+  } finally {
+    clearTimeout(timeout);
+  }
+};

--- a/apps/api/src/lib/pax-vault-client.ts
+++ b/apps/api/src/lib/pax-vault-client.ts
@@ -1,0 +1,107 @@
+/**
+ * Pax-Vault internal API client stub.
+ *
+ * TODO(F3R5_014-followup): Replace this stub with a real call to pax-vault's
+ * internal region lookup endpoint. The real call should:
+ *   1. Read `PAX_VAULT_INTERNAL_URL` from env
+ *   2. Authenticate with an s2s token minted by `@acme/sso` (once s2s support
+ *      lands in the SSO package — see the matching TODO in s2s-auth.ts)
+ *   3. GET `${PAX_VAULT_INTERNAL_URL}/internal/regions/:region_id`
+ *   4. Return `{ region_id, region_name, pax_count, most_recent_beatdown,
+ *      thumbnail_url }`
+ *   5. Throw `PaxVaultUnavailableError` on any network/5xx/timeout
+ *
+ * Until then, this stub attempts a best-effort fetch when the env var is set
+ * and throws `PaxVaultUnavailableError` in every other case so the validator
+ * route returns 503.
+ */
+
+export interface PaxVaultRegion {
+  region_id: string;
+  region_name: string;
+  pax_count: number;
+  most_recent_beatdown: string;
+  thumbnail_url: string;
+}
+
+export class PaxVaultUnavailableError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "PaxVaultUnavailableError";
+  }
+}
+
+export interface FetchPaxVaultRegionOptions {
+  regionId: string;
+  signal?: AbortSignal;
+}
+
+const PAX_VAULT_TIMEOUT_MS = 3_000;
+
+export const fetchPaxVaultRegion = async ({
+  regionId,
+  signal,
+}: FetchPaxVaultRegionOptions): Promise<PaxVaultRegion> => {
+  const baseUrl = process.env.PAX_VAULT_INTERNAL_URL;
+  if (!baseUrl) {
+    throw new PaxVaultUnavailableError(
+      "PAX_VAULT_INTERNAL_URL is not configured",
+    );
+  }
+
+  // TODO(F3R5_014-followup): attach an s2s bearer token once @acme/sso exposes one.
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), PAX_VAULT_TIMEOUT_MS);
+
+  // Link the upstream signal to our timeout controller so cancellations propagate.
+  if (signal) {
+    if (signal.aborted) {
+      controller.abort();
+    } else {
+      signal.addEventListener("abort", () => controller.abort(), {
+        once: true,
+      });
+    }
+  }
+
+  try {
+    const response = await fetch(
+      `${baseUrl.replace(/\/$/, "")}/internal/regions/${encodeURIComponent(regionId)}`,
+      { signal: controller.signal, headers: { accept: "application/json" } },
+    );
+
+    if (!response.ok) {
+      throw new PaxVaultUnavailableError(
+        `pax-vault returned HTTP ${response.status}`,
+      );
+    }
+
+    const raw = (await response.json()) as Partial<PaxVaultRegion>;
+    if (
+      typeof raw.region_id !== "string" ||
+      typeof raw.region_name !== "string" ||
+      typeof raw.pax_count !== "number" ||
+      typeof raw.most_recent_beatdown !== "string" ||
+      typeof raw.thumbnail_url !== "string"
+    ) {
+      throw new PaxVaultUnavailableError(
+        "pax-vault response missing required fields",
+      );
+    }
+
+    return {
+      region_id: raw.region_id,
+      region_name: raw.region_name,
+      pax_count: raw.pax_count,
+      most_recent_beatdown: raw.most_recent_beatdown,
+      thumbnail_url: raw.thumbnail_url,
+    };
+  } catch (error) {
+    if (error instanceof PaxVaultUnavailableError) throw error;
+    throw new PaxVaultUnavailableError(
+      error instanceof Error ? error.message : "pax-vault fetch failed",
+    );
+  } finally {
+    clearTimeout(timeout);
+  }
+};

--- a/apps/api/src/lib/region-binding-rate-limiter.test.ts
+++ b/apps/api/src/lib/region-binding-rate-limiter.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+import { createRegionBindingRateLimiter } from "./region-binding-rate-limiter";
+
+describe("createRegionBindingRateLimiter", () => {
+  it("allows up to maxRequests per window for a single caller", () => {
+    const limiter = createRegionBindingRateLimiter({
+      maxRequests: 3,
+      windowMs: 10_000,
+      now: () => 1_000,
+    });
+    expect(limiter.check(42).allowed).toBe(true);
+    expect(limiter.check(42).allowed).toBe(true);
+    expect(limiter.check(42).allowed).toBe(true);
+    const denied = limiter.check(42);
+    expect(denied.allowed).toBe(false);
+    expect(denied.retryAfterSeconds).toBeGreaterThan(0);
+  });
+
+  it("isolates callers from each other", () => {
+    const limiter = createRegionBindingRateLimiter({
+      maxRequests: 1,
+      windowMs: 10_000,
+      now: () => 1_000,
+    });
+    expect(limiter.check(1).allowed).toBe(true);
+    expect(limiter.check(2).allowed).toBe(true);
+    expect(limiter.check(1).allowed).toBe(false);
+    expect(limiter.check(2).allowed).toBe(false);
+  });
+
+  it("resets the bucket after the window elapses", () => {
+    let currentMs = 0;
+    const limiter = createRegionBindingRateLimiter({
+      maxRequests: 1,
+      windowMs: 10_000,
+      now: () => currentMs,
+    });
+    expect(limiter.check("user").allowed).toBe(true);
+    expect(limiter.check("user").allowed).toBe(false);
+    currentMs = 10_001;
+    expect(limiter.check("user").allowed).toBe(true);
+  });
+
+  it("defaults to 60 rpm when no options are supplied", () => {
+    const limiter = createRegionBindingRateLimiter({ now: () => 0 });
+    for (let i = 0; i < 60; i += 1) {
+      expect(limiter.check(1).allowed).toBe(true);
+    }
+    expect(limiter.check(1).allowed).toBe(false);
+  });
+});

--- a/apps/api/src/lib/region-binding-rate-limiter.ts
+++ b/apps/api/src/lib/region-binding-rate-limiter.ts
@@ -1,0 +1,79 @@
+/**
+ * In-memory token-bucket rate limiter for the internal region-binding
+ * validator endpoint (R5 Decision 11: 60 rpm per caller).
+ *
+ * Keyed by caller user id (the endpoint's `calling_user_id` query param).
+ * Acceptable for an internal service-to-service route where the caller
+ * count is small and rate-limit precision across pods is not critical.
+ *
+ * TODO(F3R5_014-followup): if apps/api goes multi-pod for this endpoint,
+ * swap this for a Redis-backed limiter (Upstash or the existing
+ * @orpc/experimental-ratelimit/memory adapter wired to Redis).
+ */
+
+export interface RateLimitResult {
+  allowed: boolean;
+  retryAfterSeconds: number;
+}
+
+interface BucketState {
+  count: number;
+  /** Epoch ms when the current window ends. */
+  windowEndMs: number;
+}
+
+export interface RegionBindingRateLimiterOptions {
+  /** Max requests allowed per window. Default: 60. */
+  maxRequests?: number;
+  /** Window length in milliseconds. Default: 60_000 (1 minute). */
+  windowMs?: number;
+  /** Clock override — used by tests. */
+  now?: () => number;
+}
+
+export interface RegionBindingRateLimiter {
+  check: (callerId: number | string) => RateLimitResult;
+}
+
+export const createRegionBindingRateLimiter = (
+  options: RegionBindingRateLimiterOptions = {},
+): RegionBindingRateLimiter => {
+  const maxRequests = options.maxRequests ?? 60;
+  const windowMs = options.windowMs ?? 60_000;
+  const now = options.now ?? (() => Date.now());
+  const buckets = new Map<string, BucketState>();
+
+  return {
+    check: (callerId) => {
+      const key = String(callerId);
+      const currentMs = now();
+      const existing = buckets.get(key);
+
+      if (!existing || currentMs >= existing.windowEndMs) {
+        buckets.set(key, {
+          count: 1,
+          windowEndMs: currentMs + windowMs,
+        });
+        return { allowed: true, retryAfterSeconds: 0 };
+      }
+
+      if (existing.count < maxRequests) {
+        existing.count += 1;
+        return { allowed: true, retryAfterSeconds: 0 };
+      }
+
+      const retryAfterSeconds = Math.max(
+        1,
+        Math.ceil((existing.windowEndMs - currentMs) / 1000),
+      );
+      return { allowed: false, retryAfterSeconds };
+    },
+  };
+};
+
+/**
+ * Default singleton limiter used by the route handler. Exported so that
+ * tests can import and reset it. For unit tests that mock the service, this
+ * is not used.
+ */
+export const regionBindingRateLimiter = createRegionBindingRateLimiter();

--- a/apps/api/src/lib/region-binding-s2s-auth.test.ts
+++ b/apps/api/src/lib/region-binding-s2s-auth.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+
+import { verifyRegionBindingS2sToken } from "./region-binding-s2s-auth";
+
+const SECRET = "sssh-this-is-only-a-test-secret";
+
+describe("verifyRegionBindingS2sToken", () => {
+  it("accepts a correctly formatted bearer token matching the expected secret", () => {
+    const result = verifyRegionBindingS2sToken({
+      authorizationHeader: `Bearer ${SECRET}`,
+      expectedSecret: SECRET,
+    });
+    expect(result).toEqual({ ok: true });
+  });
+
+  it("rejects a missing Authorization header", () => {
+    const result = verifyRegionBindingS2sToken({
+      authorizationHeader: null,
+      expectedSecret: SECRET,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("missing_header");
+  });
+
+  it("rejects a non-bearer header", () => {
+    const result = verifyRegionBindingS2sToken({
+      authorizationHeader: `Basic ${SECRET}`,
+      expectedSecret: SECRET,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("malformed_header");
+  });
+
+  it("rejects a bearer header with an empty token", () => {
+    const result = verifyRegionBindingS2sToken({
+      authorizationHeader: "Bearer  ",
+      expectedSecret: SECRET,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("malformed_header");
+  });
+
+  it("rejects a bearer token that does not match the expected secret", () => {
+    const result = verifyRegionBindingS2sToken({
+      authorizationHeader: "Bearer definitely-not-the-secret",
+      expectedSecret: SECRET,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("wrong_token");
+  });
+
+  it("returns server_misconfigured when the expected secret is empty", () => {
+    const result = verifyRegionBindingS2sToken({
+      authorizationHeader: `Bearer ${SECRET}`,
+      expectedSecret: "",
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("server_misconfigured");
+  });
+});

--- a/apps/api/src/lib/region-binding-s2s-auth.ts
+++ b/apps/api/src/lib/region-binding-s2s-auth.ts
@@ -1,0 +1,73 @@
+/**
+ * Service-to-service auth for the internal region-binding validator
+ * (R5 Decision 11).
+ *
+ * TODO(F3R5_014-followup): replace the shared-secret bearer check below
+ * with a real `@acme/sso` service-token verification. The SSO package does
+ * not yet expose an s2s primitive (see packages/sso/src/index.ts — only
+ * user-facing OAuth flows). Once it does, the validator should:
+ *   1. Extract the bearer token from the Authorization header
+ *   2. Call `authClient.verifyServiceToken(token)` with the expected
+ *      audience (`f3-nation-api`) and scope (`region-binding:validate`)
+ *   3. Reject on invalid signature, wrong audience, missing scope, or
+ *      expired token
+ *
+ * Until that lands, we accept a shared secret configured via the
+ * `REGION_BINDING_VALIDATOR_S2S_SECRET` env var. In development mode the
+ * check is still enforced unless the env var is explicitly set to an empty
+ * string, which is documented but not recommended.
+ */
+
+export interface VerifyS2sTokenInput {
+  authorizationHeader: string | null;
+  /** Inject the secret for tests; defaults to env. */
+  expectedSecret?: string;
+}
+
+export type VerifyS2sTokenResult =
+  | { ok: true }
+  | {
+      ok: false;
+      reason:
+        | "missing_header"
+        | "malformed_header"
+        | "wrong_token"
+        | "server_misconfigured";
+    };
+
+export const verifyRegionBindingS2sToken = (
+  input: VerifyS2sTokenInput,
+): VerifyS2sTokenResult => {
+  const expectedSecret =
+    input.expectedSecret ?? process.env.REGION_BINDING_VALIDATOR_S2S_SECRET;
+  if (!expectedSecret) {
+    return { ok: false, reason: "server_misconfigured" };
+  }
+
+  const header = input.authorizationHeader;
+  if (!header) return { ok: false, reason: "missing_header" };
+
+  const lowered = header.toLowerCase();
+  if (!lowered.startsWith("bearer ")) {
+    return { ok: false, reason: "malformed_header" };
+  }
+
+  const token = header.slice(7).trim();
+  if (!token) return { ok: false, reason: "malformed_header" };
+
+  // Constant-time compare to avoid timing oracle on a small secret.
+  if (!constantTimeEqual(token, expectedSecret)) {
+    return { ok: false, reason: "wrong_token" };
+  }
+
+  return { ok: true };
+};
+
+const constantTimeEqual = (a: string, b: string): boolean => {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i += 1) {
+    diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  return diff === 0;
+};

--- a/apps/api/src/lib/region-binding-triangulator.test.ts
+++ b/apps/api/src/lib/region-binding-triangulator.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  normalizeAggressive,
+  normalizeLoose,
+  triangulate,
+} from "./region-binding-triangulator";
+import type { TriangulationInput } from "./region-binding-triangulator";
+
+const baseInput = (): TriangulationInput => ({
+  org: { id: 123, name: "F3 Muletown" },
+  paxVault: { region_id: "35838", region_name: "F3 Muletown" },
+  f3RegionPages: { slug: "muletown" },
+  requestedRegionSlug: "muletown",
+  requestedPaxVaultRegionId: "35838",
+});
+
+describe("normalizeLoose", () => {
+  it("trims and lowercases", () => {
+    expect(normalizeLoose("  F3 Muletown  ")).toBe("f3 muletown");
+  });
+});
+
+describe("normalizeAggressive", () => {
+  it("collapses interior whitespace", () => {
+    expect(normalizeAggressive("  F3   Muletown\tRegion ")).toBe(
+      "f3 muletown region",
+    );
+  });
+});
+
+describe("triangulate", () => {
+  it("returns exact match when all three sources agree exactly", () => {
+    const result = triangulate(baseInput());
+    expect(result.triple_matches).toBe(true);
+    expect(result.match_strategy).toBe("exact");
+    expect(result.mismatches).toEqual([]);
+  });
+
+  it("returns fuzzy match when org name differs only in case/whitespace", () => {
+    const input = baseInput();
+    input.org.name = "  f3  muletown ";
+    const result = triangulate(input);
+    expect(result.triple_matches).toBe(true);
+    expect(result.match_strategy).toBe("fuzzy");
+    expect(result.mismatches).toEqual([]);
+  });
+
+  it("fails when pax_vault_region_id disagrees with query param", () => {
+    const input = baseInput();
+    input.paxVault.region_id = "99999";
+    const result = triangulate(input);
+    expect(result.triple_matches).toBe(false);
+    expect(result.match_strategy).toBe("failed");
+    expect(result.mismatches).toHaveLength(1);
+    expect(result.mismatches[0]?.field).toBe("pax_vault_region_id");
+  });
+
+  it("fails when region_slug from f3-region-pages disagrees with query param", () => {
+    const input = baseInput();
+    input.f3RegionPages.slug = "someother";
+    const result = triangulate(input);
+    expect(result.triple_matches).toBe(false);
+    expect(result.match_strategy).toBe("failed");
+    expect(result.mismatches[0]?.field).toBe("region_slug");
+  });
+
+  it("fails when org.name and pax_vault.region_name cannot be reconciled even fuzzily", () => {
+    const input = baseInput();
+    input.paxVault.region_name = "F3 SomewhereElse";
+    const result = triangulate(input);
+    expect(result.triple_matches).toBe(false);
+    expect(result.match_strategy).toBe("failed");
+    expect(result.mismatches).toHaveLength(1);
+    expect(result.mismatches[0]?.field).toBe(
+      "org_name_vs_pax_vault_region_name",
+    );
+  });
+
+  it("returns all mismatches when multiple sources disagree", () => {
+    const input = baseInput();
+    input.paxVault.region_id = "11111";
+    input.f3RegionPages.slug = "nope";
+    input.paxVault.region_name = "Nope";
+    const result = triangulate(input);
+    expect(result.triple_matches).toBe(false);
+    expect(result.match_strategy).toBe("failed");
+    // Three mismatches: pax_vault_region_id, region_slug, org_name_vs_pax_vault_region_name.
+    expect(result.mismatches).toHaveLength(3);
+    const fields = result.mismatches.map((m) => m.field).sort();
+    expect(fields).toEqual(
+      [
+        "org_name_vs_pax_vault_region_name",
+        "pax_vault_region_id",
+        "region_slug",
+      ].sort(),
+    );
+  });
+
+  it("includes the raw source values in the mismatch detail for debugging", () => {
+    const input = baseInput();
+    input.paxVault.region_name = "Totally Different";
+    const result = triangulate(input);
+    expect(result.mismatches[0]?.sources).toEqual({
+      org_name: "F3 Muletown",
+      pax_vault_region_name: "Totally Different",
+    });
+  });
+});

--- a/apps/api/src/lib/region-binding-triangulator.ts
+++ b/apps/api/src/lib/region-binding-triangulator.ts
@@ -1,0 +1,129 @@
+/**
+ * Pure triangulation logic for the internal region-binding validator
+ * (R5 Decision 11). Has no I/O — takes three normalized data points and
+ * returns a match verdict plus (on failure) a structured detail object.
+ *
+ * Keep this file dependency-free so unit tests can exercise every branch
+ * without mocking databases or network clients.
+ */
+
+export interface OrgFacts {
+  id: number;
+  name: string;
+}
+
+export interface PaxVaultFacts {
+  region_id: string;
+  region_name: string;
+}
+
+export interface F3RegionPagesFacts {
+  slug: string;
+}
+
+export interface TriangulationInput {
+  org: OrgFacts;
+  paxVault: PaxVaultFacts;
+  f3RegionPages: F3RegionPagesFacts;
+  /** The caller-provided region slug — the exact ground truth we compare against. */
+  requestedRegionSlug: string;
+  /** The caller-provided pax-vault region id claim — must match the response. */
+  requestedPaxVaultRegionId: string;
+}
+
+export type MatchStrategy = "exact" | "fuzzy" | "failed";
+
+export interface TriangulationMismatchDetail {
+  /** Which logical comparison failed. */
+  field:
+    | "org_name_vs_pax_vault_region_name"
+    | "region_slug"
+    | "pax_vault_region_id";
+  /** Which source held which value. */
+  sources: Record<string, string>;
+  reason: string;
+}
+
+export interface TriangulationResult {
+  triple_matches: boolean;
+  match_strategy: MatchStrategy;
+  mismatches: TriangulationMismatchDetail[];
+}
+
+/** Lowercase + trim. Used for fuzzy comparisons. */
+export const normalizeLoose = (value: string): string =>
+  value.trim().toLowerCase();
+
+/** Collapse all interior whitespace to a single space after trim+lowercase. */
+export const normalizeAggressive = (value: string): string =>
+  normalizeLoose(value).replace(/\s+/g, " ");
+
+export const triangulate = (input: TriangulationInput): TriangulationResult => {
+  const mismatches: TriangulationMismatchDetail[] = [];
+
+  // 1. pax-vault region id must equal the caller's claim exactly (it's an
+  //    opaque identifier, not a display string — no fuzzy match allowed).
+  if (input.paxVault.region_id !== input.requestedPaxVaultRegionId) {
+    mismatches.push({
+      field: "pax_vault_region_id",
+      sources: {
+        query_param: input.requestedPaxVaultRegionId,
+        pax_vault_response: input.paxVault.region_id,
+      },
+      reason: "pax-vault returned a different region id than requested",
+    });
+  }
+
+  // 2. f3-region-pages slug must equal the caller's claim exactly.
+  //    Slugs are canonical, case-sensitive identifiers.
+  if (input.f3RegionPages.slug !== input.requestedRegionSlug) {
+    mismatches.push({
+      field: "region_slug",
+      sources: {
+        query_param: input.requestedRegionSlug,
+        f3_region_pages_response: input.f3RegionPages.slug,
+      },
+      reason: "f3-region-pages returned a different slug than requested",
+    });
+  }
+
+  // 3. org.name vs pax_vault.region_name — display strings. We allow
+  //    exact match first, then fall back to a normalized (case-insensitive,
+  //    whitespace-collapsed) comparison, which bumps match_strategy to "fuzzy".
+  const nameExact = input.org.name === input.paxVault.region_name;
+  const nameFuzzy =
+    normalizeAggressive(input.org.name) ===
+    normalizeAggressive(input.paxVault.region_name);
+
+  let nameStrategy: MatchStrategy = "exact";
+  if (!nameExact) {
+    if (nameFuzzy) {
+      nameStrategy = "fuzzy";
+    } else {
+      nameStrategy = "failed";
+      mismatches.push({
+        field: "org_name_vs_pax_vault_region_name",
+        sources: {
+          org_name: input.org.name,
+          pax_vault_region_name: input.paxVault.region_name,
+        },
+        reason:
+          "org.name and pax_vault.region_name disagree even after case-insensitive, whitespace-normalized comparison",
+      });
+    }
+  }
+
+  if (mismatches.length > 0) {
+    return {
+      triple_matches: false,
+      match_strategy: "failed",
+      mismatches,
+    };
+  }
+
+  return {
+    triple_matches: true,
+    match_strategy: nameStrategy === "fuzzy" ? "fuzzy" : "exact",
+    mismatches: [],
+  };
+};

--- a/apps/api/src/lib/region-binding-validator-service.test.ts
+++ b/apps/api/src/lib/region-binding-validator-service.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { F3RegionPage } from "./f3-region-pages-client";
+import { F3RegionPagesUnavailableError } from "./f3-region-pages-client";
+import type { PaxVaultRegion } from "./pax-vault-client";
+import { PaxVaultUnavailableError } from "./pax-vault-client";
+import type {
+  LoadOrgFactsResult,
+  ValidatorQuery,
+} from "./region-binding-validator-service";
+import { runRegionBindingValidator } from "./region-binding-validator-service";
+
+// We don't need a real AppDb — the stubbed loadOrgFacts never touches it.
+const stubDb = {} as unknown as Parameters<
+  typeof runRegionBindingValidator
+>[1]["db"];
+
+const goodQuery = (): ValidatorQuery => ({
+  orgId: 123,
+  paxVaultRegionId: "35838",
+  regionSlug: "muletown",
+  callingUserId: 7,
+});
+
+const goodOrgFacts = (): LoadOrgFactsResult => ({
+  org: {
+    id: 123,
+    name: "F3 Muletown",
+    last_modified: "2025-12-01T00:00:00.000Z",
+  },
+  admin_count: 4,
+  caller_roles: ["admin"],
+});
+
+const goodPaxVault = (): PaxVaultRegion => ({
+  region_id: "35838",
+  region_name: "F3 Muletown",
+  pax_count: 142,
+  most_recent_beatdown: "2026-04-13",
+  thumbnail_url:
+    "https://pax-vault.f3nation.com/api/regions/35838/thumbnail.png",
+});
+
+const goodF3RegionPage = (): F3RegionPage => ({
+  slug: "muletown",
+  point_of_contact: "Slider",
+  page_url: "https://regions.f3nation.com/muletown",
+});
+
+describe("runRegionBindingValidator", () => {
+  it("returns ok with the full response body when all three sources agree", async () => {
+    const fixedNow = new Date("2026-04-14T18:23:00.000Z");
+    const outcome = await runRegionBindingValidator(goodQuery(), {
+      db: stubDb,
+      loadOrgFacts: vi.fn().mockResolvedValue(goodOrgFacts()),
+      fetchPaxVault: vi.fn().mockResolvedValue(goodPaxVault()),
+      fetchF3RegionPage: vi.fn().mockResolvedValue(goodF3RegionPage()),
+      now: () => fixedNow,
+    });
+
+    expect(outcome.kind).toBe("ok");
+    if (outcome.kind !== "ok") return;
+    expect(outcome.body.org.id).toBe(123);
+    expect(outcome.body.org.name).toBe("F3 Muletown");
+    expect(outcome.body.org.admin_count).toBe(4);
+    expect(outcome.body.org.caller_roles).toEqual(["admin"]);
+    expect(outcome.body.pax_vault.region_id).toBe("35838");
+    expect(outcome.body.f3_region_pages.slug).toBe("muletown");
+    expect(outcome.body.cross_check.triple_matches).toBe(true);
+    expect(outcome.body.cross_check.match_strategy).toBe("exact");
+    expect(outcome.body.validated_at).toBe("2026-04-14T18:23:00.000Z");
+  });
+
+  it("returns org_not_found when loadOrgFacts resolves to null", async () => {
+    const outcome = await runRegionBindingValidator(goodQuery(), {
+      db: stubDb,
+      loadOrgFacts: vi.fn().mockResolvedValue(null),
+      fetchPaxVault: vi.fn(),
+      fetchF3RegionPage: vi.fn(),
+    });
+    expect(outcome.kind).toBe("org_not_found");
+  });
+
+  it("returns forbidden when caller has no binding-capable roles on the org", async () => {
+    const outcome = await runRegionBindingValidator(goodQuery(), {
+      db: stubDb,
+      loadOrgFacts: vi
+        .fn()
+        .mockResolvedValue({ ...goodOrgFacts(), caller_roles: [] }),
+      fetchPaxVault: vi.fn(),
+      fetchF3RegionPage: vi.fn(),
+    });
+    expect(outcome.kind).toBe("forbidden");
+    if (outcome.kind === "forbidden") {
+      expect(outcome.reason).toBe("caller_not_authorized_on_org");
+    }
+  });
+
+  it("returns source_unavailable pax_vault when pax-vault throws", async () => {
+    const outcome = await runRegionBindingValidator(goodQuery(), {
+      db: stubDb,
+      loadOrgFacts: vi.fn().mockResolvedValue(goodOrgFacts()),
+      fetchPaxVault: vi
+        .fn()
+        .mockRejectedValue(new PaxVaultUnavailableError("boom")),
+      fetchF3RegionPage: vi.fn().mockResolvedValue(goodF3RegionPage()),
+    });
+    expect(outcome.kind).toBe("source_unavailable");
+    if (outcome.kind === "source_unavailable") {
+      expect(outcome.source).toBe("pax_vault");
+    }
+  });
+
+  it("returns source_unavailable f3_region_pages when f3-region-pages throws", async () => {
+    const outcome = await runRegionBindingValidator(goodQuery(), {
+      db: stubDb,
+      loadOrgFacts: vi.fn().mockResolvedValue(goodOrgFacts()),
+      fetchPaxVault: vi.fn().mockResolvedValue(goodPaxVault()),
+      fetchF3RegionPage: vi
+        .fn()
+        .mockRejectedValue(new F3RegionPagesUnavailableError("down")),
+    });
+    expect(outcome.kind).toBe("source_unavailable");
+    if (outcome.kind === "source_unavailable") {
+      expect(outcome.source).toBe("f3_region_pages");
+    }
+  });
+
+  it("prioritizes pax_vault failure over f3_region_pages failure", async () => {
+    const outcome = await runRegionBindingValidator(goodQuery(), {
+      db: stubDb,
+      loadOrgFacts: vi.fn().mockResolvedValue(goodOrgFacts()),
+      fetchPaxVault: vi
+        .fn()
+        .mockRejectedValue(new PaxVaultUnavailableError("pv-down")),
+      fetchF3RegionPage: vi
+        .fn()
+        .mockRejectedValue(new F3RegionPagesUnavailableError("rp-down")),
+    });
+    expect(outcome.kind).toBe("source_unavailable");
+    if (outcome.kind === "source_unavailable") {
+      expect(outcome.source).toBe("pax_vault");
+    }
+  });
+
+  it("returns mismatch when triangulation fails", async () => {
+    const outcome = await runRegionBindingValidator(goodQuery(), {
+      db: stubDb,
+      loadOrgFacts: vi.fn().mockResolvedValue(goodOrgFacts()),
+      fetchPaxVault: vi
+        .fn()
+        .mockResolvedValue({ ...goodPaxVault(), region_name: "Nope" }),
+      fetchF3RegionPage: vi.fn().mockResolvedValue(goodF3RegionPage()),
+    });
+    expect(outcome.kind).toBe("mismatch");
+    if (outcome.kind === "mismatch") {
+      expect(outcome.detail.mismatches).toHaveLength(1);
+      expect(outcome.detail.mismatches[0]?.field).toBe(
+        "org_name_vs_pax_vault_region_name",
+      );
+    }
+  });
+
+  it("accepts fuzzy-matched org.name vs pax_vault.region_name and reports match_strategy=fuzzy", async () => {
+    const outcome = await runRegionBindingValidator(goodQuery(), {
+      db: stubDb,
+      loadOrgFacts: vi.fn().mockResolvedValue({
+        ...goodOrgFacts(),
+        org: {
+          ...goodOrgFacts().org,
+          name: "  f3  muletown  ",
+        },
+      }),
+      fetchPaxVault: vi.fn().mockResolvedValue(goodPaxVault()),
+      fetchF3RegionPage: vi.fn().mockResolvedValue(goodF3RegionPage()),
+    });
+    expect(outcome.kind).toBe("ok");
+    if (outcome.kind === "ok") {
+      expect(outcome.body.cross_check.match_strategy).toBe("fuzzy");
+    }
+  });
+});

--- a/apps/api/src/lib/region-binding-validator-service.ts
+++ b/apps/api/src/lib/region-binding-validator-service.ts
@@ -1,0 +1,270 @@
+/**
+ * Orchestration layer for the internal region-binding validator
+ * (R5 Decision 11). Pulls facts from three sources (orgs+users in Supabase
+ * via @acme/db, pax-vault via its internal API, f3-region-pages via its
+ * client), runs the pure triangulator, and shapes the validator response.
+ *
+ * The data fetchers are injected so tests can mock each source
+ * independently — no database or network required for unit tests.
+ */
+
+import { and, countDistinct, eq, inArray, schema } from "@acme/db";
+import type { AppDb } from "@acme/db/client";
+import type { RegionRole } from "@acme/shared/app/enums";
+
+import {
+  F3RegionPagesUnavailableError,
+  fetchF3RegionPage,
+} from "./f3-region-pages-client";
+import type { F3RegionPage } from "./f3-region-pages-client";
+import {
+  PaxVaultUnavailableError,
+  fetchPaxVaultRegion,
+} from "./pax-vault-client";
+import type { PaxVaultRegion } from "./pax-vault-client";
+import { triangulate } from "./region-binding-triangulator";
+import type { TriangulationMismatchDetail } from "./region-binding-triangulator";
+
+export interface ValidatorQuery {
+  orgId: number;
+  paxVaultRegionId: string;
+  regionSlug: string;
+  callingUserId: number;
+}
+
+export interface OrgFactsDetailed {
+  id: number;
+  name: string;
+  last_modified: string;
+  admin_count: number;
+  caller_roles: string[];
+}
+
+export interface ValidatorResponseBody {
+  org: OrgFactsDetailed;
+  pax_vault: PaxVaultRegion;
+  f3_region_pages: F3RegionPage;
+  cross_check: {
+    triple_matches: boolean;
+    match_strategy: "exact" | "fuzzy" | "failed";
+  };
+  validated_at: string;
+}
+
+export type ValidatorOutcome =
+  | { kind: "ok"; body: ValidatorResponseBody }
+  | { kind: "forbidden"; reason: "caller_not_authorized_on_org" }
+  | {
+      kind: "mismatch";
+      detail: { mismatches: TriangulationMismatchDetail[] };
+    }
+  | {
+      kind: "source_unavailable";
+      source: "pax_vault" | "f3_region_pages";
+      message: string;
+    }
+  | { kind: "org_not_found" };
+
+/**
+ * Role names — must match the `regionRole` pg enum via @acme/db.
+ * We use the `admin`/`editor` set here because binding creation requires
+ * "a role sufficient to bind domains".
+ */
+const BINDING_ROLES = [
+  "admin",
+  "editor",
+] as const satisfies readonly RegionRole[];
+type BindingRole = (typeof BINDING_ROLES)[number];
+
+const isBindingRole = (name: RegionRole): name is BindingRole =>
+  name === "admin" || name === "editor";
+
+export interface LoadOrgFactsInput {
+  db: AppDb;
+  orgId: number;
+  callingUserId: number;
+}
+
+export interface LoadOrgFactsResult {
+  org: {
+    id: number;
+    name: string;
+    last_modified: string;
+  };
+  admin_count: number;
+  caller_roles: BindingRole[];
+}
+
+/**
+ * Loads org row, counts admins for that org, and fetches the calling user's
+ * roles on that org. Returns `null` if the org doesn't exist.
+ */
+export const loadOrgFacts = async (
+  input: LoadOrgFactsInput,
+): Promise<LoadOrgFactsResult | null> => {
+  const [org] = await input.db
+    .select({
+      id: schema.orgs.id,
+      name: schema.orgs.name,
+      updated: schema.orgs.updated,
+    })
+    .from(schema.orgs)
+    .where(eq(schema.orgs.id, input.orgId))
+    .limit(1);
+
+  if (!org) return null;
+
+  // admin_count = distinct users with a binding-capable role on this org.
+  const [adminCountRow] = await input.db
+    .select({ value: countDistinct(schema.rolesXUsersXOrg.userId) })
+    .from(schema.rolesXUsersXOrg)
+    .innerJoin(schema.roles, eq(schema.roles.id, schema.rolesXUsersXOrg.roleId))
+    .where(
+      and(
+        eq(schema.rolesXUsersXOrg.orgId, input.orgId),
+        inArray(schema.roles.name, [...BINDING_ROLES]),
+      ),
+    );
+
+  // Caller's roles on THIS specific org.
+  const callerRoleRows = await input.db
+    .select({ roleName: schema.roles.name })
+    .from(schema.rolesXUsersXOrg)
+    .innerJoin(schema.roles, eq(schema.roles.id, schema.rolesXUsersXOrg.roleId))
+    .where(
+      and(
+        eq(schema.rolesXUsersXOrg.orgId, input.orgId),
+        eq(schema.rolesXUsersXOrg.userId, input.callingUserId),
+      ),
+    );
+
+  const callerRoles: BindingRole[] = callerRoleRows
+    .map((r) => r.roleName)
+    .filter(isBindingRole);
+
+  return {
+    org: {
+      id: org.id,
+      name: org.name,
+      last_modified: org.updated,
+    },
+    admin_count: Number(adminCountRow?.value ?? 0),
+    caller_roles: callerRoles,
+  };
+};
+
+export type LoadOrgFactsFn = (
+  input: LoadOrgFactsInput,
+) => Promise<LoadOrgFactsResult | null>;
+
+export interface ValidatorDependencies {
+  db: AppDb;
+  loadOrgFacts?: LoadOrgFactsFn;
+  fetchPaxVault?: typeof fetchPaxVaultRegion;
+  fetchF3RegionPage?: typeof fetchF3RegionPage;
+  now?: () => Date;
+}
+
+/**
+ * Main validator orchestrator. Does not do authentication or rate limiting —
+ * those are handled by the route boundary. Does enforce authorization
+ * (caller role check against the org) per Decision 11.
+ */
+export const runRegionBindingValidator = async (
+  query: ValidatorQuery,
+  deps: ValidatorDependencies,
+): Promise<ValidatorOutcome> => {
+  const paxVaultClient = deps.fetchPaxVault ?? fetchPaxVaultRegion;
+  const f3RegionPagesClient = deps.fetchF3RegionPage ?? fetchF3RegionPage;
+  const loadFacts = deps.loadOrgFacts ?? loadOrgFacts;
+  const clock = deps.now ?? (() => new Date());
+
+  const orgFacts = await loadFacts({
+    db: deps.db,
+    orgId: query.orgId,
+    callingUserId: query.callingUserId,
+  });
+
+  if (!orgFacts) {
+    return { kind: "org_not_found" };
+  }
+
+  // Authorization: caller must have a binding-capable role on the org.
+  if (orgFacts.caller_roles.length === 0) {
+    return { kind: "forbidden", reason: "caller_not_authorized_on_org" };
+  }
+
+  // Fetch pax-vault and f3-region-pages in parallel. Either can fail
+  // independently; we want to report the first failing source cleanly.
+  const [paxVaultResult, f3RegionPagesResult] = await Promise.allSettled([
+    paxVaultClient({ regionId: query.paxVaultRegionId }),
+    f3RegionPagesClient({ slug: query.regionSlug }),
+  ]);
+
+  if (paxVaultResult.status === "rejected") {
+    const reason = paxVaultResult.reason as unknown;
+    const message =
+      reason instanceof PaxVaultUnavailableError
+        ? reason.message
+        : reason instanceof Error
+          ? reason.message
+          : "pax-vault fetch failed";
+    return { kind: "source_unavailable", source: "pax_vault", message };
+  }
+
+  if (f3RegionPagesResult.status === "rejected") {
+    const reason = f3RegionPagesResult.reason as unknown;
+    const message =
+      reason instanceof F3RegionPagesUnavailableError
+        ? reason.message
+        : reason instanceof Error
+          ? reason.message
+          : "f3-region-pages fetch failed";
+    return {
+      kind: "source_unavailable",
+      source: "f3_region_pages",
+      message,
+    };
+  }
+
+  const paxVault = paxVaultResult.value;
+  const f3RegionPages = f3RegionPagesResult.value;
+
+  const triangulation = triangulate({
+    org: { id: orgFacts.org.id, name: orgFacts.org.name },
+    paxVault: {
+      region_id: paxVault.region_id,
+      region_name: paxVault.region_name,
+    },
+    f3RegionPages: { slug: f3RegionPages.slug },
+    requestedRegionSlug: query.regionSlug,
+    requestedPaxVaultRegionId: query.paxVaultRegionId,
+  });
+
+  if (!triangulation.triple_matches) {
+    return {
+      kind: "mismatch",
+      detail: { mismatches: triangulation.mismatches },
+    };
+  }
+
+  return {
+    kind: "ok",
+    body: {
+      org: {
+        id: orgFacts.org.id,
+        name: orgFacts.org.name,
+        last_modified: new Date(orgFacts.org.last_modified).toISOString(),
+        admin_count: orgFacts.admin_count,
+        caller_roles: orgFacts.caller_roles,
+      },
+      pax_vault: paxVault,
+      f3_region_pages: f3RegionPages,
+      cross_check: {
+        triple_matches: true,
+        match_strategy: triangulation.match_strategy,
+      },
+      validated_at: clock().toISOString(),
+    },
+  };
+};


### PR DESCRIPTION
## Summary

R5 Decision 11 — the internal validator API that the admin UI will call when creating or verifying an `org_region_bindings` row. Triangulates org data (Supabase), pax-vault region data, and f3-region-pages data so the admin confirmation screen can show real evidence to a region admin (Decision 9).

- `GET /api/internal/region-binding/validate` route handler (Next.js 15 App Router static segment, resolved before the existing oRPC catch-all)
- Service-to-service shared-secret auth with constant-time compare
- In-memory token bucket rate limiter (60 rpm per calling user)
- Triangulation logic as a pure function, directly testable
- Stubbed pax-vault + f3-region-pages clients with `TODO(F3R5_014-followup)` markers — these unblock the endpoint while the real integrations are wired later
- 47 tests (38 new + 9 pre-existing regression-safe), all pass

## Notable deviations from the spec

- **Bypassed `checkHasRoleOnOrg`** — the existing helper requires a pre-built `Session`. Wrote a direct `@acme/db` query with the same semantics; flagged as a follow-up to add a `checkHasRoleOnOrgByUserId` variant.
- **Added 404 `org_not_found`** response — without it, a missing org falls through to 403 which is misleading. UX improvement.
- **Shared-secret S2S** as initial auth mechanism — `@acme/sso` doesn't expose service-token primitives yet. Migration TODO flagged.

## Follow-ups (tracked for hardening after merge)

1. Wire real pax-vault internal API
2. Wire real f3-region-pages Postgres read
3. Migrate S2S auth to `@acme/sso` service tokens
4. Unify authorization via new `checkHasRoleOnOrgByUserId`
5. Add env vars to `apps/api/src/env.ts` for boot-time validation
6. Promote in-memory rate limiter to Redis when apps/api scales past 1 instance
7. Integration test with real Supabase + HTTP-mocked externals

**Stack context:** independent branch, base is `dev` directly. Not in the reconciler stack.

## Test plan

- [x] `pnpm --filter f3-nation-api typecheck` clean
- [x] `pnpm --filter f3-nation-api lint` clean
- [x] `pnpm --filter f3-nation-api test` — 47/47 pass
- [ ] End-to-end test once pax-vault and f3-region-pages real integrations are wired

🤖 Generated with [Claude Code](https://claude.com/claude-code)