### PR TITLE
R5 Phase 1: apps/reconciler scaffold (stacked on schema package)

### DIFF
--- a/apps/reconciler/Dockerfile
+++ b/apps/reconciler/Dockerfile
@@ -1,0 +1,79 @@
+# ---------------------------------------------------------------------------
+# apps/reconciler/Dockerfile
+#
+# Multi-stage build for the redirect-platform reconciler Cloud Run Job.
+#
+# Layout mirrors the other f3-nation apps (`apps/auth/Dockerfile`,
+# `apps/api/Dockerfile`): turbo prune -> install -> build. The runner
+# copies the whole workspace rather than tightening the output tree,
+# because pnpm workspace hoisting + the `@acme/redirect-platform-db`
+# symlink make a minimal copy non-trivial. TODO(F3R5_004): tighten the
+# runner stage when Cloud Run Jobs deploy wiring lands — this is a
+# functional-first scaffold, not an optimized image.
+#
+# Cloud Run Jobs are one-shot processes; there is no HTTP port, no
+# healthcheck, no long-running server. Cloud Scheduler invokes the job
+# every 5 minutes per R5 Decision 6.
+# ---------------------------------------------------------------------------
+
+# ---------- Stage 1: Prune monorepo ----------
+FROM node:20-alpine AS builder
+
+ENV TURBO_TELEMETRY_DISABLED=1
+ENV PNPM_HOME="/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
+RUN apk add --no-cache libc6-compat && apk update
+WORKDIR /app
+
+RUN corepack enable && corepack prepare pnpm@8.15.1 --activate
+RUN pnpm add -g turbo@^1.12.3
+
+COPY . .
+RUN turbo prune @acme/reconciler --docker
+
+# ---------- Stage 2: Install + build ----------
+FROM node:20-alpine AS installer
+
+ENV TURBO_TELEMETRY_DISABLED=1
+ENV PNPM_HOME="/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
+RUN apk add --no-cache libc6-compat openssl && apk update
+WORKDIR /app
+
+RUN corepack enable && corepack prepare pnpm@8.15.1 --activate
+RUN pnpm add -g turbo@^1.12.3
+
+# Install dependencies from pruned lockfile
+COPY --from=builder /app/out/json/ .
+COPY --from=builder /app/out/pnpm-lock.yaml ./pnpm-lock.yaml
+RUN pnpm install --frozen-lockfile
+
+# Copy source and build
+COPY --from=builder /app/out/full/ .
+
+ENV NODE_ENV=production
+ENV CI=true
+ENV SKIP_ENV_VALIDATION=true
+
+RUN pnpm turbo build --filter=@acme/reconciler
+
+# ---------- Stage 3: Production runner ----------
+FROM node:20-alpine AS runner
+
+RUN apk add --no-cache libc6-compat openssl && apk update
+WORKDIR /app
+
+RUN addgroup --system --gid 1001 nodejs && \
+    adduser --system --uid 1001 reconciler
+
+# Copy the entire installed workspace. The reconciler loads `drizzle-orm`
+# and `postgres` at runtime plus `@acme/redirect-platform-db` via pnpm
+# workspace symlinks, so tightening the copy requires threading those
+# hoisted stores. TODO(F3R5_004): narrow this to the minimal set.
+COPY --from=installer --chown=reconciler:nodejs /app /app
+
+USER reconciler
+
+ENV NODE_ENV=production
+
+CMD ["node", "apps/reconciler/dist/index.js"]

--- a/apps/reconciler/README.md
+++ b/apps/reconciler/README.md
@@ -1,0 +1,118 @@
+# `@acme/reconciler` — redirect platform reconciler Cloud Run job
+
+> **Status:** scaffold only. F3R5_009.
+> Reconciler operations 1-4 land in F3R5_010, operations 5-8 in F3R5_011.
+
+This app is a **Cloud Run Job** (one-shot per invocation) that drives the F3
+redirect platform lifecycle state machine. Cloud Scheduler invokes it every
+5 minutes in both `us-central1` and `europe-west1`; a singleton lease in
+Postgres (`reconciler_leases`) ensures only one region is doing work at a
+time in the steady state.
+
+See R5 Decision 6 (Backend Reconciler with Designed Concurrency) for the
+authoritative spec, and the full plan at
+`~/workspaces/clients/f3-nation/f3-redirect/docs/plans/2026-04-14-multi-tenant-saas-refactor.md`.
+
+## Repo location (migrated 2026-04-14)
+
+This app was **migrated from the f3-redirect repo into the f3-nation monorepo
+on 2026-04-14** (task F3R5_015) per the R5 schema-sharing decision — Option A
+in the plan's Decision 7 follow-up: move the reconciler into the same repo
+as the canonical Drizzle schema (`@acme/redirect-platform-db`) and the
+admin UI (`apps/redirect-admin`, placed in f3-nation per Decision 5).
+
+Before the migration the reconciler carried a loud duplicated-schema stub at
+`src/db/schema.ts` with a TODO about cross-repo schema sharing. That stub
+has been **deleted**; `src/db/client.ts` now imports `schema` directly from
+`@acme/redirect-platform-db`, and the workspace link makes drift impossible.
+
+The original branch in f3-redirect (`feat/r5-reconciler-scaffold`) is now
+orphaned reference material.
+
+## What the scaffold implements (F3R5_009)
+
+- [x] Config loading and validation (`src/config.ts`)
+- [x] Structured JSON logging matching the F3R5_003 alert policy contract (`src/logging.ts`)
+- [x] Neon Drizzle client (`src/db/client.ts`) — schema from `@acme/redirect-platform-db`
+- [x] Singleton lease acquire / heartbeat / release (`src/lease.ts`)
+- [x] `withHeartbeat(...)` runner with 30-minute hard cap (`src/lease.ts`)
+- [x] `processTransientStates(...)` stub (`src/process.ts`)
+- [x] Main entry point wiring everything together (`src/index.ts`)
+- [x] Unit tests for lease SQL and logging (`tests/`)
+- [x] `apps/reconciler/Dockerfile` (inside the app directory, following the
+      `apps/auth/Dockerfile` / `apps/api/Dockerfile` pattern)
+
+## What the scaffold does NOT implement
+
+- Reconciler operations 1-4 (DNS challenge validation, cert provisioning,
+  SNI probe, post-cutover DNS verification) — **F3R5_010** (now unblocked
+  by this migration)
+- Reconciler operations 5-8 (active health re-probe, tombstone cleanup,
+  quarantine drift check, periodic drift detection) — F3R5_011
+- Cloud Scheduler + Cloud Run Job Terraform wiring — F3R5_004
+
+## Log label contract (interop with F3R5_003)
+
+The structured logging module in `src/logging.ts` emits labels in the exact
+shape expected by the alert policies in
+`/tmp/f3-r5-infra/infra/terraform/shared-platform/alert_policies.tf` (the
+Terraform module stays in the f3-redirect repo — only the reconciler app
+moved to f3-nation). Filter expressions:
+
+```
+resource.type="cloud_run_job"
+severity=CRITICAL
+jsonPayload.labels.redirect_platform_drift="true"
+```
+
+```
+resource.type="cloud_run_job"
+severity=CRITICAL
+jsonPayload.labels.redirect_platform_stuck_operation="true"
+```
+
+```
+resource.type="cloud_run_job"
+severity=CRITICAL
+jsonPayload.labels.redirect_platform_cert_renewal="true"
+```
+
+Cloud Logging promotes top-level JSON fields on stdout into `jsonPayload`,
+so emitting `labels.redirect_platform_*="true"` at the top level of a
+stdout JSON entry matches the filter path `jsonPayload.labels.redirect_platform_*`.
+**Do not rename these labels or change the string value `"true"` without
+coordinating with F3R5_003.**
+
+## Required environment variables
+
+| Name                             | Purpose                                                                                                                                                                                                  | Required? |
+| -------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- |
+| `REDIRECT_PLATFORM_DATABASE_URL` | Neon connection string for the `redirect_reconciler` role (see R5 Decision 8)                                                                                                                            | yes       |
+| `RECONCILER_REGION`              | GCP region of this task (`us-central1` \| `europe-west1`)                                                                                                                                                | yes       |
+| `RECONCILER_INSTANCE_ID`         | Optional override for the lease `held_by`. When unset, we synthesize from `${RECONCILER_REGION}-${CLOUD_RUN_EXECUTION}-task${CLOUD_RUN_TASK_INDEX}-${rand}` or fall back to `local-${hostname}-${rand}`. | no        |
+
+On Cloud Run Jobs, `CLOUD_RUN_EXECUTION` and `CLOUD_RUN_TASK_INDEX` are set
+automatically by the runtime, so you only need to provide the database URL
+and region.
+
+## Local development
+
+```bash
+# From the repo root
+pnpm install
+pnpm --filter @acme/reconciler typecheck
+pnpm --filter @acme/reconciler test
+pnpm --filter @acme/reconciler lint
+pnpm --filter @acme/reconciler build
+
+# Run against a local Postgres (or a Neon dev branch) with the table
+# created from R5 Decision 7:
+export REDIRECT_PLATFORM_DATABASE_URL='postgresql://...'
+export RECONCILER_REGION='us-central1'
+pnpm --filter @acme/reconciler start
+```
+
+## Deployment
+
+Deferred to **F3R5_004** (Cloud Scheduler + Cloud Run Job Terraform). The
+image is built from `apps/reconciler/Dockerfile`.

--- a/apps/reconciler/package.json
+++ b/apps/reconciler/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@acme/reconciler",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "F3 redirect platform reconciler Cloud Run job (R5 / F3R5_009 scaffold).",
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "clean": "rm -rf .turbo node_modules dist",
+    "format": "prettier --check . --ignore-path ../../.gitignore --ignore-path ../../.prettierignore",
+    "lint": "eslint .",
+    "start": "node dist/index.js",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest --run"
+  },
+  "dependencies": {
+    "@acme/redirect-platform-db": "workspace:*",
+    "drizzle-orm": "^0.39.3",
+    "postgres": "^3.4.3"
+  },
+  "devDependencies": {
+    "@acme/eslint-config": "workspace:^0.2.0",
+    "@acme/prettier-config": "workspace:^0.1.0",
+    "@acme/tsconfig": "workspace:^0.1.0",
+    "@types/node": "^20.11.13",
+    "eslint": "^8.56.0",
+    "prettier": "^3.2.5",
+    "typescript": "^5.3.3",
+    "vitest": "^1.5.0"
+  },
+  "eslintConfig": {
+    "root": true,
+    "extends": [
+      "@acme/eslint-config/base"
+    ],
+    "ignorePatterns": [
+      "dist",
+      "vitest.config.mts"
+    ]
+  },
+  "prettier": "@acme/prettier-config"
+}

--- a/apps/reconciler/src/config.ts
+++ b/apps/reconciler/src/config.ts
@@ -1,0 +1,77 @@
+/**
+ * Environment variable loading for the reconciler Cloud Run job.
+ *
+ * See R5 Decision 8 for the `redirect_reconciler` Neon role this process
+ * connects as. The connection string is provisioned via Secret Manager as
+ * `neon-redirect-reconciler-url`.
+ */
+
+import { hostname as osHostname } from "node:os";
+import { randomBytes } from "node:crypto";
+
+export interface ReconcilerConfig {
+  /** Neon connection string for the `redirect_reconciler` role. */
+  databaseUrl: string;
+  /** Unique per Cloud Run job task; passed into the singleton lease as `held_by`. */
+  instanceId: string;
+  /** GCP region this task is running in (`us-central1` | `europe-west1`). */
+  region: string;
+}
+
+export class ConfigError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ConfigError";
+  }
+}
+
+/**
+ * Synthesize a unique reconciler instance id.
+ *
+ * Cloud Run Jobs sets `CLOUD_RUN_EXECUTION` (execution name) and
+ * `CLOUD_RUN_TASK_INDEX` (0-based index within the execution) on every task;
+ * see https://cloud.google.com/run/docs/container-contract#env-vars. When
+ * those are present we build a stable id from them plus a short random
+ * suffix (so the same execution retrying a task still yields a unique
+ * `held_by`). Otherwise we fall back to a local-dev shape.
+ */
+export function buildInstanceId(env: NodeJS.ProcessEnv = process.env): string {
+  if (env.RECONCILER_INSTANCE_ID) {
+    return env.RECONCILER_INSTANCE_ID;
+  }
+  const suffix = randomBytes(3).toString("hex");
+  const execution = env.CLOUD_RUN_EXECUTION;
+  const taskIndex = env.CLOUD_RUN_TASK_INDEX;
+  const region = env.RECONCILER_REGION;
+  if (execution && taskIndex !== undefined && region) {
+    return `${region}-${execution}-task${taskIndex}-${suffix}`;
+  }
+  return `local-${osHostname()}-${suffix}`;
+}
+
+/**
+ * Load + validate config. Throws `ConfigError` on missing required vars —
+ * the caller (index.ts) is responsible for logging a CRITICAL entry and
+ * exiting with code 1.
+ */
+export function loadConfig(
+  env: NodeJS.ProcessEnv = process.env,
+): ReconcilerConfig {
+  const databaseUrl = env.REDIRECT_PLATFORM_DATABASE_URL;
+  if (!databaseUrl) {
+    throw new ConfigError(
+      "Missing required env var REDIRECT_PLATFORM_DATABASE_URL (Neon connection string for redirect_reconciler role)",
+    );
+  }
+  const region = env.RECONCILER_REGION;
+  if (!region) {
+    throw new ConfigError(
+      "Missing required env var RECONCILER_REGION (e.g. us-central1 or europe-west1)",
+    );
+  }
+  return {
+    databaseUrl,
+    instanceId: buildInstanceId(env),
+    region,
+  };
+}

--- a/apps/reconciler/src/db/client.ts
+++ b/apps/reconciler/src/db/client.ts
@@ -1,0 +1,58 @@
+/**
+ * Neon Postgres client for the reconciler.
+ *
+ * Imports the canonical Drizzle schema from `@acme/redirect-platform-db`
+ * (R5 Decision 7). Pool size is 2 because the reconciler is a singleton
+ * via the `reconciler_leases` lease — concurrency is deliberately tiny.
+ *
+ * SSL is required for Neon in production; callers can disable it for
+ * local PgBouncer proxies or tests.
+ *
+ * NOTE: we intentionally instantiate a Drizzle client here rather than
+ * calling `createRedirectPlatformDb` from `@acme/redirect-platform-db`
+ * because the reconciler needs to share the same `postgres.Sql` handle
+ * with the lease module (which uses raw tagged templates against
+ * `reconciler_leases`). The schema object is identical either way.
+ */
+
+import { schema } from "@acme/redirect-platform-db";
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
+import type { Sql } from "postgres";
+
+export interface CreateReconcilerDbOptions {
+  connectionString: string;
+  ssl?: boolean;
+  max?: number;
+}
+
+export interface ReconcilerDbHandle {
+  db: ReturnType<typeof drizzle<typeof schema>>;
+  client: Sql;
+  end(): Promise<void>;
+}
+
+export function createReconcilerDb(
+  options: CreateReconcilerDbOptions,
+): ReconcilerDbHandle {
+  const { connectionString, ssl = true, max = 2 } = options;
+  if (!connectionString) {
+    throw new Error(
+      "createReconcilerDb: connectionString is required (expected a Neon Postgres URL)",
+    );
+  }
+  const client = postgres(connectionString, {
+    ssl: ssl ? "require" : false,
+    max,
+  });
+  const db = drizzle(client, { schema });
+  return {
+    db,
+    client,
+    async end() {
+      await client.end({ timeout: 5 });
+    },
+  };
+}
+
+export type ReconcilerDb = ReconcilerDbHandle["db"];

--- a/apps/reconciler/src/index.ts
+++ b/apps/reconciler/src/index.ts
@@ -1,0 +1,127 @@
+/**
+ * Reconciler Cloud Run job entry point.
+ *
+ * One-shot process per Cloud Run Jobs semantics: acquire the singleton
+ * lease, run one reconciler cycle under a heartbeat, release the lease,
+ * close the DB pool, exit. Cloud Scheduler re-invokes us every 5 minutes
+ * (R5 Decision 6).
+ */
+
+import { randomUUID } from "node:crypto";
+
+import { ConfigError, loadConfig } from "./config.js";
+import { createReconcilerDb } from "./db/client.js";
+import {
+  LEASE_KEY_DOMAIN_RECONCILER,
+  LeaseLostError,
+  StuckOperationError,
+  acquireLease,
+  releaseLease,
+  withHeartbeat,
+} from "./lease.js";
+import { createLogger } from "./logging.js";
+import { processTransientStates } from "./process.js";
+
+async function main(): Promise<void> {
+  let config;
+  try {
+    config = loadConfig();
+  } catch (err) {
+    if (err instanceof ConfigError) {
+      console.log(
+        JSON.stringify({
+          severity: "CRITICAL",
+          message: "reconciler config load failed",
+          error: err.message,
+        }),
+      );
+      process.exit(1);
+    }
+    throw err;
+  }
+
+  const logger = createLogger({
+    context: {
+      instanceId: config.instanceId,
+      region: config.region,
+      runId: randomUUID(),
+    },
+  });
+
+  logger.info("reconciler job started", {
+    region: config.region,
+    instance_id: config.instanceId,
+  });
+
+  const handle = createReconcilerDb({ connectionString: config.databaseUrl });
+
+  try {
+    const lease = await acquireLease(handle.client, {
+      leaseKey: LEASE_KEY_DOMAIN_RECONCILER,
+      instanceId: config.instanceId,
+    });
+
+    if (lease === null) {
+      logger.info(
+        "another reconciler instance holds the lease; exiting cleanly",
+      );
+      return;
+    }
+
+    logger.info("lease acquired", {
+      lease_key: lease.leaseKey,
+      expires_at: lease.expiresAt,
+    });
+
+    try {
+      await withHeartbeat(
+        {
+          sql: handle.client,
+          lease,
+          logger,
+          operationName: "processTransientStates",
+        },
+        async (heartbeat) => {
+          await processTransientStates({
+            db: handle.db,
+            lease,
+            logger,
+            heartbeat,
+          });
+        },
+      );
+    } catch (err) {
+      if (err instanceof StuckOperationError) {
+        logger.error("reconciler cycle aborted: stuck operation hard cap", {
+          operation: err.operation,
+          duration_ms: err.durationMs,
+        });
+      } else if (err instanceof LeaseLostError) {
+        logger.error("reconciler cycle aborted: lease lost", {
+          operation: err.operation,
+        });
+      } else {
+        logger.error("reconciler cycle failed", { error: String(err) });
+      }
+      throw err;
+    } finally {
+      await releaseLease(handle.client, lease);
+      logger.info("lease released");
+    }
+
+    logger.info("reconciler cycle completed");
+  } finally {
+    await handle.end();
+  }
+}
+
+main().catch((err) => {
+  console.log(
+    JSON.stringify({
+      severity: "ERROR",
+      message: "reconciler fatal error",
+      error: String(err),
+    }),
+  );
+  process.exit(1);
+});

--- a/apps/reconciler/src/lease.ts
+++ b/apps/reconciler/src/lease.ts
@@ -1,0 +1,314 @@
+/**
+ * Singleton reconciler lease — R5 Decision 6 "Backend Reconciler with
+ * Designed Concurrency".
+ *
+ * Three operations:
+ *   1. acquire() — DELETE stale + INSERT ON CONFLICT DO NOTHING, TTL 4 min
+ *   2. heartbeat() — UPDATE WHERE held_by AND expires_at > now()
+ *   3. release() — DELETE WHERE lease_key AND held_by
+ *
+ * The SQL here mirrors the exact statements in R5 Decision 6 to the letter.
+ * If you change these, update the plan too — this is the concurrency
+ * primitive the entire reconciler depends on.
+ *
+ * Heartbeat wrapper semantics:
+ *   - `withHeartbeat(lease, maxDurationMs, fn)` runs `fn` and extends the
+ *     lease every 30 seconds in the background.
+ *   - If the heartbeat returns zero rows, the lease is LOST — we set an
+ *     `isLost()` flag and `fn` is expected to abort cleanly (R5: "rolls
+ *     back any open DB work, does NOT attempt further GCP API calls,
+ *     logs the abort"). The wrapper throws `LeaseLostError` after `fn`
+ *     returns or when the caller checks.
+ *   - If `fn` runs longer than `maxDurationMs` (R5 hard cap: 30 minutes),
+ *     we log a stuck-operation CRITICAL and throw `StuckOperationError`.
+ *     The caller (index.ts) catches and exits.
+ */
+
+import type { Sql } from "postgres";
+
+import type { Logger } from "./logging.js";
+
+export const LEASE_KEY_DOMAIN_RECONCILER = "domain-reconciler";
+export const LEASE_TTL_MINUTES = 4;
+export const HEARTBEAT_INTERVAL_MS = 30_000;
+export const HEARTBEAT_HARD_CAP_MS = 30 * 60 * 1000;
+
+export interface Lease {
+  leaseKey: string;
+  heldBy: string;
+  acquiredAt: string;
+  expiresAt: string;
+}
+
+/** Subset of the `postgres-js` Sql interface the lease module actually uses. */
+export type LeaseSqlExecutor = Pick<Sql, "begin" | "unsafe"> & Sql;
+
+export interface AcquireOptions {
+  leaseKey?: string;
+  instanceId: string;
+  ttlMinutes?: number;
+}
+
+export interface HeartbeatResult {
+  newExpiresAt: string;
+}
+
+export class LeaseLostError extends Error {
+  constructor(
+    public readonly lease: Lease,
+    public readonly operation: string,
+  ) {
+    super(
+      `reconciler lease ${lease.leaseKey} held by ${lease.heldBy} was lost while running operation '${operation}'`,
+    );
+    this.name = "LeaseLostError";
+  }
+}
+
+export class StuckOperationError extends Error {
+  constructor(
+    public readonly lease: Lease,
+    public readonly operation: string,
+    public readonly durationMs: number,
+  ) {
+    super(
+      `reconciler operation '${operation}' exceeded heartbeat hard cap after ${durationMs}ms (lease ${lease.leaseKey})`,
+    );
+    this.name = "StuckOperationError";
+  }
+}
+
+interface RawLeaseRow {
+  lease_key: string;
+  held_by: string;
+  acquired_at: Date | string;
+  expires_at: Date | string;
+}
+
+function toIsoString(value: Date | string): string {
+  return value instanceof Date ? value.toISOString() : value;
+}
+
+function rowToLease(row: RawLeaseRow): Lease {
+  return {
+    leaseKey: row.lease_key,
+    heldBy: row.held_by,
+    acquiredAt: toIsoString(row.acquired_at),
+    expiresAt: toIsoString(row.expires_at),
+  };
+}
+
+/**
+ * Attempt to acquire the singleton reconciler lease.
+ *
+ * Runs the exact SQL from R5 Decision 6: a single transaction containing
+ * (1) DELETE stale leases, (2) INSERT ON CONFLICT DO NOTHING RETURNING *.
+ * Returns the claimed lease on success, or `null` if another instance
+ * already holds it.
+ *
+ * No GCP API calls happen inside the transaction — this is deliberately
+ * a short DB-only op per the plan.
+ */
+export async function acquireLease(
+  sql: LeaseSqlExecutor,
+  options: AcquireOptions,
+): Promise<Lease | null> {
+  const leaseKey = options.leaseKey ?? LEASE_KEY_DOMAIN_RECONCILER;
+  const instanceId = options.instanceId;
+  const ttlMinutes = options.ttlMinutes ?? LEASE_TTL_MINUTES;
+  const ttlInterval = `${ttlMinutes} minutes`;
+
+  const rows = await sql.begin(async (tx) => {
+    await tx`
+      DELETE FROM reconciler_leases
+       WHERE lease_key = ${leaseKey}
+         AND expires_at < timezone('utc', now())
+    `;
+    const inserted = await tx<RawLeaseRow[]>`
+      INSERT INTO reconciler_leases (lease_key, held_by, acquired_at, expires_at)
+      VALUES (
+        ${leaseKey},
+        ${instanceId},
+        timezone('utc', now()),
+        timezone('utc', now()) + ${ttlInterval}::interval
+      )
+      ON CONFLICT (lease_key) DO NOTHING
+      RETURNING lease_key, held_by, acquired_at, expires_at
+    `;
+    return inserted;
+  });
+
+  const row = rows?.[0];
+  if (!row) {
+    return null;
+  }
+  return rowToLease(row);
+}
+
+/**
+ * Extend the lease by the standard TTL. Returns `null` if the lease was
+ * lost (expired or stolen by another instance).
+ *
+ * The WHERE clause is the exact guard from R5 Decision 6:
+ *   held_by = $instance AND expires_at > now()
+ */
+export async function heartbeatLease(
+  sql: LeaseSqlExecutor,
+  lease: Lease,
+  ttlMinutes: number = LEASE_TTL_MINUTES,
+): Promise<HeartbeatResult | null> {
+  const ttlInterval = `${ttlMinutes} minutes`;
+  const rows = await sql<{ expires_at: Date | string }[]>`
+    UPDATE reconciler_leases
+       SET expires_at = timezone('utc', now()) + ${ttlInterval}::interval
+     WHERE lease_key = ${lease.leaseKey}
+       AND held_by = ${lease.heldBy}
+       AND expires_at > timezone('utc', now())
+    RETURNING expires_at
+  `;
+  const row = rows?.[0];
+  if (!row) {
+    return null;
+  }
+  return { newExpiresAt: toIsoString(row.expires_at) };
+}
+
+/**
+ * Release the lease. Idempotent: returns cleanly even if the row is
+ * already gone (another instance took over after TTL expiry).
+ */
+export async function releaseLease(
+  sql: LeaseSqlExecutor,
+  lease: Lease,
+): Promise<void> {
+  await sql`
+    DELETE FROM reconciler_leases
+     WHERE lease_key = ${lease.leaseKey}
+       AND held_by = ${lease.heldBy}
+  `;
+}
+
+// ---------------------------------------------------------------------------
+// Heartbeat runner
+// ---------------------------------------------------------------------------
+
+export interface WithHeartbeatOptions {
+  sql: LeaseSqlExecutor;
+  lease: Lease;
+  logger: Logger;
+  /** Hard cap on a single operation; R5 says 30 minutes. */
+  maxDurationMs?: number;
+  /** Heartbeat interval; R5 says 30 seconds. */
+  intervalMs?: number;
+  /** Label used in logs when the heartbeat runner aborts. */
+  operationName?: string;
+  /** Test seam: replace the heartbeat implementation. */
+  heartbeatFn?: typeof heartbeatLease;
+  /** Test seam: replace timers. */
+  timers?: HeartbeatTimers;
+}
+
+export interface HeartbeatTimers {
+  setInterval(callback: () => void, ms: number): NodeJS.Timeout;
+  clearInterval(handle: NodeJS.Timeout): void;
+  now(): number;
+}
+
+const realTimers: HeartbeatTimers = {
+  setInterval: (cb, ms) => setInterval(cb, ms),
+  clearInterval: (h) => clearInterval(h),
+  now: () => Date.now(),
+};
+
+/**
+ * Run `fn` while periodically extending the lease in the background.
+ *
+ * Lifecycle:
+ *   - Start: schedule a heartbeat every `intervalMs`.
+ *   - On heartbeat failure: set `leaseLost = true`, capture a
+ *     `LeaseLostError`, stop the timer. `fn` should notice either via
+ *     `status.isLost()` or when its own DB calls fail.
+ *   - On hard cap: emit `log.stuckOperation`, set a pending
+ *     `StuckOperationError`, stop the timer.
+ *   - When `fn` settles: stop the timer. If a pending error exists,
+ *     throw it. Otherwise return `fn`'s value.
+ */
+export interface HeartbeatStatus {
+  isLost(): boolean;
+}
+
+export async function withHeartbeat<T>(
+  options: WithHeartbeatOptions,
+  fn: (status: HeartbeatStatus) => Promise<T>,
+): Promise<T> {
+  const {
+    sql,
+    lease,
+    logger,
+    maxDurationMs = HEARTBEAT_HARD_CAP_MS,
+    intervalMs = HEARTBEAT_INTERVAL_MS,
+    operationName = "reconciler_cycle",
+    heartbeatFn = heartbeatLease,
+    timers = realTimers,
+  } = options;
+
+  let leaseLost = false;
+  let pendingError: Error | null = null;
+  let lastExtendedAt = new Date(timers.now()).toISOString();
+  const startedAt = timers.now();
+
+  const status: HeartbeatStatus = {
+    isLost: () => leaseLost,
+  };
+
+  const handle = timers.setInterval(() => {
+    if (leaseLost || pendingError !== null) {
+      return;
+    }
+    const now = timers.now();
+    if (now - startedAt >= maxDurationMs) {
+      logger.stuckOperation({
+        operationName,
+        lastLeaseExtendedAt: lastExtendedAt,
+      });
+      pendingError = new StuckOperationError(
+        lease,
+        operationName,
+        now - startedAt,
+      );
+      return;
+    }
+    // Fire and forget; if the heartbeat fails we capture it via the closure.
+    // Tests inject a fake interval/heartbeat so this is deterministic.
+    void (async () => {
+      try {
+        const result = await heartbeatFn(sql, lease);
+        if (result === null) {
+          leaseLost = true;
+          logger.error("reconciler lease lost during heartbeat", {
+            operation: operationName,
+            lease_key: lease.leaseKey,
+          });
+          pendingError = new LeaseLostError(lease, operationName);
+        } else {
+          lastExtendedAt = result.newExpiresAt;
+        }
+      } catch (err) {
+        logger.error("reconciler heartbeat SQL error", {
+          operation: operationName,
+          error: String(err),
+        });
+      }
+    })();
+  }, intervalMs);
+
+  try {
+    const value = await fn(status);
+    if (pendingError !== null) {
+      throw pendingError;
+    }
+    return value;
+  } finally {
+    timers.clearInterval(handle);
+  }
+}

--- a/apps/reconciler/src/logging.ts
+++ b/apps/reconciler/src/logging.ts
@@ -1,0 +1,219 @@
+/**
+ * Structured JSON logging for Google Cloud Logging.
+ *
+ * This is an INTEROP CONTRACT with the F3R5_003 Terraform alert policies in
+ * `infra/terraform/shared-platform/alert_policies.tf`. The log-based metrics
+ * filter on these exact filter expressions:
+ *
+ *   resource.type="cloud_run_job"
+ *   severity=CRITICAL
+ *   jsonPayload.labels.redirect_platform_drift="true"
+ *
+ *   resource.type="cloud_run_job"
+ *   severity=CRITICAL
+ *   jsonPayload.labels.redirect_platform_stuck_operation="true"
+ *
+ *   resource.type="cloud_run_job"
+ *   severity=CRITICAL
+ *   jsonPayload.labels.redirect_platform_cert_renewal="true"
+ *
+ * So: severity MUST be the exact string "CRITICAL", and the label MUST live
+ * at `jsonPayload.labels.<name>` with the string value "true". Cloud Logging
+ * picks up a stdout JSON entry and promotes the top-level `severity` field
+ * automatically; everything else we put in the top-level object shows up
+ * under `jsonPayload` on the Cloud Logging entry. That means to land labels
+ * at `jsonPayload.labels.*`, we emit them at `labels.*` on stdout.
+ *
+ * DO NOT rename, DO NOT change the value shape ("true" string, not boolean)
+ * without coordinating with F3R5_003.
+ */
+
+export type LogSeverity = "INFO" | "WARNING" | "ERROR" | "CRITICAL";
+
+export type LogFields = Record<string, unknown>;
+
+export interface LoggerContext {
+  instanceId: string;
+  region: string;
+  /** Optional per-run id; index.ts sets this once per invocation. */
+  runId?: string;
+}
+
+export interface DriftLogInput {
+  domainId: string;
+  driftKind: "spec_mismatch" | "orphan_resource" | "unexpected_state";
+  resourceType: string;
+  resourceName: string;
+  observedSpec: unknown;
+  expectedSpec: unknown;
+  recoverableFrom: string | null;
+}
+
+export interface StuckOperationLogInput {
+  operationName: string;
+  lastLeaseExtendedAt: string;
+  domainId?: string;
+}
+
+export interface CertRenewalLogInput {
+  domainId: string;
+  daysUntilExpiry: number;
+  escalationLevel: "T-14" | "T-7" | "T-1";
+}
+
+export interface Logger {
+  info(message: string, fields?: LogFields): void;
+  warn(message: string, fields?: LogFields): void;
+  error(message: string, fields?: LogFields): void;
+  critical(message: string, fields?: LogFields): void;
+  drift(input: DriftLogInput): void;
+  stuckOperation(input: StuckOperationLogInput): void;
+  certRenewal(input: CertRenewalLogInput): void;
+}
+
+/**
+ * Build a log entry in the shape Cloud Logging expects on stdout. Callers
+ * get to inject an `emit` function so tests can capture entries instead of
+ * writing to `console.log`.
+ */
+export interface CreateLoggerOptions {
+  context: LoggerContext;
+  emit?: (line: string) => void;
+}
+
+type Labels = Record<string, string>;
+
+interface BaseEntry {
+  severity: LogSeverity;
+  message: string;
+  reconciler_instance_id: string;
+  reconciler_region: string;
+  reconciler_run_id?: string;
+  labels?: Labels;
+  [key: string]: unknown;
+}
+
+function defaultEmit(line: string): void {
+  // Cloud Logging automatically structures stdout JSON; no writer library
+  // needed. Using console.log keeps the dependency footprint at zero.
+  console.log(line);
+}
+
+function buildEntry(
+  severity: LogSeverity,
+  message: string,
+  context: LoggerContext,
+  extras: LogFields | undefined,
+  labels: Labels | undefined,
+): BaseEntry {
+  const entry: BaseEntry = {
+    severity,
+    message,
+    reconciler_instance_id: context.instanceId,
+    reconciler_region: context.region,
+  };
+  if (context.runId !== undefined) {
+    entry.reconciler_run_id = context.runId;
+  }
+  if (labels !== undefined) {
+    entry.labels = labels;
+  }
+  if (extras !== undefined) {
+    for (const [key, value] of Object.entries(extras)) {
+      if (
+        key === "severity" ||
+        key === "message" ||
+        key === "labels" ||
+        key === "reconciler_instance_id" ||
+        key === "reconciler_region" ||
+        key === "reconciler_run_id"
+      ) {
+        // Reserved keys — ignore to preserve the contract.
+        continue;
+      }
+      entry[key] = value;
+    }
+  }
+  return entry;
+}
+
+export function createLogger(options: CreateLoggerOptions): Logger {
+  const { context } = options;
+  const emit = options.emit ?? defaultEmit;
+
+  function emitEntry(
+    severity: LogSeverity,
+    message: string,
+    extras?: LogFields,
+    labels?: Labels,
+  ): void {
+    const entry = buildEntry(severity, message, context, extras, labels);
+    emit(JSON.stringify(entry));
+  }
+
+  return {
+    info(message, fields) {
+      emitEntry("INFO", message, fields);
+    },
+    warn(message, fields) {
+      emitEntry("WARNING", message, fields);
+    },
+    error(message, fields) {
+      emitEntry("ERROR", message, fields);
+    },
+    critical(message, fields) {
+      emitEntry("CRITICAL", message, fields);
+    },
+    drift(input) {
+      emitEntry(
+        "CRITICAL",
+        `reconciler drift detected: ${input.driftKind} on ${input.resourceType} ${input.resourceName}`,
+        {
+          domain_id: input.domainId,
+          drift_kind: input.driftKind,
+          resource_type: input.resourceType,
+          resource_name: input.resourceName,
+          observed_spec: input.observedSpec,
+          expected_spec: input.expectedSpec,
+          recoverable_from: input.recoverableFrom,
+        },
+        { redirect_platform_drift: "true", domain_id: input.domainId },
+      );
+    },
+    stuckOperation(input) {
+      emitEntry(
+        "CRITICAL",
+        `reconciler stuck operation: ${input.operationName} exceeded 30-minute heartbeat cap`,
+        {
+          operation_name: input.operationName,
+          last_lease_extended_at: input.lastLeaseExtendedAt,
+          ...(input.domainId !== undefined
+            ? { domain_id: input.domainId }
+            : {}),
+        },
+        {
+          redirect_platform_stuck_operation: "true",
+          ...(input.domainId !== undefined
+            ? { domain_id: input.domainId }
+            : {}),
+        },
+      );
+    },
+    certRenewal(input) {
+      emitEntry(
+        "CRITICAL",
+        `reconciler cert renewal escalation ${input.escalationLevel} for ${input.domainId} (${input.daysUntilExpiry} days until expiry)`,
+        {
+          domain_id: input.domainId,
+          days_until_expiry: input.daysUntilExpiry,
+          escalation_level: input.escalationLevel,
+        },
+        {
+          redirect_platform_cert_renewal: "true",
+          domain_id: input.domainId,
+          escalation_level: input.escalationLevel,
+        },
+      );
+    },
+  };
+}

--- a/apps/reconciler/src/process.ts
+++ b/apps/reconciler/src/process.ts
@@ -1,0 +1,75 @@
+/**
+ * Reconciler cycle entry point — scaffold stub.
+ *
+ * F3R5_009 is the scaffold only. The actual reconciler operations land
+ * in F3R5_010 (ops 1-4: DNS challenge validation, cert provisioning,
+ * SNI probe, post-cutover DNS verification) and F3R5_011 (ops 5-8:
+ * active health re-probe, tombstone cleanup, quarantine drift check,
+ * periodic drift detection).
+ *
+ * See R5 Decision 6 "Operations performed per cycle" for the
+ * authoritative spec of each operation.
+ */
+
+import type { ReconcilerDb } from "./db/client.js";
+import type { Lease, HeartbeatStatus } from "./lease.js";
+import type { Logger } from "./logging.js";
+
+export interface ProcessTransientStatesInput {
+  db: ReconcilerDb;
+  lease: Lease;
+  logger: Logger;
+  heartbeat: HeartbeatStatus;
+}
+
+// F3R5_010 / F3R5_011 will add real awaited DB work here; until then the
+// scaffold function is async to match its final shape — hence the lint
+// suppression. Remove both this comment and the disable once the first
+// real operation lands.
+// eslint-disable-next-line @typescript-eslint/require-await
+export async function processTransientStates(
+  input: ProcessTransientStatesInput,
+): Promise<void> {
+  const { logger, lease, heartbeat } = input;
+
+  logger.info(
+    "reconciler cycle started (scaffold stub — no operations implemented)",
+    {
+      lease_key: lease.leaseKey,
+      held_by: lease.heldBy,
+    },
+  );
+
+  // Crash recovery scan (R5 Decision 6): re-queue rows in transient states
+  // with `last_reconciled_at` older than 10 minutes. The real query will
+  // live here in F3R5_010.
+  // TODO(F3R5_010): SELECT id FROM region_custom_domains
+  //   WHERE lifecycle_state IN (...transient states...)
+  //     AND (last_reconciled_at IS NULL OR last_reconciled_at < now() - interval '10 minutes');
+
+  // TODO(F3R5_010): op 1 — DNS challenge validation
+  //   awaiting_dns_challenge -> provisioning_cert
+  // TODO(F3R5_010): op 2 — Cert provisioning
+  //   provisioning_cert -> awaiting_probe | degraded
+  // TODO(F3R5_010): op 3 — Multi-vantage SNI probe (Decision 4)
+  //   awaiting_probe -> awaiting_cutover | degraded
+  // TODO(F3R5_010): op 4 — Post-cutover DNS verification
+  //   awaiting_cutover -> active
+
+  // TODO(F3R5_011): op 5 — Active health re-probe
+  //   active -> degraded on ≥2 consecutive SNI probe failures
+  // TODO(F3R5_011): op 6 — Tombstone cleanup
+  //   tombstoned -> quarantined
+  // TODO(F3R5_011): op 7 — Quarantine expiry with drift check
+  //   quarantined -> released (or degraded on orphan_resource)
+  // TODO(F3R5_011): op 8 — Periodic drift detection across GCP resources
+
+  if (heartbeat.isLost()) {
+    logger.warn(
+      "reconciler lease lost before any work; scaffold stub returning",
+    );
+    return;
+  }
+
+  logger.info("reconciler cycle completed (scaffold stub)");
+}

--- a/apps/reconciler/tests/lease.test.ts
+++ b/apps/reconciler/tests/lease.test.ts
@@ -1,0 +1,310 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  HEARTBEAT_INTERVAL_MS,
+  LEASE_KEY_DOMAIN_RECONCILER,
+  LeaseLostError,
+  StuckOperationError,
+  acquireLease,
+  heartbeatLease,
+  releaseLease,
+  withHeartbeat,
+} from "../src/lease.js";
+import type { HeartbeatTimers, Lease, LeaseSqlExecutor } from "../src/lease.js";
+import type { Logger } from "../src/logging.js";
+
+/**
+ * The lease module's only surface to the database is a `postgres-js` Sql
+ * tagged-template object. Tests mock it with a recorder that returns a
+ * programmed value for each call, so we never touch a real Postgres.
+ *
+ * The tagged-template shape (`sql\`...\``) is modeled as a function that
+ * accepts TemplateStringsArray + values and returns a Promise. `sql.begin`
+ * is a function that calls its callback with a transaction object that
+ * behaves the same way.
+ */
+interface RecordedCall {
+  strings: readonly string[];
+  values: readonly unknown[];
+}
+
+interface MockSql {
+  executor: LeaseSqlExecutor;
+  calls: RecordedCall[];
+  nextResults: unknown[][];
+}
+
+function createMockSql(results: unknown[][]): MockSql {
+  const calls: RecordedCall[] = [];
+  const nextResults = [...results];
+
+  function tagged(
+    strings: TemplateStringsArray,
+    ...values: unknown[]
+  ): Promise<unknown[]> {
+    calls.push({ strings: [...strings], values });
+    const result = nextResults.shift();
+    return Promise.resolve(result ?? []);
+  }
+
+  const executor = tagged as unknown as LeaseSqlExecutor;
+  (executor as unknown as { begin: unknown }).begin = async (
+    cb: (tx: LeaseSqlExecutor) => Promise<unknown>,
+  ) => cb(executor);
+  (executor as unknown as { unsafe: unknown }).unsafe = () => {
+    throw new Error("unsafe() not used in lease module");
+  };
+
+  return { executor, calls, nextResults };
+}
+
+const SAMPLE_ROW = {
+  lease_key: LEASE_KEY_DOMAIN_RECONCILER,
+  held_by: "test-instance-1",
+  acquired_at: "2026-04-14T10:00:00.000Z",
+  expires_at: "2026-04-14T10:04:00.000Z",
+};
+
+describe("acquireLease", () => {
+  it("returns the claimed lease when INSERT returns a row", async () => {
+    // First call is DELETE (no rows), second call is INSERT with a row.
+    const mock = createMockSql([[], [SAMPLE_ROW]]);
+    const lease = await acquireLease(mock.executor, {
+      instanceId: "test-instance-1",
+    });
+    expect(lease).not.toBeNull();
+    expect(lease?.leaseKey).toBe(LEASE_KEY_DOMAIN_RECONCILER);
+    expect(lease?.heldBy).toBe("test-instance-1");
+    expect(lease?.acquiredAt).toBe("2026-04-14T10:00:00.000Z");
+    expect(lease?.expiresAt).toBe("2026-04-14T10:04:00.000Z");
+    expect(mock.calls).toHaveLength(2);
+    // Basic sanity: the DELETE + INSERT SQL is present in the call record.
+    expect(mock.calls[0]?.strings.join("")).toContain(
+      "DELETE FROM reconciler_leases",
+    );
+    expect(mock.calls[1]?.strings.join("")).toContain(
+      "INSERT INTO reconciler_leases",
+    );
+    expect(mock.calls[1]?.strings.join("")).toContain(
+      "ON CONFLICT (lease_key) DO NOTHING",
+    );
+  });
+
+  it("returns null when INSERT returns no rows (another instance holds lease)", async () => {
+    const mock = createMockSql([[], []]);
+    const lease = await acquireLease(mock.executor, {
+      instanceId: "test-instance-2",
+    });
+    expect(lease).toBeNull();
+  });
+});
+
+describe("heartbeatLease", () => {
+  const lease: Lease = {
+    leaseKey: LEASE_KEY_DOMAIN_RECONCILER,
+    heldBy: "test-instance-1",
+    acquiredAt: "2026-04-14T10:00:00.000Z",
+    expiresAt: "2026-04-14T10:04:00.000Z",
+  };
+
+  it("returns the new expiry when UPDATE matches", async () => {
+    const mock = createMockSql([[{ expires_at: "2026-04-14T10:04:30.000Z" }]]);
+    const result = await heartbeatLease(mock.executor, lease);
+    expect(result).not.toBeNull();
+    expect(result?.newExpiresAt).toBe("2026-04-14T10:04:30.000Z");
+    expect(mock.calls[0]?.strings.join("")).toContain(
+      "UPDATE reconciler_leases",
+    );
+    expect(mock.calls[0]?.strings.join("")).toContain("expires_at > timezone");
+  });
+
+  it("returns null when the lease was stolen (UPDATE zero rows)", async () => {
+    const mock = createMockSql([[]]);
+    const result = await heartbeatLease(mock.executor, lease);
+    expect(result).toBeNull();
+  });
+});
+
+describe("releaseLease", () => {
+  it("is idempotent — does not throw on zero affected rows", async () => {
+    const mock = createMockSql([[]]);
+    await expect(
+      releaseLease(mock.executor, {
+        leaseKey: LEASE_KEY_DOMAIN_RECONCILER,
+        heldBy: "test-instance-1",
+        acquiredAt: "2026-04-14T10:00:00.000Z",
+        expiresAt: "2026-04-14T10:04:00.000Z",
+      }),
+    ).resolves.toBeUndefined();
+    expect(mock.calls[0]?.strings.join("")).toContain(
+      "DELETE FROM reconciler_leases",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// withHeartbeat — uses fake timers + injected heartbeatFn
+// ---------------------------------------------------------------------------
+
+interface FakeTimerController extends HeartbeatTimers {
+  advance(ms: number): Promise<void>;
+}
+
+function createFakeTimers(start = 0): FakeTimerController {
+  let current = start;
+  let nextId = 1;
+  const intervals: { id: number; cb: () => void; ms: number; last: number }[] =
+    [];
+
+  async function flush(): Promise<void> {
+    // Allow queued microtasks (heartbeat promise chains) to settle so the
+    // async effects of each tick are visible to the test.
+    for (let i = 0; i < 5; i++) {
+      await Promise.resolve();
+    }
+  }
+
+  return {
+    setInterval(cb, ms) {
+      const id = nextId++;
+      intervals.push({ id, cb, ms, last: current });
+      return id as unknown as NodeJS.Timeout;
+    },
+    clearInterval(handle) {
+      const idx = intervals.findIndex(
+        (i) => i.id === (handle as unknown as number),
+      );
+      if (idx >= 0) intervals.splice(idx, 1);
+    },
+    now() {
+      return current;
+    },
+    async advance(ms) {
+      const target = current + ms;
+      while (current < target) {
+        // Find the earliest next firing.
+        let next = target;
+        for (const iv of intervals) {
+          const fireAt = iv.last + iv.ms;
+          if (fireAt < next) next = fireAt;
+        }
+        current = next;
+        // Fire all intervals whose time has come.
+        for (const iv of intervals) {
+          if (iv.last + iv.ms <= current) {
+            iv.last = current;
+            iv.cb();
+          }
+        }
+        await flush();
+      }
+    },
+  };
+}
+
+describe("withHeartbeat", () => {
+  const loggerError = vi.fn();
+  const loggerStuckOperation = vi.fn();
+  const logger: Logger = {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: loggerError,
+    critical: vi.fn(),
+    drift: vi.fn(),
+    stuckOperation: loggerStuckOperation,
+    certRenewal: vi.fn(),
+  };
+
+  const lease: Lease = {
+    leaseKey: LEASE_KEY_DOMAIN_RECONCILER,
+    heldBy: "test-instance-1",
+    acquiredAt: "2026-04-14T10:00:00.000Z",
+    expiresAt: "2026-04-14T10:04:00.000Z",
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("runs fn to completion when the heartbeat keeps succeeding", async () => {
+    const mock = createMockSql([]);
+    const timers = createFakeTimers();
+    const heartbeatFn = vi.fn(() => Promise.resolve({ newExpiresAt: "later" }));
+
+    const result = await withHeartbeat(
+      {
+        sql: mock.executor,
+        lease,
+        logger,
+        heartbeatFn,
+        timers,
+        operationName: "test-op",
+      },
+      async () => {
+        // Advance past 3 intervals to exercise the heartbeat timer.
+        await timers.advance(HEARTBEAT_INTERVAL_MS * 3);
+        return "ok";
+      },
+    );
+
+    expect(result).toBe("ok");
+    expect(heartbeatFn).toHaveBeenCalledTimes(3);
+  });
+
+  it("throws LeaseLostError when the heartbeat returns null", async () => {
+    const mock = createMockSql([]);
+    const timers = createFakeTimers();
+    const heartbeatFn = vi.fn(() => Promise.resolve(null));
+
+    await expect(
+      withHeartbeat(
+        {
+          sql: mock.executor,
+          lease,
+          logger,
+          heartbeatFn,
+          timers,
+          operationName: "test-op",
+        },
+        async (status) => {
+          await timers.advance(HEARTBEAT_INTERVAL_MS);
+          // Caller observes the lost status and returns; wrapper should
+          // still throw LeaseLostError.
+          expect(status.isLost()).toBe(true);
+        },
+      ),
+    ).rejects.toBeInstanceOf(LeaseLostError);
+    expect(loggerError).toHaveBeenCalledWith(
+      "reconciler lease lost during heartbeat",
+      expect.objectContaining({ operation: "test-op" }),
+    );
+  });
+
+  it("throws StuckOperationError after exceeding the hard cap", async () => {
+    const mock = createMockSql([]);
+    const timers = createFakeTimers();
+    const heartbeatFn = vi.fn(() => Promise.resolve({ newExpiresAt: "later" }));
+
+    await expect(
+      withHeartbeat(
+        {
+          sql: mock.executor,
+          lease,
+          logger,
+          heartbeatFn,
+          timers,
+          maxDurationMs: HEARTBEAT_INTERVAL_MS * 2,
+          operationName: "test-op",
+        },
+        async () => {
+          // Cross the cap: advance 3 intervals; the 3rd tick should log
+          // stuckOperation and throw on return.
+          await timers.advance(HEARTBEAT_INTERVAL_MS * 3);
+        },
+      ),
+    ).rejects.toBeInstanceOf(StuckOperationError);
+    expect(loggerStuckOperation).toHaveBeenCalledWith(
+      expect.objectContaining({ operationName: "test-op" }),
+    );
+  });
+});

--- a/apps/reconciler/tests/logging.test.ts
+++ b/apps/reconciler/tests/logging.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it } from "vitest";
+
+import { createLogger } from "../src/logging.js";
+
+/**
+ * The log shapes asserted here are an interop contract with the F3R5_003
+ * alert_policies.tf filter expressions:
+ *
+ *   severity=CRITICAL
+ *   jsonPayload.labels.redirect_platform_drift="true"
+ *   jsonPayload.labels.redirect_platform_stuck_operation="true"
+ *   jsonPayload.labels.redirect_platform_cert_renewal="true"
+ *
+ * Cloud Logging lifts top-level stdout JSON fields into `jsonPayload`, so
+ * emitting `labels.redirect_platform_*="true"` at the top of the stdout
+ * object yields `jsonPayload.labels.redirect_platform_*="true"` on the
+ * Cloud Logging entry, which is what the alert filters match.
+ */
+
+type LogEntry = Record<string, unknown>;
+
+function capture(): {
+  lines: string[];
+  emit: (line: string) => void;
+} {
+  const lines: string[] = [];
+  return {
+    lines,
+    emit: (line) => {
+      lines.push(line);
+    },
+  };
+}
+
+function parseLog(line: string | undefined): LogEntry {
+  if (line === undefined) {
+    throw new Error("parseLog: expected a captured log line but got undefined");
+  }
+  return JSON.parse(line) as LogEntry;
+}
+
+const baseContext = {
+  instanceId: "us-central1-exec-abc-task0-deadbe",
+  region: "us-central1",
+  runId: "run-1234",
+};
+
+describe("createLogger basic severities", () => {
+  it("emits INFO/WARNING/ERROR/CRITICAL with instance+region metadata", () => {
+    const { lines, emit } = capture();
+    const log = createLogger({ context: baseContext, emit });
+
+    log.info("info msg");
+    log.warn("warn msg");
+    log.error("error msg");
+    log.critical("critical msg");
+
+    expect(lines).toHaveLength(4);
+    const entries = lines.map((l) => parseLog(l));
+    expect(entries[0]).toMatchObject({
+      severity: "INFO",
+      message: "info msg",
+      reconciler_instance_id: baseContext.instanceId,
+      reconciler_region: baseContext.region,
+      reconciler_run_id: baseContext.runId,
+    });
+    expect(entries[1]).toMatchObject({ severity: "WARNING" });
+    expect(entries[2]).toMatchObject({ severity: "ERROR" });
+    expect(entries[3]).toMatchObject({ severity: "CRITICAL" });
+  });
+
+  it("ignores reserved fields in extras so the contract is preserved", () => {
+    const { lines, emit } = capture();
+    const log = createLogger({ context: baseContext, emit });
+    log.info("hello", {
+      severity: "HACKED",
+      message: "HACKED",
+      labels: { redirect_platform_drift: "true" },
+      custom: "ok",
+    });
+    const entry = parseLog(lines[0]);
+    expect(entry.severity).toBe("INFO");
+    expect(entry.message).toBe("hello");
+    expect(entry.labels).toBeUndefined();
+    expect(entry.custom).toBe("ok");
+  });
+});
+
+describe("log.drift — redirect_platform_drift label contract", () => {
+  it("emits severity=CRITICAL with labels.redirect_platform_drift='true'", () => {
+    const { lines, emit } = capture();
+    const log = createLogger({ context: baseContext, emit });
+    log.drift({
+      domainId: "abc123",
+      driftKind: "spec_mismatch",
+      resourceType: "Certificate",
+      resourceName: "cert-abc123",
+      observedSpec: { managed: { state: "FAILED" } },
+      expectedSpec: { managed: { state: "ACTIVE" } },
+      recoverableFrom: "awaiting_dns_challenge",
+    });
+
+    expect(lines).toHaveLength(1);
+    const entry = parseLog(lines[0]);
+    expect(entry.severity).toBe("CRITICAL");
+    expect(entry.labels).toEqual({
+      redirect_platform_drift: "true",
+      domain_id: "abc123",
+    });
+    expect(entry.drift_kind).toBe("spec_mismatch");
+    expect(entry.resource_type).toBe("Certificate");
+    expect(entry.resource_name).toBe("cert-abc123");
+    expect(entry.domain_id).toBe("abc123");
+    expect(entry.observed_spec).toEqual({ managed: { state: "FAILED" } });
+    expect(entry.expected_spec).toEqual({ managed: { state: "ACTIVE" } });
+    expect(entry.recoverable_from).toBe("awaiting_dns_challenge");
+  });
+});
+
+describe("log.stuckOperation — redirect_platform_stuck_operation label contract", () => {
+  it("emits severity=CRITICAL with labels.redirect_platform_stuck_operation='true'", () => {
+    const { lines, emit } = capture();
+    const log = createLogger({ context: baseContext, emit });
+    log.stuckOperation({
+      operationName: "processTransientStates",
+      lastLeaseExtendedAt: "2026-04-14T10:30:00.000Z",
+    });
+
+    expect(lines).toHaveLength(1);
+    const entry = parseLog(lines[0]);
+    expect(entry.severity).toBe("CRITICAL");
+    expect(entry.labels).toEqual({
+      redirect_platform_stuck_operation: "true",
+    });
+    expect(entry.operation_name).toBe("processTransientStates");
+    expect(entry.last_lease_extended_at).toBe("2026-04-14T10:30:00.000Z");
+  });
+
+  it("carries domain_id through labels and payload when provided", () => {
+    const { lines, emit } = capture();
+    const log = createLogger({ context: baseContext, emit });
+    log.stuckOperation({
+      operationName: "cert-issuance",
+      lastLeaseExtendedAt: "2026-04-14T10:30:00.000Z",
+      domainId: "dom-xyz",
+    });
+    const entry = parseLog(lines[0]);
+    expect(entry.labels).toMatchObject({ domain_id: "dom-xyz" });
+    expect(entry.domain_id).toBe("dom-xyz");
+  });
+});
+
+describe("log.certRenewal — redirect_platform_cert_renewal label contract", () => {
+  it("emits severity=CRITICAL with labels.redirect_platform_cert_renewal='true'", () => {
+    const { lines, emit } = capture();
+    const log = createLogger({ context: baseContext, emit });
+    log.certRenewal({
+      domainId: "dom-abc",
+      daysUntilExpiry: 1,
+      escalationLevel: "T-1",
+    });
+    const entry = parseLog(lines[0]);
+    expect(entry.severity).toBe("CRITICAL");
+    expect(entry.labels).toEqual({
+      redirect_platform_cert_renewal: "true",
+      domain_id: "dom-abc",
+      escalation_level: "T-1",
+    });
+    expect(entry.days_until_expiry).toBe(1);
+  });
+});

--- a/apps/reconciler/tsconfig.build.json
+++ b/apps/reconciler/tsconfig.build.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": false,
+    "sourceMap": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "tsBuildInfoFile": "dist/.tsbuildinfo"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist", "tests"]
+}

--- a/apps/reconciler/tsconfig.json
+++ b/apps/reconciler/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../tooling/typescript/base.json",
+  "compilerOptions": {
+    // Pure Node.js app: override the base (which is shared across Next.js
+    // apps and therefore includes DOM libs) to a Node-only `lib` + `types`,
+    // and use `nodenext` module/moduleResolution so `tsc` emits real Node
+    // ESM for the `start` script (build target is a Cloud Run Job, not a
+    // bundled Next.js app).
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "lib": ["ES2022"],
+    "types": ["node"],
+    "rootDir": ".",
+    "noEmit": true,
+    "tsBuildInfoFile": "node_modules/.cache/tsbuildinfo.json"
+  },
+  "include": ["src/**/*.ts", "tests/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/apps/reconciler/vitest.config.mts
+++ b/apps/reconciler/vitest.config.mts
@@ -1,0 +1,17 @@
+import { defineConfig } from "vitest/config";
+
+// f3-nation does not have a shared vitest preset package; other packages
+// (e.g. `packages/api/vitest.config.ts`) each define a standalone config.
+// We mirror that pattern here.
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["tests/**/*.test.ts"],
+    globals: false,
+    coverage: {
+      include: ["src/**/*.ts"],
+      exclude: ["src/index.ts"],
+    },
+  },
+});
+

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,7 +99,7 @@ importers:
         version: 3.1.1(react@18.3.1)
       '@scalar/nextjs-api-reference':
         specifier: ^0.9.5
-        version: 0.9.26(next@15.5.14(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
+        version: 0.9.26(next@15.5.14(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
       '@sentry/nextjs':
         specifier: ^9.15.0
         version: 9.47.1(@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1))(next@15.5.14(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(webpack@5.105.4)
@@ -601,6 +601,43 @@ importers:
       vitest-canvas-mock:
         specifier: ^0.3.3
         version: 0.3.3(vitest@1.6.1(@types/node@20.19.39)(jsdom@24.1.3)(terser@5.46.1))
+
+  apps/reconciler:
+    dependencies:
+      '@acme/redirect-platform-db':
+        specifier: workspace:*
+        version: link:../../packages/redirect-platform-db
+      drizzle-orm:
+        specifier: ^0.39.3
+        version: 0.39.3(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.20.0)(postgres@3.4.9)
+      postgres:
+        specifier: ^3.4.3
+        version: 3.4.9
+    devDependencies:
+      '@acme/eslint-config':
+        specifier: workspace:^0.2.0
+        version: link:../../tooling/eslint
+      '@acme/prettier-config':
+        specifier: workspace:^0.1.0
+        version: link:../../tooling/prettier
+      '@acme/tsconfig':
+        specifier: workspace:^0.1.0
+        version: link:../../tooling/typescript
+      '@types/node':
+        specifier: ^20.11.13
+        version: 20.19.39
+      eslint:
+        specifier: ^8.56.0
+        version: 8.57.1
+      prettier:
+        specifier: 3.2.5
+        version: 3.2.5
+      typescript:
+        specifier: 5.3.3
+        version: 5.3.3
+      vitest:
+        specifier: ^1.5.0
+        version: 1.6.1(@types/node@20.19.39)(jsdom@24.1.3)(terser@5.46.1)
 
   packages/api:
     dependencies:
@@ -11305,7 +11342,7 @@ snapshots:
 
   '@scalar/helpers@0.2.18': {}
 
-  '@scalar/nextjs-api-reference@0.9.26(next@15.5.14(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)':
+  '@scalar/nextjs-api-reference@0.9.26(next@15.5.14(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@scalar/core': 0.3.45
       next: 15.5.14(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)


### PR DESCRIPTION
## Summary

Reconciler Cloud Run job scaffold per R5 Decision 6. Landed in the f3-nation monorepo so it can share `@acme/redirect-platform-db` directly with `apps/redirect-admin` (schema-sharing decision: Option A — monorepo consolidation).

- `@acme/reconciler` package with singleton lease (exact SQL from Decision 6), heartbeat runner with 30-min cap, structured logging matching the Cloud Monitoring alert filter contract
- Neon Drizzle client factory
- Stubbed \`processTransientStates\` entry point — real reconciler operations 1-4 land in the follow-up PR (F3R5_010) and operations 5-8 in F3R5_011
- 14 tests pass (lease acquire/heartbeat/release + logging label contract assertions)
- `Dockerfile` at `apps/reconciler/Dockerfile` using turbo-prune → pnpm → build pattern

## Log label contract (critical interop)

The logger emits top-level stdout JSON with `severity: "CRITICAL"` and a top-level `labels` object with string values. Cloud Logging promotes top-level JSON into `jsonPayload` at ingest. The resulting log entry path is `jsonPayload.labels.redirect_platform_drift="true"` (and equivalent for `stuck_operation`, `cert_renewal`), which exactly matches the filters in the Cloud Monitoring alert policies defined in F3-Nation/f3-redirect on branch `feat/r5-phase0-infra` (`infra/terraform/shared-platform/alert_policies.tf`). `tests/logging.test.ts` asserts this shape verbatim — a regression would fail CI.

## Migration history

This branch is the result of F3R5_015 — the reconciler was originally scaffolded in F3-Nation/f3-redirect on branch `feat/r5-reconciler-scaffold` (HEAD `87909d4`), then migrated to this monorepo. The original branch is now orphaned. The migration dropped a stub schema file entirely and switched to a single import of `schema` from `@acme/redirect-platform-db`.

## Stack

1. **`feat/r5-redirect-platform-db`** (base) — schema package
2. **`feat/r5-reconciler`** (this PR) — scaffold on top of schema
3. **`feat/r5-reconciler-ops-1-4`** (upcoming F3R5_010) — real operations on top of this scaffold
4. **`feat/r5-reconciler-ops-5-8`** (upcoming F3R5_011) — more operations on top of ops 1-4

Merge order follows the stack: schema first, then this, then ops 1-4, then ops 5-8.

## Test plan

- [x] `pnpm --filter @acme/reconciler typecheck` clean
- [x] `pnpm --filter @acme/reconciler lint` clean
- [x] `pnpm --filter @acme/reconciler test` — 14/14 pass
- [x] `pnpm --filter @acme/reconciler build` clean
- [x] Whole-repo turbo typecheck + lint + build pass
- [ ] Real reconciler operations implemented (F3R5_010, F3R5_011)
- [ ] Integration test against a live Neon dev branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)