### PR TITLE
R5 Phase 1: reconciler ops 1-4 (DNS challenge, cert provisioning, SNI probe, post-cutover)

### DIFF
--- a/apps/reconciler/package.json
+++ b/apps/reconciler/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@acme/redirect-platform-db": "workspace:*",
+    "@google-cloud/certificate-manager": "^2.1.1",
     "drizzle-orm": "^0.39.3",
     "postgres": "^3.4.3"
   },
@@ -25,6 +26,7 @@
     "@types/node": "^20.11.13",
     "eslint": "^8.56.0",
     "prettier": "^3.2.5",
+    "selfsigned": "^5.5.0",
     "typescript": "^5.3.3",
     "vitest": "^1.5.0"
   },
@@ -36,6 +38,18 @@
     "ignorePatterns": [
       "dist",
       "vitest.config.mts"
+    ],
+    "overrides": [
+      {
+        "files": [
+          "tests/**/*.ts"
+        ],
+        "rules": {
+          "@typescript-eslint/require-await": "off",
+          "@typescript-eslint/no-empty-function": "off",
+          "@typescript-eslint/no-non-null-assertion": "off"
+        }
+      }
     ]
   },
   "prettier": "@acme/prettier-config"

--- a/apps/reconciler/src/gcp/cert-manager-client.ts
+++ b/apps/reconciler/src/gcp/cert-manager-client.ts
@@ -1,0 +1,342 @@
+/**
+ * Thin wrapper over @google-cloud/certificate-manager.
+ *
+ * The official client is gRPC-based and long-operation-heavy. This module
+ * exposes the small, opinionated surface the reconciler actually needs:
+ *
+ *   - `getDnsAuthorization(id)` → DnsAuthorization | null
+ *   - `createCertificate({...})` → void  (await LRO to settle name only)
+ *   - `getCertificate(id)` → Certificate
+ *   - `getCertificateMapEntry(id)` → CertificateMapEntry
+ *   - `createCertificateMapEntry({...})` → void
+ *
+ * All calls go through `mapGcpError` so callers branch via typed errors
+ * (NotFoundError / AlreadyExistsError / PermissionDeniedError) instead of
+ * inspecting raw google-gax objects. R5 Decision 6's "ALREADY_EXISTS as
+ * success path" pattern is implemented at the operation layer; this module
+ * just surfaces the error in a typed way.
+ *
+ * Long-running operations: Certificate Manager CREATE methods return an
+ * `LROperation`. For the reconciler's state-machine use case we always
+ * `await op.promise()` — if CREATE returns ALREADY_EXISTS, the error is
+ * surfaced immediately (before the LRO starts) and we re-GET. If the CREATE
+ * is accepted, we wait for the LRO to settle before returning so the row
+ * can transition to the next state confident the resource exists.
+ *
+ * The client is constructed lazily on first use; tests inject a mocked
+ * client via `setCertManagerClientForTesting()`.
+ */
+
+import { CertificateManagerClient } from "@google-cloud/certificate-manager";
+
+import { NotFoundError, mapGcpError } from "./errors.js";
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+export interface CertManagerConfig {
+  /** GCP project that owns the LB and Certificate Manager resources. */
+  projectId: string;
+  /**
+   * Certificate Manager is a GLOBAL product — all resources live under
+   * `locations/global`. We keep this a config field so future regional
+   * variants don't require a rewrite.
+   */
+  location: string;
+  /** Name of the target Certificate Map (Terraform: redirect-platform-cert-map). */
+  certMapName: string;
+}
+
+export function loadCertManagerConfig(
+  env: NodeJS.ProcessEnv = process.env,
+): CertManagerConfig {
+  return {
+    projectId: env.GCP_PROJECT_ID ?? "f3-redirects",
+    location: "global",
+    certMapName: env.REDIRECT_CERT_MAP_NAME ?? "redirect-platform-cert-map",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Types — narrow projections of the upstream protos
+// ---------------------------------------------------------------------------
+
+export interface DnsAuthorizationView {
+  /** Full resource path, e.g. `projects/f3-redirects/locations/global/dnsAuthorizations/dns-auth-<uuid>`. */
+  name: string;
+  domain: string;
+  state: string;
+  /** Records the user has to add as a CNAME to validate the authorization. */
+  dnsResourceRecord: {
+    name: string;
+    type: string;
+    data: string;
+  } | null;
+}
+
+export interface CertificateView {
+  name: string;
+  managed: {
+    domains: string[];
+    dnsAuthorizations: string[];
+    state: string;
+    /** Extracted from `authorizationAttemptInfo[0].details` for FAILED certs. */
+    failureDetails: string | null;
+  } | null;
+}
+
+export interface CertificateMapEntryView {
+  name: string;
+  hostname: string;
+  /** Full resource path of the attached Certificate. */
+  certificates: string[];
+}
+
+export interface CreateCertificateInput {
+  certificateId: string;
+  domain: string;
+  dnsAuthorizationName: string;
+}
+
+export interface CreateCertificateMapEntryInput {
+  entryId: string;
+  hostname: string;
+  certificateName: string;
+}
+
+// ---------------------------------------------------------------------------
+// Client interface (for test injection)
+// ---------------------------------------------------------------------------
+
+export interface CertManagerClient {
+  getDnsAuthorization(id: string): Promise<DnsAuthorizationView | null>;
+  getCertificate(id: string): Promise<CertificateView>;
+  createCertificate(input: CreateCertificateInput): Promise<void>;
+  getCertificateMapEntry(id: string): Promise<CertificateMapEntryView | null>;
+  createCertificateMapEntry(
+    input: CreateCertificateMapEntryInput,
+  ): Promise<void>;
+  /** Return the full resource path for a DnsAuthorization id. */
+  dnsAuthorizationResourcePath(id: string): string;
+  /** Return the full resource path for a Certificate id. */
+  certificateResourcePath(id: string): string;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers to access google-gax LRO .promise() without using `any`
+// ---------------------------------------------------------------------------
+
+interface LongRunningOp<T> {
+  promise(): Promise<[T, unknown, unknown]>;
+}
+
+function isLongRunningOp<T>(value: unknown): value is LongRunningOp<T> {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "promise" in value &&
+    typeof (value as { promise: unknown }).promise === "function"
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Narrow proto-view projections — defensively typed
+// ---------------------------------------------------------------------------
+
+function asString(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+function asStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((v): v is string => typeof v === "string");
+}
+
+function projectDnsAuthorization(raw: unknown): DnsAuthorizationView {
+  const obj = (raw ?? {}) as Record<string, unknown>;
+  const dnsResource = (obj.dnsResourceRecord ?? null) as Record<
+    string,
+    unknown
+  > | null;
+  return {
+    name: asString(obj.name),
+    domain: asString(obj.domain),
+    state: asString(obj.state),
+    dnsResourceRecord: dnsResource
+      ? {
+          name: asString(dnsResource.name),
+          type: asString(dnsResource.type),
+          data: asString(dnsResource.data),
+        }
+      : null,
+  };
+}
+
+function projectCertificate(raw: unknown): CertificateView {
+  const obj = (raw ?? {}) as Record<string, unknown>;
+  const managed = obj.managed as Record<string, unknown> | null | undefined;
+  if (!managed) {
+    return { name: asString(obj.name), managed: null };
+  }
+  let failureDetails: string | null = null;
+  const attemptInfoRaw = managed.authorizationAttemptInfo;
+  if (Array.isArray(attemptInfoRaw) && attemptInfoRaw.length > 0) {
+    const first = attemptInfoRaw[0] as Record<string, unknown> | undefined;
+    if (first && typeof first.details === "string") {
+      failureDetails = first.details;
+    }
+  }
+  return {
+    name: asString(obj.name),
+    managed: {
+      domains: asStringArray(managed.domains),
+      dnsAuthorizations: asStringArray(managed.dnsAuthorizations),
+      state: asString(managed.state),
+      failureDetails,
+    },
+  };
+}
+
+function projectCertificateMapEntry(raw: unknown): CertificateMapEntryView {
+  const obj = (raw ?? {}) as Record<string, unknown>;
+  return {
+    name: asString(obj.name),
+    hostname: asString(obj.hostname),
+    certificates: asStringArray(obj.certificates),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Real implementation backed by @google-cloud/certificate-manager
+// ---------------------------------------------------------------------------
+
+/**
+ * Subset of CertificateManagerClient we actually use. Declaring it as a
+ * structural interface lets us mock without pulling in the heavy proto types.
+ */
+export interface UpstreamCertManagerClient {
+  getDnsAuthorization(req: { name: string }): Promise<[unknown]>;
+  getCertificate(req: { name: string }): Promise<[unknown]>;
+  createCertificate(req: {
+    parent: string;
+    certificateId: string;
+    certificate: unknown;
+  }): Promise<[unknown]>;
+  getCertificateMapEntry(req: { name: string }): Promise<[unknown]>;
+  createCertificateMapEntry(req: {
+    parent: string;
+    certificateMapEntryId: string;
+    certificateMapEntry: unknown;
+  }): Promise<[unknown]>;
+}
+
+export function createCertManagerClient(
+  config: CertManagerConfig,
+  upstream?: UpstreamCertManagerClient,
+): CertManagerClient {
+  const client: UpstreamCertManagerClient =
+    upstream ??
+    (new CertificateManagerClient() as unknown as UpstreamCertManagerClient);
+
+  const parent = `projects/${config.projectId}/locations/${config.location}`;
+  const certMapParent = `${parent}/certificateMaps/${config.certMapName}`;
+
+  function dnsAuthorizationResourcePath(id: string): string {
+    return `${parent}/dnsAuthorizations/${id}`;
+  }
+  function certificateResourcePath(id: string): string {
+    return `${parent}/certificates/${id}`;
+  }
+  function certificateMapEntryResourcePath(id: string): string {
+    return `${certMapParent}/certificateMapEntries/${id}`;
+  }
+
+  async function waitForLro<T>(value: unknown): Promise<void> {
+    if (isLongRunningOp<T>(value)) {
+      await value.promise();
+    }
+  }
+
+  return {
+    dnsAuthorizationResourcePath,
+    certificateResourcePath,
+
+    async getDnsAuthorization(id) {
+      const name = dnsAuthorizationResourcePath(id);
+      try {
+        return await mapGcpError("DnsAuthorization", name, async () => {
+          const [raw] = await client.getDnsAuthorization({ name });
+          return projectDnsAuthorization(raw);
+        });
+      } catch (err) {
+        if (err instanceof NotFoundError) {
+          return null;
+        }
+        throw err;
+      }
+    },
+
+    async getCertificate(id) {
+      const name = certificateResourcePath(id);
+      return mapGcpError("Certificate", name, async () => {
+        const [raw] = await client.getCertificate({ name });
+        return projectCertificate(raw);
+      });
+    },
+
+    async createCertificate(input) {
+      const name = certificateResourcePath(input.certificateId);
+      await mapGcpError("Certificate", name, async () => {
+        const [op] = await client.createCertificate({
+          parent,
+          certificateId: input.certificateId,
+          certificate: {
+            managed: {
+              domains: [input.domain],
+              dnsAuthorizations: [input.dnsAuthorizationName],
+            },
+          },
+        });
+        await waitForLro(op);
+      });
+    },
+
+    async getCertificateMapEntry(id) {
+      const name = certificateMapEntryResourcePath(id);
+      try {
+        return await mapGcpError("CertificateMapEntry", name, async () => {
+          const [raw] = await client.getCertificateMapEntry({ name });
+          return projectCertificateMapEntry(raw);
+        });
+      } catch (err) {
+        if (err instanceof NotFoundError) {
+          return null;
+        }
+        throw err;
+      }
+    },
+
+    async createCertificateMapEntry(input) {
+      const name = certificateMapEntryResourcePath(input.entryId);
+      await mapGcpError("CertificateMapEntry", name, async () => {
+        const [op] = await client.createCertificateMapEntry({
+          parent: certMapParent,
+          certificateMapEntryId: input.entryId,
+          certificateMapEntry: {
+            hostname: input.hostname,
+            certificates: [input.certificateName],
+          },
+        });
+        await waitForLro(op);
+      });
+    },
+  };
+}
+
+// Re-exports for convenience.
+export {
+  AlreadyExistsError,
+  NotFoundError,
+  PermissionDeniedError,
+} from "./errors.js";

--- a/apps/reconciler/src/gcp/errors.ts
+++ b/apps/reconciler/src/gcp/errors.ts
@@ -1,0 +1,105 @@
+/**
+ * Typed error classes for the reconciler's GCP Certificate Manager calls.
+ *
+ * We translate google-gax's numeric gRPC status codes into domain errors so
+ * call sites can branch via `instanceof` instead of inspecting anonymous
+ * error objects. The mapping follows the standard gRPC status enum:
+ *
+ *   5 = NOT_FOUND
+ *   6 = ALREADY_EXISTS
+ *   7 = PERMISSION_DENIED
+ *
+ * See https://github.com/googleapis/googleapis/blob/master/google/rpc/code.proto
+ *
+ * R5 Decision 6 treats `ALREADY_EXISTS` as an explicit success path: on
+ * CREATE it means a prior run already built the resource (lease-expiry
+ * mid-operation window). The reconciler re-GETs and verifies the spec.
+ */
+
+export const GRPC_STATUS_NOT_FOUND = 5;
+export const GRPC_STATUS_ALREADY_EXISTS = 6;
+export const GRPC_STATUS_PERMISSION_DENIED = 7;
+
+/**
+ * Shape of a google-gax error. We intentionally type it as a loose record
+ * and narrow via `hasCode`, because google-gax ships `any`-typed errors
+ * and this project's lint rules forbid `any`.
+ */
+interface GaxLikeError {
+  code?: number;
+  message?: string;
+  details?: string;
+}
+
+function isGaxLikeError(err: unknown): err is GaxLikeError {
+  return typeof err === "object" && err !== null;
+}
+
+export class NotFoundError extends Error {
+  constructor(
+    public readonly resourceKind: string,
+    public readonly resourceName: string,
+    cause?: unknown,
+  ) {
+    super(`GCP ${resourceKind} not found: ${resourceName}`);
+    this.name = "NotFoundError";
+    if (cause !== undefined) {
+      (this as Error & { cause?: unknown }).cause = cause;
+    }
+  }
+}
+
+export class AlreadyExistsError extends Error {
+  constructor(
+    public readonly resourceKind: string,
+    public readonly resourceName: string,
+    cause?: unknown,
+  ) {
+    super(`GCP ${resourceKind} already exists: ${resourceName}`);
+    this.name = "AlreadyExistsError";
+    if (cause !== undefined) {
+      (this as Error & { cause?: unknown }).cause = cause;
+    }
+  }
+}
+
+export class PermissionDeniedError extends Error {
+  constructor(
+    public readonly resourceKind: string,
+    public readonly resourceName: string,
+    cause?: unknown,
+  ) {
+    super(`GCP ${resourceKind} permission denied: ${resourceName}`);
+    this.name = "PermissionDeniedError";
+    if (cause !== undefined) {
+      (this as Error & { cause?: unknown }).cause = cause;
+    }
+  }
+}
+
+/**
+ * Wraps a promise-returning GCP call. On rejection, translates known
+ * gRPC status codes to our domain errors; unknown errors are rethrown.
+ */
+export async function mapGcpError<T>(
+  resourceKind: string,
+  resourceName: string,
+  fn: () => Promise<T>,
+): Promise<T> {
+  try {
+    return await fn();
+  } catch (err) {
+    if (isGaxLikeError(err) && typeof err.code === "number") {
+      if (err.code === GRPC_STATUS_NOT_FOUND) {
+        throw new NotFoundError(resourceKind, resourceName, err);
+      }
+      if (err.code === GRPC_STATUS_ALREADY_EXISTS) {
+        throw new AlreadyExistsError(resourceKind, resourceName, err);
+      }
+      if (err.code === GRPC_STATUS_PERMISSION_DENIED) {
+        throw new PermissionDeniedError(resourceKind, resourceName, err);
+      }
+    }
+    throw err;
+  }
+}

--- a/apps/reconciler/src/gcp/index.ts
+++ b/apps/reconciler/src/gcp/index.ts
@@ -1,0 +1,23 @@
+export {
+  AlreadyExistsError,
+  NotFoundError,
+  PermissionDeniedError,
+  mapGcpError,
+  GRPC_STATUS_ALREADY_EXISTS,
+  GRPC_STATUS_NOT_FOUND,
+  GRPC_STATUS_PERMISSION_DENIED,
+} from "./errors.js";
+export {
+  createCertManagerClient,
+  loadCertManagerConfig,
+} from "./cert-manager-client.js";
+export type {
+  CertManagerClient,
+  CertManagerConfig,
+  CertificateView,
+  CertificateMapEntryView,
+  CreateCertificateInput,
+  CreateCertificateMapEntryInput,
+  DnsAuthorizationView,
+  UpstreamCertManagerClient,
+} from "./cert-manager-client.js";

--- a/apps/reconciler/src/index.ts
+++ b/apps/reconciler/src/index.ts
@@ -10,6 +10,7 @@
 import { randomUUID } from "node:crypto";
 
 import { ConfigError, loadConfig } from "./config.js";
+import type { ReconcilerConfig } from "./config.js";
 import { createReconcilerDb } from "./db/client.js";
 import {
   LEASE_KEY_DOMAIN_RECONCILER,
@@ -23,7 +24,7 @@ import { createLogger } from "./logging.js";
 import { processTransientStates } from "./process.js";
 
 async function main(): Promise<void> {
-  let config;
+  let config: ReconcilerConfig;
   try {
     config = loadConfig();
   } catch (err) {
@@ -87,6 +88,7 @@ async function main(): Promise<void> {
             lease,
             logger,
             heartbeat,
+            region: config.region,
           });
         },
       );

--- a/apps/reconciler/src/operations/cert-provisioning.ts
+++ b/apps/reconciler/src/operations/cert-provisioning.ts
@@ -1,0 +1,265 @@
+/**
+ * Operation 2 — Cert provisioning
+ *
+ * Trigger: rows where lifecycle_state = 'provisioning_cert'.
+ *
+ * Flow (R5 Decision 6, op 2):
+ *
+ *   1. GET Certificate at `cert-<uuid>`.
+ *   2. Inspect managed.state:
+ *       - PROVISIONING → no-op, bump last_reconciled_at.
+ *       - ACTIVE → GET CertificateMapEntry at `cme-<uuid>`. 404 → CREATE.
+ *         ALREADY_EXISTS → re-GET + verify spec. Mismatch → halt-on-drift.
+ *         On attach success, advance to `awaiting_probe`.
+ *       - FAILED → extract authorizationAttemptInfo[0].details, write to
+ *         reconciler_error.details, transition to `degraded` with
+ *         recoverable_from = 'awaiting_dns_challenge'.
+ */
+
+import { regionCustomDomains } from "@acme/redirect-platform-db";
+import type { RegionCustomDomain } from "@acme/redirect-platform-db";
+import { eq } from "drizzle-orm";
+
+import { AlreadyExistsError, NotFoundError } from "../gcp/index.js";
+import type { CertificateMapEntryView } from "../gcp/index.js";
+import {
+  SpecMismatchError,
+  appendDomainEvent,
+  deterministicResourceName,
+  haltOnDrift,
+  handleAlreadyExists,
+  stateGuardedUpdate,
+  touchReconciledAt,
+} from "./shared.js";
+import type { OperationContext } from "./shared.js";
+
+const MAX_ROWS_PER_CYCLE = 20;
+
+interface PlannedCmeSpec {
+  hostname: string;
+  certificateName: string;
+}
+
+export function cmeSpecMatches(
+  existing: CertificateMapEntryView,
+  planned: PlannedCmeSpec,
+): boolean {
+  if (existing.hostname !== planned.hostname) return false;
+  return existing.certificates.includes(planned.certificateName);
+}
+
+export async function runCertProvisioning(
+  ctx: OperationContext,
+): Promise<void> {
+  const rows = await ctx.db
+    .select()
+    .from(regionCustomDomains)
+    .where(eq(regionCustomDomains.lifecycleState, "provisioning_cert"))
+    .limit(MAX_ROWS_PER_CYCLE);
+
+  for (const row of rows) {
+    await reconcileOneCertProvisioning(ctx, row);
+  }
+}
+
+export async function reconcileOneCertProvisioning(
+  ctx: OperationContext,
+  row: RegionCustomDomain,
+): Promise<void> {
+  const certId = deterministicResourceName("Certificate", row.id);
+  const certResourcePath = ctx.certManager.certificateResourcePath(certId);
+  const logFields = { domain_id: row.id, hostname: row.hostname };
+
+  const cert = await ctx.certManager.getCertificate(certId);
+
+  if (!cert.managed) {
+    await haltOnDrift({
+      db: ctx.db,
+      logger: ctx.logger,
+      rowId: row.id,
+      currentState: "provisioning_cert",
+      driftKind: "unexpected_state",
+      resourceType: "Certificate.managed",
+      resourceName: certResourcePath,
+      observedSpec: cert,
+      expectedSpec: { managed: "required" },
+      recoverableFrom: "awaiting_dns_challenge",
+      reconcilerRunId: ctx.reconcilerRunId,
+    });
+    return;
+  }
+
+  switch (cert.managed.state) {
+    case "PROVISIONING":
+    case "AUTHORIZING":
+    case "PENDING": {
+      ctx.logger.info("certificate still provisioning", {
+        ...logFields,
+        managed_state: cert.managed.state,
+      });
+      await touchReconciledAt(ctx.db, row.id);
+      return;
+    }
+    case "ACTIVE": {
+      await attachCertificateMapEntry(ctx, row, certResourcePath);
+      return;
+    }
+    case "FAILED": {
+      await handleFailedCertificate(ctx, row, cert.managed.failureDetails);
+      return;
+    }
+    default: {
+      ctx.logger.warn("certificate in unknown managed.state; waiting", {
+        ...logFields,
+        managed_state: cert.managed.state,
+      });
+      await touchReconciledAt(ctx.db, row.id);
+      return;
+    }
+  }
+}
+
+async function attachCertificateMapEntry(
+  ctx: OperationContext,
+  row: RegionCustomDomain,
+  certResourcePath: string,
+): Promise<void> {
+  const entryId = deterministicResourceName("CertificateMapEntry", row.id);
+  const plannedSpec: PlannedCmeSpec = {
+    hostname: row.hostname,
+    certificateName: certResourcePath,
+  };
+
+  const existing = await ctx.certManager.getCertificateMapEntry(entryId);
+  if (existing !== null) {
+    if (!cmeSpecMatches(existing, plannedSpec)) {
+      await haltOnDrift({
+        db: ctx.db,
+        logger: ctx.logger,
+        rowId: row.id,
+        currentState: "provisioning_cert",
+        driftKind: "spec_mismatch",
+        resourceType: "CertificateMapEntry",
+        resourceName: existing.name,
+        observedSpec: existing,
+        expectedSpec: plannedSpec,
+        recoverableFrom: "provisioning_cert",
+        reconcilerRunId: ctx.reconcilerRunId,
+      });
+      return;
+    }
+    await advanceToAwaitingProbe(ctx, row, entryId);
+    return;
+  }
+
+  // 404 → CREATE with ALREADY_EXISTS fall-through.
+  try {
+    await ctx.certManager.createCertificateMapEntry({
+      entryId,
+      hostname: row.hostname,
+      certificateName: certResourcePath,
+    });
+  } catch (err) {
+    if (err instanceof AlreadyExistsError) {
+      try {
+        await handleAlreadyExists<CertificateMapEntryView, PlannedCmeSpec>({
+          resourceKind: "CertificateMapEntry",
+          rowId: row.id,
+          resourceName: entryId,
+          plannedSpec,
+          getFn: async () => ctx.certManager.getCertificateMapEntry(entryId),
+          specMatches: cmeSpecMatches,
+        });
+      } catch (resolveErr) {
+        if (resolveErr instanceof SpecMismatchError) {
+          await haltOnDrift({
+            db: ctx.db,
+            logger: ctx.logger,
+            rowId: row.id,
+            currentState: "provisioning_cert",
+            driftKind: "spec_mismatch",
+            resourceType: "CertificateMapEntry",
+            resourceName: entryId,
+            observedSpec: resolveErr.observedSpec,
+            expectedSpec: resolveErr.expectedSpec,
+            recoverableFrom: "provisioning_cert",
+            reconcilerRunId: ctx.reconcilerRunId,
+          });
+          return;
+        }
+        if (resolveErr instanceof NotFoundError) {
+          ctx.logger.warn(
+            "ALREADY_EXISTS fallback re-GET returned 404; will retry next cycle",
+            { domain_id: row.id },
+          );
+          await touchReconciledAt(ctx.db, row.id);
+          return;
+        }
+        throw resolveErr;
+      }
+    } else {
+      throw err;
+    }
+  }
+
+  await advanceToAwaitingProbe(ctx, row, entryId);
+}
+
+async function advanceToAwaitingProbe(
+  ctx: OperationContext,
+  row: RegionCustomDomain,
+  entryId: string,
+): Promise<void> {
+  const updated = await stateGuardedUpdate(ctx.db, {
+    id: row.id,
+    expectedState: "provisioning_cert",
+    newState: "awaiting_probe",
+    patch: {
+      gcpCertMapEntryId: entryId,
+      probeConsecutiveSuccesses: 0,
+    },
+  });
+  if (updated === null) {
+    ctx.logger.info(
+      "state guard failed on provisioning_cert → awaiting_probe",
+      { domain_id: row.id },
+    );
+    return;
+  }
+  await appendDomainEvent(ctx.db, {
+    domainId: row.id,
+    eventType: "reconciler.cert_active_attached",
+    fromState: "provisioning_cert",
+    toState: "awaiting_probe",
+    details: { cert_map_entry_id: entryId },
+    reconcilerRunId: ctx.reconcilerRunId,
+  });
+  ctx.logger.info("advanced provisioning_cert → awaiting_probe", {
+    domain_id: row.id,
+    hostname: row.hostname,
+  });
+}
+
+async function handleFailedCertificate(
+  ctx: OperationContext,
+  row: RegionCustomDomain,
+  failureDetails: string | null,
+): Promise<void> {
+  const certId = deterministicResourceName("Certificate", row.id);
+  const certResourcePath = ctx.certManager.certificateResourcePath(certId);
+
+  await haltOnDrift({
+    db: ctx.db,
+    logger: ctx.logger,
+    rowId: row.id,
+    currentState: "provisioning_cert",
+    driftKind: "unexpected_state",
+    resourceType: "Certificate",
+    resourceName: certResourcePath,
+    observedSpec: { managed: { state: "FAILED", failureDetails } },
+    expectedSpec: { managed: { state: "ACTIVE" } },
+    recoverableFrom: "awaiting_dns_challenge",
+    reconcilerRunId: ctx.reconcilerRunId,
+    details: failureDetails ?? undefined,
+  });
+}

--- a/apps/reconciler/src/operations/dns-challenge-validation.ts
+++ b/apps/reconciler/src/operations/dns-challenge-validation.ts
@@ -1,0 +1,249 @@
+/**
+ * Operation 1 — DNS challenge validation
+ *
+ * Trigger: rows where lifecycle_state = 'awaiting_dns_challenge'.
+ *
+ * Flow (R5 Decision 6, op 1):
+ *
+ *   1. Select the row batch.
+ *   2. GET DnsAuthorization at `dns-auth-<uuid>`.
+ *      - state != 'ACTIVE' → no-op, bump last_reconciled_at, next cycle.
+ *      - state === 'ACTIVE' → proceed.
+ *   3. GET Certificate at `cert-<uuid>`.
+ *      - 404 → CREATE. `ALREADY_EXISTS` → re-GET + verify spec. Mismatch → halt-on-drift.
+ *      - 200 → verify spec. Mismatch → halt-on-drift.
+ *   4. Advance `awaiting_dns_challenge → provisioning_cert` via state-guarded UPDATE.
+ */
+
+import { regionCustomDomains } from "@acme/redirect-platform-db";
+import type { RegionCustomDomain } from "@acme/redirect-platform-db";
+import { eq } from "drizzle-orm";
+
+import { AlreadyExistsError, NotFoundError } from "../gcp/index.js";
+import type { CertificateView, DnsAuthorizationView } from "../gcp/index.js";
+import {
+  SpecMismatchError,
+  appendDomainEvent,
+  deterministicResourceName,
+  haltOnDrift,
+  handleAlreadyExists,
+  stateGuardedUpdate,
+  touchReconciledAt,
+} from "./shared.js";
+import type { OperationContext } from "./shared.js";
+
+const MAX_ROWS_PER_CYCLE = 20;
+
+interface PlannedCertSpec {
+  domain: string;
+  dnsAuthorizationName: string;
+}
+
+/**
+ * Does the Certificate returned by GCP match the spec we planned to create?
+ * A match requires:
+ *   - managed.domains contains the planned domain
+ *   - managed.dnsAuthorizations contains the planned auth resource path
+ */
+export function certSpecMatches(
+  existing: CertificateView,
+  planned: PlannedCertSpec,
+): boolean {
+  if (!existing.managed) return false;
+  const domainsOk = existing.managed.domains.includes(planned.domain);
+  const authsOk = existing.managed.dnsAuthorizations.includes(
+    planned.dnsAuthorizationName,
+  );
+  return domainsOk && authsOk;
+}
+
+export async function runDnsChallengeValidation(
+  ctx: OperationContext,
+): Promise<void> {
+  const rows = await ctx.db
+    .select()
+    .from(regionCustomDomains)
+    .where(eq(regionCustomDomains.lifecycleState, "awaiting_dns_challenge"))
+    .limit(MAX_ROWS_PER_CYCLE);
+
+  for (const row of rows) {
+    await reconcileOneDnsChallenge(ctx, row);
+  }
+}
+
+interface EnsureCertificateInput {
+  rowId: string;
+  certId: string;
+  certResourceName: string;
+  plannedSpec: PlannedCertSpec;
+  dnsAuth: DnsAuthorizationView;
+  hostname: string;
+}
+
+type EnsureOutcome = "created" | "existed_matching" | "halted";
+
+async function ensureCertificateExists(
+  ctx: OperationContext,
+  input: EnsureCertificateInput,
+): Promise<EnsureOutcome> {
+  // First attempt: GET. If the cert exists already, verify its spec
+  // directly — this is the crash-recovery path where a prior run created
+  // the cert but died before advancing the DB row.
+  try {
+    const existing = await ctx.certManager.getCertificate(input.certId);
+    if (certSpecMatches(existing, input.plannedSpec)) {
+      return "existed_matching";
+    }
+    await haltOnDrift({
+      db: ctx.db,
+      logger: ctx.logger,
+      rowId: input.rowId,
+      currentState: "awaiting_dns_challenge",
+      driftKind: "spec_mismatch",
+      resourceType: "Certificate",
+      resourceName: input.certResourceName,
+      observedSpec: existing,
+      expectedSpec: input.plannedSpec,
+      recoverableFrom: "awaiting_dns_challenge",
+      reconcilerRunId: ctx.reconcilerRunId,
+    });
+    return "halted";
+  } catch (err) {
+    if (!(err instanceof NotFoundError)) {
+      throw err;
+    }
+  }
+
+  // GET returned 404 → attempt CREATE.
+  try {
+    await ctx.certManager.createCertificate({
+      certificateId: input.certId,
+      domain: input.hostname,
+      dnsAuthorizationName: input.dnsAuth.name,
+    });
+    return "created";
+  } catch (createErr) {
+    if (!(createErr instanceof AlreadyExistsError)) {
+      throw createErr;
+    }
+  }
+
+  // CREATE returned ALREADY_EXISTS → re-GET and verify spec (R5 Decision 6).
+  try {
+    await handleAlreadyExists<CertificateView, PlannedCertSpec>({
+      resourceKind: "Certificate",
+      rowId: input.rowId,
+      resourceName: input.certResourceName,
+      plannedSpec: input.plannedSpec,
+      getFn: async () => ctx.certManager.getCertificate(input.certId),
+      specMatches: certSpecMatches,
+    });
+    return "existed_matching";
+  } catch (resolveErr) {
+    if (resolveErr instanceof SpecMismatchError) {
+      await haltOnDrift({
+        db: ctx.db,
+        logger: ctx.logger,
+        rowId: input.rowId,
+        currentState: "awaiting_dns_challenge",
+        driftKind: "spec_mismatch",
+        resourceType: "Certificate",
+        resourceName: input.certResourceName,
+        observedSpec: resolveErr.observedSpec,
+        expectedSpec: resolveErr.expectedSpec,
+        recoverableFrom: "awaiting_dns_challenge",
+        reconcilerRunId: ctx.reconcilerRunId,
+      });
+      return "halted";
+    }
+    throw resolveErr;
+  }
+}
+
+export async function reconcileOneDnsChallenge(
+  ctx: OperationContext,
+  row: RegionCustomDomain,
+): Promise<void> {
+  const logFields = { domain_id: row.id, hostname: row.hostname };
+
+  const dnsAuthId = deterministicResourceName("DnsAuthorization", row.id);
+  const dnsAuth = await ctx.certManager.getDnsAuthorization(dnsAuthId);
+
+  if (dnsAuth === null) {
+    // The reconciler does not create the DnsAuthorization — registration
+    // does. If it's missing, we halt on orphan row.
+    await haltOnDrift({
+      db: ctx.db,
+      logger: ctx.logger,
+      rowId: row.id,
+      currentState: "awaiting_dns_challenge",
+      driftKind: "orphan_resource",
+      resourceType: "DnsAuthorization",
+      resourceName: dnsAuthId,
+      observedSpec: null,
+      expectedSpec: { domain: row.hostname },
+      recoverableFrom: "awaiting_dns_challenge",
+      reconcilerRunId: ctx.reconcilerRunId,
+    });
+    return;
+  }
+
+  if (dnsAuth.state !== "ACTIVE") {
+    ctx.logger.info("dns authorization not yet active; waiting", {
+      ...logFields,
+      dns_authorization_state: dnsAuth.state,
+    });
+    await touchReconciledAt(ctx.db, row.id);
+    return;
+  }
+
+  const certId = deterministicResourceName("Certificate", row.id);
+  const certResourceName = ctx.certManager.certificateResourcePath(certId);
+  const plannedSpec: PlannedCertSpec = {
+    domain: row.hostname,
+    dnsAuthorizationName: dnsAuth.name,
+  };
+
+  const ensured = await ensureCertificateExists(ctx, {
+    rowId: row.id,
+    certId,
+    certResourceName,
+    plannedSpec,
+    dnsAuth,
+    hostname: row.hostname,
+  });
+  if (ensured === "halted") {
+    return;
+  }
+
+  // Whether we just created it or it already existed, we advance the state.
+  // The row now has a Certificate resource associated with it; the provisioning
+  // state machine (op 2) will observe managed.state transitions.
+  const updated = await stateGuardedUpdate(ctx.db, {
+    id: row.id,
+    expectedState: "awaiting_dns_challenge",
+    newState: "provisioning_cert",
+    patch: {
+      gcpDnsAuthorizationId: dnsAuthId,
+      gcpCertificateId: certId,
+    },
+  });
+  if (updated === null) {
+    ctx.logger.info(
+      "state guard failed on awaiting_dns_challenge → provisioning_cert",
+      logFields,
+    );
+    return;
+  }
+  await appendDomainEvent(ctx.db, {
+    domainId: row.id,
+    eventType: "reconciler.dns_challenge_validated",
+    fromState: "awaiting_dns_challenge",
+    toState: "provisioning_cert",
+    reconcilerRunId: ctx.reconcilerRunId,
+  });
+  ctx.logger.info(
+    "advanced awaiting_dns_challenge → provisioning_cert",
+    logFields,
+  );
+}

--- a/apps/reconciler/src/operations/index.ts
+++ b/apps/reconciler/src/operations/index.ts
@@ -1,0 +1,30 @@
+export { runDnsChallengeValidation } from "./dns-challenge-validation.js";
+export { runCertProvisioning } from "./cert-provisioning.js";
+export {
+  runSniProbeOperation,
+  loadSniProbeConfig,
+  MissingLbIpError,
+} from "./sni-probe.js";
+export type { SniProbeOpConfig } from "./sni-probe.js";
+export {
+  runPostCutoverVerification,
+  loadPostCutoverConfig,
+  expectedRedirectTarget,
+  verifyDnsPointsAtLb,
+  MissingPostCutoverLbIpError,
+} from "./post-cutover-verification.js";
+export type { PostCutoverConfig } from "./post-cutover-verification.js";
+export {
+  deterministicResourceName,
+  stateGuardedUpdate,
+  appendDomainEvent,
+  haltOnDrift,
+  handleAlreadyExists,
+  touchReconciledAt,
+  SpecMismatchError,
+} from "./shared.js";
+export type {
+  OperationContext,
+  ResourceKind,
+  ReconcilerErrorPayload,
+} from "./shared.js";

--- a/apps/reconciler/src/operations/post-cutover-verification.ts
+++ b/apps/reconciler/src/operations/post-cutover-verification.ts
@@ -1,0 +1,268 @@
+/**
+ * Operation 4 — Post-cutover DNS verification
+ *
+ * Trigger: rows where lifecycle_state = 'awaiting_cutover'.
+ *
+ * Flow (R5 Decision 6, op 4):
+ *
+ *   1. Resolve apex A/AAAA via public DNS (this op INTENTIONALLY uses
+ *      public DNS — the point is to verify the user's DNS change took
+ *      effect).
+ *   2. Confirm A points to REDIRECT_LB_IPV4 (and AAAA to REDIRECT_LB_IPV6
+ *      when set).
+ *   3. Make an HTTPS request to `https://<hostname>/` through public DNS
+ *      and confirm a 307 to the expected target:
+ *        - apex → https://regions.f3nation.com/<region_slug>
+ *        - stats → https://pax-vault.f3nation.com/stats/region/<region_id>
+ *   4. On success, transition awaiting_cutover → active.
+ *   5. On failure, stay in awaiting_cutover (user may not have updated DNS
+ *      yet). Log at INFO level, bump last_reconciled_at.
+ */
+
+import { promises as dnsPromises } from "node:dns";
+import { request as httpsRequest } from "node:https";
+import type { RequestOptions } from "node:https";
+import type { IncomingMessage } from "node:http";
+
+import { regionCustomDomains } from "@acme/redirect-platform-db";
+import type { RegionCustomDomain } from "@acme/redirect-platform-db";
+import { eq } from "drizzle-orm";
+
+import {
+  appendDomainEvent,
+  stateGuardedUpdate,
+  touchReconciledAt,
+} from "./shared.js";
+import type { OperationContext } from "./shared.js";
+
+const MAX_ROWS_PER_CYCLE = 20;
+const HTTPS_TIMEOUT_MS = 10_000;
+
+// ---------------------------------------------------------------------------
+// Config — same LB IPs as op 3, but used only for the `A`/`AAAA` equality
+// check. This op is the only place in the reconciler where we talk to
+// public DNS on the tenant hostname.
+// ---------------------------------------------------------------------------
+
+export interface PostCutoverConfig {
+  lbIpv4: string;
+  lbIpv6?: string;
+  /** Injectable DNS resolver (test seam). */
+  dnsResolver?: {
+    resolve4(hostname: string): Promise<string[]>;
+    resolve6(hostname: string): Promise<string[]>;
+  };
+  /** Injectable HTTPS head-requester (test seam). */
+  httpsHead?: (input: {
+    hostname: string;
+    path: string;
+  }) => Promise<{ status: number | null; location: string | null }>;
+  now?: () => Date;
+}
+
+export class MissingPostCutoverLbIpError extends Error {
+  constructor() {
+    super(
+      "REDIRECT_LB_IPV4 is not set; post-cutover DNS verification requires it.",
+    );
+    this.name = "MissingPostCutoverLbIpError";
+  }
+}
+
+export function loadPostCutoverConfig(
+  env: NodeJS.ProcessEnv = process.env,
+): PostCutoverConfig {
+  const lbIpv4 = env.REDIRECT_LB_IPV4;
+  if (!lbIpv4) {
+    throw new MissingPostCutoverLbIpError();
+  }
+  return {
+    lbIpv4,
+    ...(env.REDIRECT_LB_IPV6 ? { lbIpv6: env.REDIRECT_LB_IPV6 } : {}),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Expected redirect targets
+// ---------------------------------------------------------------------------
+
+export function expectedRedirectTarget(row: RegionCustomDomain): string {
+  if (row.hostnameRole === "apex") {
+    return `https://regions.f3nation.com/${row.regionSlug}`;
+  }
+  if (row.hostnameRole === "stats") {
+    return `https://pax-vault.f3nation.com/stats/region/${row.regionId}`;
+  }
+  throw new Error(`unknown hostname_role: ${String(row.hostnameRole)}`);
+}
+
+// ---------------------------------------------------------------------------
+// Default HTTPS head requester
+// ---------------------------------------------------------------------------
+
+function defaultHttpsHead(input: {
+  hostname: string;
+  path: string;
+}): Promise<{ status: number | null; location: string | null }> {
+  return new Promise((resolve) => {
+    const options: RequestOptions = {
+      hostname: input.hostname,
+      port: 443,
+      path: input.path,
+      method: "GET",
+      headers: {
+        "User-Agent": "redirect-platform-reconciler/1.0",
+      },
+    };
+    const req = httpsRequest(options, (res: IncomingMessage) => {
+      const location = res.headers.location ?? null;
+      const status = res.statusCode ?? null;
+      // Drain and discard body; we only care about status + Location.
+      res.resume();
+      res.on("end", () => {
+        resolve({ status, location });
+      });
+      res.on("error", () => {
+        resolve({ status, location });
+      });
+    });
+    req.setTimeout(HTTPS_TIMEOUT_MS, () => {
+      req.destroy(new Error("HTTPS request timeout"));
+    });
+    req.on("error", () => {
+      resolve({ status: null, location: null });
+    });
+    req.end();
+  });
+}
+
+// ---------------------------------------------------------------------------
+// DNS verification helpers
+// ---------------------------------------------------------------------------
+
+export interface DnsVerifyResult {
+  a_records: string[];
+  aaaa_records: string[];
+  a_matches: boolean;
+  aaaa_matches: boolean;
+  error: string | null;
+}
+
+export async function verifyDnsPointsAtLb(
+  hostname: string,
+  config: PostCutoverConfig,
+): Promise<DnsVerifyResult> {
+  const resolver = config.dnsResolver ?? {
+    resolve4: (h) => dnsPromises.resolve4(h),
+    resolve6: (h) => dnsPromises.resolve6(h),
+  };
+  let aRecords: string[] = [];
+  let aaaaRecords: string[] = [];
+  let error: string | null = null;
+  try {
+    aRecords = await resolver.resolve4(hostname);
+  } catch (err) {
+    error = `A-record lookup failed: ${String(err)}`;
+  }
+  if (config.lbIpv6) {
+    try {
+      aaaaRecords = await resolver.resolve6(hostname);
+    } catch (err) {
+      // AAAA lookup failure is non-fatal if we don't require IPv6 coverage.
+      error = error ?? `AAAA-record lookup failed: ${String(err)}`;
+    }
+  }
+  const aMatches = aRecords.includes(config.lbIpv4);
+  const aaaaMatches = !config.lbIpv6 || aaaaRecords.includes(config.lbIpv6);
+  return {
+    a_records: aRecords,
+    aaaa_records: aaaaRecords,
+    a_matches: aMatches,
+    aaaa_matches: aaaaMatches,
+    error,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Operation entry point
+// ---------------------------------------------------------------------------
+
+export async function runPostCutoverVerification(
+  ctx: OperationContext,
+  config: PostCutoverConfig,
+): Promise<void> {
+  const rows = await ctx.db
+    .select()
+    .from(regionCustomDomains)
+    .where(eq(regionCustomDomains.lifecycleState, "awaiting_cutover"))
+    .limit(MAX_ROWS_PER_CYCLE);
+  const httpsHead = config.httpsHead ?? defaultHttpsHead;
+  for (const row of rows) {
+    await reconcileOnePostCutover(ctx, config, row, httpsHead);
+  }
+}
+
+export async function reconcileOnePostCutover(
+  ctx: OperationContext,
+  config: PostCutoverConfig,
+  row: RegionCustomDomain,
+  httpsHead: NonNullable<PostCutoverConfig["httpsHead"]>,
+): Promise<void> {
+  const logFields = { domain_id: row.id, hostname: row.hostname };
+
+  const dnsResult = await verifyDnsPointsAtLb(row.hostname, config);
+  if (!dnsResult.a_matches || !dnsResult.aaaa_matches) {
+    ctx.logger.info(
+      "awaiting_cutover: DNS does not yet point at LB; staying in state",
+      {
+        ...logFields,
+        a_records: dnsResult.a_records,
+        aaaa_records: dnsResult.aaaa_records,
+      },
+    );
+    await touchReconciledAt(ctx.db, row.id);
+    return;
+  }
+
+  const expected = expectedRedirectTarget(row);
+  const httpResult = await httpsHead({ hostname: row.hostname, path: "/" });
+  if (httpResult.status !== 307 || httpResult.location !== expected) {
+    ctx.logger.info(
+      "awaiting_cutover: HTTP response does not match expected redirect",
+      {
+        ...logFields,
+        http_status: httpResult.status,
+        http_location: httpResult.location,
+        expected_location: expected,
+      },
+    );
+    await touchReconciledAt(ctx.db, row.id);
+    return;
+  }
+
+  const updated = await stateGuardedUpdate(ctx.db, {
+    id: row.id,
+    expectedState: "awaiting_cutover",
+    newState: "active",
+  });
+  if (updated === null) {
+    ctx.logger.info(
+      "state guard failed on awaiting_cutover → active; another worker advanced",
+      logFields,
+    );
+    return;
+  }
+  await appendDomainEvent(ctx.db, {
+    domainId: row.id,
+    eventType: "reconciler.post_cutover_verified",
+    fromState: "awaiting_cutover",
+    toState: "active",
+    details: {
+      dns_result: dnsResult,
+      http_status: httpResult.status,
+      http_location: httpResult.location,
+    },
+    reconcilerRunId: ctx.reconcilerRunId,
+  });
+  ctx.logger.info("advanced awaiting_cutover → active", logFields);
+}

--- a/apps/reconciler/src/operations/shared.ts
+++ b/apps/reconciler/src/operations/shared.ts
@@ -1,0 +1,352 @@
+/**
+ * Shared primitives for reconciler operations 1–8 (R5 Decision 6).
+ *
+ * This module concentrates the three concurrency-critical patterns the
+ * plan calls out:
+ *
+ *   1. State-guarded UPDATE — `UPDATE ... WHERE id = $id AND lifecycle_state
+ *      = $expected RETURNING *`. If zero rows, another worker got there
+ *      first; the caller aborts gracefully.
+ *   2. Deterministic resource names — `dns-auth-<uuid>`, `cert-<uuid>`,
+ *      `cme-<uuid>`. Derived from the row's UUID so every reconciler run
+ *      converges on the same GCP resource id.
+ *   3. `ALREADY_EXISTS` as success path + halt-on-spec-mismatch.
+ *
+ * Also provides `haltOnDrift` which writes the Decision 6 JSON payload to
+ * `reconciler_error`, transitions the row to `degraded`, emits the
+ * structured Cloud Logging drift entry, and appends an append-only event
+ * for the audit trail.
+ */
+
+import {
+  regionCustomDomains,
+  regionCustomDomainEvents,
+} from "@acme/redirect-platform-db";
+import type { RegionCustomDomain } from "@acme/redirect-platform-db";
+import { and, eq } from "drizzle-orm";
+
+import type { ReconcilerDb } from "../db/client.js";
+import type { CertManagerClient } from "../gcp/index.js";
+import { AlreadyExistsError, NotFoundError } from "../gcp/index.js";
+import type { Logger } from "../logging.js";
+
+// ---------------------------------------------------------------------------
+// Deterministic resource names
+// ---------------------------------------------------------------------------
+
+export type ResourceKind =
+  | "DnsAuthorization"
+  | "Certificate"
+  | "CertificateMapEntry";
+
+/**
+ * Build a deterministic GCP resource id for a domain row. The prefix comes
+ * from R5 Decision 6: `dns-auth-<uuid>`, `cert-<uuid>`, `cme-<uuid>`.
+ */
+export function deterministicResourceName(
+  kind: ResourceKind,
+  rowId: string,
+): string {
+  switch (kind) {
+    case "DnsAuthorization":
+      return `dns-auth-${rowId}`;
+    case "Certificate":
+      return `cert-${rowId}`;
+    case "CertificateMapEntry":
+      return `cme-${rowId}`;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// State-guarded UPDATE
+// ---------------------------------------------------------------------------
+
+export interface StateGuardedUpdateInput {
+  id: string;
+  expectedState: RegionCustomDomain["lifecycleState"];
+  newState: RegionCustomDomain["lifecycleState"];
+  /** Extra column patches applied in the same UPDATE. */
+  patch?: Partial<
+    Omit<
+      RegionCustomDomain,
+      "id" | "lifecycleState" | "createdAt" | "createdBy"
+    >
+  >;
+}
+
+/**
+ * Runs the exact state-guarded UPDATE pattern from R5 Decision 6:
+ *
+ *   UPDATE region_custom_domains
+ *      SET lifecycle_state = $new_state,
+ *          last_reconciled_at = now(),
+ *          updated_at = now(),
+ *          ... patch ...
+ *    WHERE id = $id AND lifecycle_state = $expected_state
+ *   RETURNING *;
+ *
+ * Returns the updated row on success or `null` if the state guard failed
+ * (another worker moved the row first, or the state changed out-of-band).
+ * The caller must treat `null` as an abort-this-cycle signal, not an error.
+ */
+export async function stateGuardedUpdate(
+  db: ReconcilerDb,
+  input: StateGuardedUpdateInput,
+): Promise<RegionCustomDomain | null> {
+  const nowIso = new Date().toISOString();
+  const values: Record<string, unknown> = {
+    lifecycleState: input.newState,
+    lastReconciledAt: nowIso,
+    updatedAt: nowIso,
+    ...(input.patch ?? {}),
+  };
+  const rows = await db
+    .update(regionCustomDomains)
+    .set(values)
+    .where(
+      and(
+        eq(regionCustomDomains.id, input.id),
+        eq(regionCustomDomains.lifecycleState, input.expectedState),
+      ),
+    )
+    .returning();
+  return rows[0] ?? null;
+}
+
+/**
+ * Update `last_reconciled_at` without moving state. Used on every cycle
+ * touch, success or no-op, so the crash-recovery scan can tell the row
+ * is actively reconciled.
+ */
+export async function touchReconciledAt(
+  db: ReconcilerDb,
+  id: string,
+): Promise<void> {
+  const nowIso = new Date().toISOString();
+  await db
+    .update(regionCustomDomains)
+    .set({ lastReconciledAt: nowIso, updatedAt: nowIso })
+    .where(eq(regionCustomDomains.id, id));
+}
+
+// ---------------------------------------------------------------------------
+// Append-only event emission
+// ---------------------------------------------------------------------------
+
+export interface AppendEventInput {
+  domainId: string;
+  eventType: string;
+  fromState: RegionCustomDomain["lifecycleState"] | null;
+  toState: RegionCustomDomain["lifecycleState"] | null;
+  details?: Record<string, unknown>;
+  /**
+   * The reconciler run id — included in details so every event can be
+   * correlated back to the Cloud Run job execution that wrote it.
+   */
+  reconcilerRunId: string;
+}
+
+export async function appendDomainEvent(
+  db: ReconcilerDb,
+  input: AppendEventInput,
+): Promise<void> {
+  await db.insert(regionCustomDomainEvents).values({
+    domainId: input.domainId,
+    eventType: input.eventType,
+    fromState: input.fromState,
+    toState: input.toState,
+    // Reconciler-initiated events never have an actor_user_id (Decision 8).
+    actorUserId: null,
+    details: {
+      ...(input.details ?? {}),
+      reconciler_run_id: input.reconcilerRunId,
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Spec mismatch + drift payload
+// ---------------------------------------------------------------------------
+
+export class SpecMismatchError extends Error {
+  constructor(
+    public readonly resourceKind: ResourceKind,
+    public readonly resourceName: string,
+    public readonly observedSpec: unknown,
+    public readonly expectedSpec: unknown,
+  ) {
+    super(
+      `reconciler spec mismatch on ${resourceKind} ${resourceName}: halt-on-drift`,
+    );
+    this.name = "SpecMismatchError";
+  }
+}
+
+export interface ReconcilerErrorPayload {
+  drift_kind: "spec_mismatch" | "orphan_resource" | "unexpected_state";
+  resource_type: ResourceKind | "Certificate.managed";
+  resource_name: string;
+  observed_spec: unknown;
+  expected_spec: unknown;
+  recoverable_from: RegionCustomDomain["lifecycleState"] | null;
+  detected_at: string;
+  reconciler_run_id: string;
+  /** Free-form extra details — used by op 2's FAILED cert path for attempt info. */
+  details?: string;
+}
+
+export interface HaltOnDriftInput {
+  db: ReconcilerDb;
+  logger: Logger;
+  rowId: string;
+  currentState: RegionCustomDomain["lifecycleState"];
+  driftKind: ReconcilerErrorPayload["drift_kind"];
+  resourceType: ReconcilerErrorPayload["resource_type"];
+  resourceName: string;
+  observedSpec: unknown;
+  expectedSpec: unknown;
+  recoverableFrom: RegionCustomDomain["lifecycleState"] | null;
+  reconcilerRunId: string;
+  details?: string;
+}
+
+/**
+ * Halt reconciliation of a single row: write the structured drift payload
+ * to `reconciler_error`, transition to `degraded` via state-guarded UPDATE,
+ * and emit the `log.drift(...)` entry.
+ *
+ * If the state guard fails (the row has moved out of its expected state
+ * since we read it), we log a WARNING and return — the next cycle will
+ * pick the row up in its new state.
+ */
+export async function haltOnDrift(
+  input: HaltOnDriftInput,
+): Promise<RegionCustomDomain | null> {
+  const payload: ReconcilerErrorPayload = {
+    drift_kind: input.driftKind,
+    resource_type: input.resourceType,
+    resource_name: input.resourceName,
+    observed_spec: input.observedSpec,
+    expected_spec: input.expectedSpec,
+    recoverable_from: input.recoverableFrom,
+    detected_at: new Date().toISOString(),
+    reconciler_run_id: input.reconcilerRunId,
+    ...(input.details !== undefined ? { details: input.details } : {}),
+  };
+
+  const updated = await stateGuardedUpdate(input.db, {
+    id: input.rowId,
+    expectedState: input.currentState,
+    newState: "degraded",
+    patch: { reconcilerError: payload },
+  });
+
+  if (updated === null) {
+    input.logger.warn(
+      "haltOnDrift: state guard failed (row moved concurrently)",
+      {
+        domain_id: input.rowId,
+        expected_state: input.currentState,
+      },
+    );
+    return null;
+  }
+
+  // NOTE: drift log uses the resource_type in the label contract. We map
+  // Certificate.managed → Certificate for the label since the alert policy
+  // is keyed on the resource kind string.
+  input.logger.drift({
+    domainId: input.rowId,
+    driftKind: input.driftKind,
+    resourceType: input.resourceType,
+    resourceName: input.resourceName,
+    observedSpec: input.observedSpec,
+    expectedSpec: input.expectedSpec,
+    recoverableFrom: input.recoverableFrom,
+  });
+
+  await appendDomainEvent(input.db, {
+    domainId: input.rowId,
+    eventType: "reconciler.halt_on_drift",
+    fromState: input.currentState,
+    toState: "degraded",
+    details: { drift: payload },
+    reconcilerRunId: input.reconcilerRunId,
+  });
+
+  return updated;
+}
+
+// ---------------------------------------------------------------------------
+// ALREADY_EXISTS handler for CREATE calls
+// ---------------------------------------------------------------------------
+
+export interface HandleAlreadyExistsInput<TExisting, TSpec> {
+  resourceKind: ResourceKind;
+  rowId: string;
+  resourceName: string;
+  plannedSpec: TSpec;
+  /** Re-GET the resource by its deterministic name. */
+  getFn: () => Promise<TExisting | null>;
+  /** Returns true if the existing resource matches what we planned to create. */
+  specMatches: (existing: TExisting, planned: TSpec) => boolean;
+}
+
+export interface HandleAlreadyExistsResult<TExisting> {
+  existing: TExisting;
+}
+
+/**
+ * Resolve an `AlreadyExistsError` from a CREATE call into a success-path
+ * outcome (R5 Decision 6):
+ *
+ *   1. Re-GET at the deterministic name.
+ *   2. If the GET returns null (transient race), throw NotFoundError — the
+ *      next cycle will retry from GET.
+ *   3. If the GET returns an object whose spec matches `plannedSpec`,
+ *      return the existing resource as the success value.
+ *   4. If the GET returns an object whose spec does NOT match, throw
+ *      `SpecMismatchError`. The caller is responsible for routing this
+ *      through `haltOnDrift`.
+ */
+export async function handleAlreadyExists<TExisting, TSpec>(
+  input: HandleAlreadyExistsInput<TExisting, TSpec>,
+): Promise<HandleAlreadyExistsResult<TExisting>> {
+  const existing = await input.getFn();
+  if (existing === null) {
+    throw new NotFoundError(input.resourceKind, input.resourceName);
+  }
+  if (!input.specMatches(existing, input.plannedSpec)) {
+    throw new SpecMismatchError(
+      input.resourceKind,
+      input.resourceName,
+      existing,
+      input.plannedSpec,
+    );
+  }
+  return { existing };
+}
+
+// ---------------------------------------------------------------------------
+// OperationContext — passed into every operation function
+// ---------------------------------------------------------------------------
+
+export interface OperationContext {
+  db: ReconcilerDb;
+  logger: Logger;
+  reconcilerRunId: string;
+  /**
+   * GCP region this reconciler instance runs in. Expected values are
+   * `us-central1` and `europe-west1` per Decision 4; we type as `string`
+   * so tests can inject synthetic regions without a cast.
+   */
+  region: string;
+  /** GCP Certificate Manager client wrapper. */
+  certManager: CertManagerClient;
+}
+
+// ---------------------------------------------------------------------------
+// Re-exports for call sites
+// ---------------------------------------------------------------------------
+
+export { AlreadyExistsError, NotFoundError };

--- a/apps/reconciler/src/operations/sni-probe.ts
+++ b/apps/reconciler/src/operations/sni-probe.ts
@@ -1,0 +1,401 @@
+/**
+ * Operation 3 — SNI probe before cutover (R5 Decision 4).
+ *
+ * Trigger: rows where lifecycle_state = 'awaiting_probe'.
+ *
+ * For each row:
+ *
+ *   1. Resolve the LB static IPv4 from env (`REDIRECT_LB_IPV4`). No DNS.
+ *   2. Run `runSniProbe` from the probe module. The probe dials the IP
+ *      directly with SNI = tenant hostname and verifies the TLS handshake,
+ *      `/health` → 200, `x-redirect-platform: ok` header.
+ *   3. Update per-region `probe_region_<this_region>_last_success` and the
+ *      `probe_last_result_detail` JSONB blob. On success in BOTH regions
+ *      (fresh within 3 minutes), increment `probe_consecutive_successes`.
+ *      On failure, reset to 0.
+ *   4. If the row has `probe_consecutive_successes >= 3` AND both regions'
+ *      last success is within 3 minutes, transition to `awaiting_cutover`
+ *      via state-guarded UPDATE.
+ *   5. If the row has been in `awaiting_probe` > 2 hours, transition to
+ *      `degraded` with `recoverable_from = 'awaiting_probe'`.
+ *
+ * **CRITICAL INVARIANT:** this operation does not resolve public DNS for
+ * the tenant hostname anywhere in the probe path. The probe socket dials
+ * `targetIp` (a numeric IPv4 from config), and `servername` drives TLS
+ * cert validation. Violating this re-certifies the old stack.
+ */
+
+import {
+  regionCustomDomainEvents,
+  regionCustomDomains,
+} from "@acme/redirect-platform-db";
+import type { RegionCustomDomain } from "@acme/redirect-platform-db";
+import { desc, eq } from "drizzle-orm";
+
+import { isSniProbeSuccess, runSniProbe } from "../probe/index.js";
+import type { SniProbeInput, SniProbeResult } from "../probe/index.js";
+import {
+  appendDomainEvent,
+  stateGuardedUpdate,
+  touchReconciledAt,
+} from "./shared.js";
+import type { OperationContext } from "./shared.js";
+
+const MAX_ROWS_PER_CYCLE = 20;
+const FRESHNESS_WINDOW_MS = 3 * 60 * 1000; // 3 minutes
+const REQUIRED_CONSECUTIVE_SUCCESSES = 3;
+const HARD_TIMEOUT_MS = 2 * 60 * 60 * 1000; // 2 hours
+
+export interface SniProbeOpConfig {
+  /** LB static IPv4 — read from REDIRECT_LB_IPV4 env var at cycle start. */
+  lbIpv4: string;
+  /** Optional LB static IPv6. */
+  lbIpv6?: string;
+  /** Injectable probe runner (test seam). */
+  probeFn?: (input: SniProbeInput) => Promise<SniProbeResult>;
+  /** Injectable clock (test seam). */
+  now?: () => Date;
+}
+
+export class MissingLbIpError extends Error {
+  constructor() {
+    super(
+      "REDIRECT_LB_IPV4 is not set; SNI probe requires the LB static IP (Terraform output lb_ipv4_address). Refusing to run op 3.",
+    );
+    this.name = "MissingLbIpError";
+  }
+}
+
+export function loadSniProbeConfig(
+  env: NodeJS.ProcessEnv = process.env,
+): SniProbeOpConfig {
+  const lbIpv4 = env.REDIRECT_LB_IPV4;
+  if (!lbIpv4) {
+    throw new MissingLbIpError();
+  }
+  return {
+    lbIpv4,
+    ...(env.REDIRECT_LB_IPV6 ? { lbIpv6: env.REDIRECT_LB_IPV6 } : {}),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Per-region probe detail tracking (JSONB blob shape)
+// ---------------------------------------------------------------------------
+
+interface PerRegionDetail {
+  last_attempted_at: string;
+  handshake_ok: boolean;
+  http_status: number | null;
+  cert_serial: string | null;
+  cert_expiry: string | null;
+  latency_ms: number;
+  error: string | null;
+}
+
+interface ProbeDetailBlob {
+  /** Most recent probe (either region). */
+  handshake_ok: boolean;
+  http_status: number | null;
+  cert_serial: string | null;
+  cert_expiry: string | null;
+  latency_ms: number;
+  per_region: {
+    us_central1?: PerRegionDetail;
+    europe_west1?: PerRegionDetail;
+  };
+}
+
+function probeResultToPerRegion(
+  result: SniProbeResult,
+  now: Date,
+): PerRegionDetail {
+  return {
+    last_attempted_at: now.toISOString(),
+    handshake_ok: result.handshake_ok,
+    http_status: result.http_status,
+    cert_serial: result.cert?.serialNumber ?? null,
+    cert_expiry: result.cert?.validTo ?? null,
+    latency_ms: result.latency_ms,
+    error: result.error,
+  };
+}
+
+function isExistingBlob(value: unknown): value is ProbeDetailBlob {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "per_region" in (value as Record<string, unknown>)
+  );
+}
+
+function mergeProbeDetail(
+  existing: unknown,
+  region: string,
+  perRegion: PerRegionDetail,
+  result: SniProbeResult,
+): ProbeDetailBlob {
+  const base: ProbeDetailBlob = isExistingBlob(existing)
+    ? existing
+    : {
+        handshake_ok: false,
+        http_status: null,
+        cert_serial: null,
+        cert_expiry: null,
+        latency_ms: 0,
+        per_region: {},
+      };
+  const per_region: ProbeDetailBlob["per_region"] = { ...base.per_region };
+  if (region === "us-central1") {
+    per_region.us_central1 = perRegion;
+  } else if (region === "europe-west1") {
+    per_region.europe_west1 = perRegion;
+  }
+  return {
+    handshake_ok: result.handshake_ok,
+    http_status: result.http_status,
+    cert_serial: result.cert?.serialNumber ?? null,
+    cert_expiry: result.cert?.validTo ?? null,
+    latency_ms: result.latency_ms,
+    per_region,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Freshness + advance criteria
+// ---------------------------------------------------------------------------
+
+function isFresh(timestamp: string | null | undefined, now: Date): boolean {
+  if (!timestamp) return false;
+  const t = new Date(timestamp).getTime();
+  if (Number.isNaN(t)) return false;
+  return now.getTime() - t <= FRESHNESS_WINDOW_MS;
+}
+
+export interface BothRegionsFreshInput {
+  probeRegionUsCentral1LastSuccess: string | null;
+  probeRegionEuropeWest1LastSuccess: string | null;
+  now: Date;
+}
+
+export function bothRegionsFresh(input: BothRegionsFreshInput): boolean {
+  return (
+    isFresh(input.probeRegionUsCentral1LastSuccess, input.now) &&
+    isFresh(input.probeRegionEuropeWest1LastSuccess, input.now)
+  );
+}
+
+/**
+ * Find when the row entered `awaiting_probe`. Used to enforce the 2-hour
+ * hard timeout. Returns null if we can't find the transition event, in
+ * which case the caller falls back to `created_at`.
+ */
+export async function findAwaitingProbeEnteredAt(
+  ctx: OperationContext,
+  domainId: string,
+): Promise<Date | null> {
+  const rows = await ctx.db
+    .select()
+    .from(regionCustomDomainEvents)
+    .where(eq(regionCustomDomainEvents.domainId, domainId))
+    .orderBy(desc(regionCustomDomainEvents.createdAt))
+    .limit(50);
+  // Find the most recent event whose to_state is 'awaiting_probe'.
+  for (const event of rows) {
+    if (event.toState === "awaiting_probe") {
+      return new Date(event.createdAt);
+    }
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Operation entry point
+// ---------------------------------------------------------------------------
+
+export async function runSniProbeOperation(
+  ctx: OperationContext,
+  config: SniProbeOpConfig,
+): Promise<void> {
+  const now = config.now?.() ?? new Date();
+  const probeFn = config.probeFn ?? runSniProbe;
+
+  const rows = await ctx.db
+    .select()
+    .from(regionCustomDomains)
+    .where(eq(regionCustomDomains.lifecycleState, "awaiting_probe"))
+    .limit(MAX_ROWS_PER_CYCLE);
+
+  for (const row of rows) {
+    await reconcileOneSniProbe(ctx, config, row, {
+      now,
+      probeFn,
+    });
+  }
+}
+
+interface ReconcileOneDeps {
+  now: Date;
+  probeFn: (input: SniProbeInput) => Promise<SniProbeResult>;
+}
+
+export async function reconcileOneSniProbe(
+  ctx: OperationContext,
+  config: SniProbeOpConfig,
+  row: RegionCustomDomain,
+  deps: ReconcileOneDeps,
+): Promise<void> {
+  const logFields = {
+    domain_id: row.id,
+    hostname: row.hostname,
+    region: ctx.region,
+  };
+
+  const result = await deps.probeFn({
+    targetIp: config.lbIpv4,
+    hostname: row.hostname,
+  });
+  const success = isSniProbeSuccess(result);
+  const perRegion = probeResultToPerRegion(result, deps.now);
+  const mergedBlob = mergeProbeDetail(
+    row.probeLastResultDetail,
+    ctx.region,
+    perRegion,
+    result,
+  );
+
+  ctx.logger.info(success ? "sni probe succeeded" : "sni probe failed", {
+    ...logFields,
+    handshake_ok: result.handshake_ok,
+    http_status: result.http_status,
+    cert_serial: result.cert?.serialNumber ?? null,
+    latency_ms: result.latency_ms,
+    ...(result.error !== null ? { error: result.error } : {}),
+  });
+
+  const nowIso = deps.now.toISOString();
+  const patch: Partial<RegionCustomDomain> = {
+    probeLastAttemptedAt: nowIso,
+    probeLastResultDetail: mergedBlob,
+  };
+
+  if (success) {
+    if (ctx.region === "us-central1") {
+      patch.probeRegionUsCentral1LastSuccess = nowIso;
+    } else if (ctx.region === "europe-west1") {
+      patch.probeRegionEuropeWest1LastSuccess = nowIso;
+    }
+    const otherRegionFresh =
+      ctx.region === "us-central1"
+        ? isFresh(row.probeRegionEuropeWest1LastSuccess, deps.now)
+        : isFresh(row.probeRegionUsCentral1LastSuccess, deps.now);
+    if (otherRegionFresh) {
+      // Both regions have fresh green results — increment the counter.
+      patch.probeConsecutiveSuccesses =
+        (row.probeConsecutiveSuccesses ?? 0) + 1;
+    }
+  } else {
+    patch.probeConsecutiveSuccesses = 0;
+  }
+
+  // Short DB op to persist probe tracking.
+  await ctx.db
+    .update(regionCustomDomains)
+    .set(patch)
+    .where(eq(regionCustomDomains.id, row.id));
+
+  // Re-read relevant fields to decide the state transition.
+  const projectedUs =
+    ctx.region === "us-central1" && success
+      ? nowIso
+      : row.probeRegionUsCentral1LastSuccess;
+  const projectedEu =
+    ctx.region === "europe-west1" && success
+      ? nowIso
+      : row.probeRegionEuropeWest1LastSuccess;
+  const projectedConsecutive = patch.probeConsecutiveSuccesses ?? 0;
+
+  // Advance criteria: >=3 consecutive successes AND both regions fresh.
+  if (
+    projectedConsecutive >= REQUIRED_CONSECUTIVE_SUCCESSES &&
+    bothRegionsFresh({
+      probeRegionUsCentral1LastSuccess: projectedUs,
+      probeRegionEuropeWest1LastSuccess: projectedEu,
+      now: deps.now,
+    })
+  ) {
+    const updated = await stateGuardedUpdate(ctx.db, {
+      id: row.id,
+      expectedState: "awaiting_probe",
+      newState: "awaiting_cutover",
+    });
+    if (updated !== null) {
+      await appendDomainEvent(ctx.db, {
+        domainId: row.id,
+        eventType: "reconciler.probe_advanced",
+        fromState: "awaiting_probe",
+        toState: "awaiting_cutover",
+        details: { probe_result: mergedBlob },
+        reconcilerRunId: ctx.reconcilerRunId,
+      });
+      ctx.logger.info("advanced awaiting_probe → awaiting_cutover", logFields);
+    }
+    return;
+  }
+
+  // 2-hour hard timeout.
+  const enteredAt =
+    (await findAwaitingProbeEnteredAt(ctx, row.id)) ?? new Date(row.createdAt);
+  if (deps.now.getTime() - enteredAt.getTime() > HARD_TIMEOUT_MS) {
+    await transitionToDegradedOnTimeout(ctx, row, mergedBlob);
+    return;
+  }
+
+  // Otherwise nothing to do beyond the patch already persisted.
+  await touchReconciledAt(ctx.db, row.id);
+}
+
+async function transitionToDegradedOnTimeout(
+  ctx: OperationContext,
+  row: RegionCustomDomain,
+  mergedBlob: ProbeDetailBlob,
+): Promise<void> {
+  const payload = {
+    drift_kind: "unexpected_state" as const,
+    resource_type: "Certificate" as const,
+    resource_name: `cert-${row.id}`,
+    observed_spec: mergedBlob,
+    expected_spec: {
+      probe_consecutive_successes_required: REQUIRED_CONSECUTIVE_SUCCESSES,
+      freshness_window_ms: FRESHNESS_WINDOW_MS,
+    },
+    recoverable_from: "awaiting_probe" as const,
+    detected_at: new Date().toISOString(),
+    reconciler_run_id: ctx.reconcilerRunId,
+    details: "awaiting_probe hard timeout exceeded (2 hours)",
+  };
+  const updated = await stateGuardedUpdate(ctx.db, {
+    id: row.id,
+    expectedState: "awaiting_probe",
+    newState: "degraded",
+    patch: { reconcilerError: payload },
+  });
+  if (updated === null) return;
+  ctx.logger.drift({
+    domainId: row.id,
+    driftKind: "unexpected_state",
+    resourceType: "Certificate",
+    resourceName: `cert-${row.id}`,
+    observedSpec: mergedBlob,
+    expectedSpec: payload.expected_spec,
+    recoverableFrom: "awaiting_probe",
+  });
+  await appendDomainEvent(ctx.db, {
+    domainId: row.id,
+    eventType: "reconciler.probe_hard_timeout",
+    fromState: "awaiting_probe",
+    toState: "degraded",
+    details: { reconciler_error: payload },
+    reconcilerRunId: ctx.reconcilerRunId,
+  });
+}

--- a/apps/reconciler/src/probe/index.ts
+++ b/apps/reconciler/src/probe/index.ts
@@ -1,0 +1,10 @@
+export {
+  runSniProbe,
+  isSniProbeSuccess,
+  parseHttpResponse,
+} from "./sni-probe.js";
+export type {
+  SniProbeInput,
+  SniProbeResult,
+  SniProbeCertDetail,
+} from "./sni-probe.js";

--- a/apps/reconciler/src/probe/sni-probe.ts
+++ b/apps/reconciler/src/probe/sni-probe.ts
@@ -1,0 +1,306 @@
+/**
+ * Direct-to-LB SNI probe (R5 Decision 4).
+ *
+ * This is the architectural centerpiece of R5. The probe MUST NOT resolve
+ * public DNS for the tenant hostname — the whole point of this rewrite is
+ * that R4's probe did exactly that and certified the old stack.
+ *
+ * Flow:
+ *   1. Open a raw TCP connection to the LB's static IPv4 on port 443.
+ *      The IPv4 is a known config value (Terraform output), passed in
+ *      as `targetIp`.
+ *   2. Initiate a TLS handshake via `tls.connect()` with:
+ *        - `host` = targetIp                (no DNS lookup — numeric)
+ *        - `servername` = tenant hostname   (SNI + certificate name check)
+ *        - `rejectUnauthorized: true`       (full cert validation)
+ *   3. On `secureConnect`, immediately write a minimal HTTP/1.1 GET /health
+ *      request to the already-established socket (Host header = hostname).
+ *   4. Read response, require HTTP/1.1 200 OK + x-redirect-platform: ok.
+ *   5. Extract cert serial and expiry from the peer cert for logging.
+ *   6. Resolve with a structured result; reject only on programming errors.
+ *
+ * The probe has a hard timeout (default 10s). Retry loops are deliberately
+ * NOT implemented here — the reconciler retries at the cycle level.
+ */
+
+import { connect as tlsConnect } from "node:tls";
+import type { TLSSocket, ConnectionOptions } from "node:tls";
+
+/** Default `tls.connect` wrapper constrained to the single options-object signature. */
+function defaultTlsConnect(options: ConnectionOptions): TLSSocket {
+  return tlsConnect(options);
+}
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export interface SniProbeInput {
+  /** LB static IPv4 (e.g. from Terraform output `lb_ipv4_address`). */
+  targetIp: string;
+  /** LB port. Defaults to 443. */
+  targetPort?: number;
+  /** Tenant hostname — passed as SNI servername and Host header. */
+  hostname: string;
+  /** Hard timeout for the entire probe in ms. Defaults to 10000. */
+  timeoutMs?: number;
+  /**
+   * Test seam — replaces `tls.connect`. Production code leaves this
+   * undefined and uses the real Node TLS stack. The shape is a single
+   * options-object signature (narrower than the `tls.connect` overload
+   * set) so call sites can delegate cleanly.
+   */
+  tlsConnectFn?: (options: ConnectionOptions) => TLSSocket;
+}
+
+export interface SniProbeCertDetail {
+  serialNumber: string | null;
+  validFrom: string | null;
+  validTo: string | null;
+  subjectCN: string | null;
+  issuerCN: string | null;
+}
+
+export interface SniProbeResult {
+  handshake_ok: boolean;
+  http_status: number | null;
+  cert: SniProbeCertDetail | null;
+  latency_ms: number;
+  redirect_platform_header_ok: boolean;
+  error: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// Implementation
+// ---------------------------------------------------------------------------
+
+const REQUIRED_HEADER_NAME = "x-redirect-platform";
+const REQUIRED_HEADER_VALUE = "ok";
+
+function formatHttpRequest(hostname: string): string {
+  return (
+    `GET /health HTTP/1.1\r\n` +
+    `Host: ${hostname}\r\n` +
+    `User-Agent: redirect-platform-reconciler/1.0\r\n` +
+    `Connection: close\r\n` +
+    `Accept: */*\r\n` +
+    `\r\n`
+  );
+}
+
+interface ParsedHttpResponse {
+  status: number;
+  headers: Record<string, string>;
+  body: string;
+}
+
+/**
+ * Minimal HTTP/1.1 response parser — just enough to read status code,
+ * headers (lowercased), and body. Not a general-purpose parser.
+ */
+export function parseHttpResponse(raw: string): ParsedHttpResponse | null {
+  const headerEnd = raw.indexOf("\r\n\r\n");
+  if (headerEnd < 0) return null;
+  const head = raw.slice(0, headerEnd);
+  const body = raw.slice(headerEnd + 4);
+  const lines = head.split("\r\n");
+  const statusLine = lines[0];
+  if (!statusLine) return null;
+  const statusMatch = /^HTTP\/1\.[01]\s+(\d{3})/.exec(statusLine);
+  if (!statusMatch?.[1]) return null;
+  const status = Number.parseInt(statusMatch[1], 10);
+  const headers: Record<string, string> = {};
+  for (let i = 1; i < lines.length; i++) {
+    const line = lines[i];
+    if (!line) continue;
+    const colon = line.indexOf(":");
+    if (colon < 0) continue;
+    const key = line.slice(0, colon).toLowerCase();
+    const value = line.slice(colon + 1).trim();
+    headers[key] = value;
+  }
+  return { status, headers, body };
+}
+
+/**
+ * Extract the narrow cert-detail projection from a TLS peer certificate.
+ * Returns null if no cert is present or all fields are unavailable.
+ */
+function projectPeerCert(socket: TLSSocket): SniProbeCertDetail | null {
+  // getPeerCertificate returns an object where every field may be missing.
+  const raw = socket.getPeerCertificate(false) as
+    | {
+        serialNumber?: string;
+        valid_from?: string;
+        valid_to?: string;
+        subject?: { CN?: string };
+        issuer?: { CN?: string };
+      }
+    | undefined;
+  if (!raw || Object.keys(raw).length === 0) {
+    return null;
+  }
+  return {
+    serialNumber: raw.serialNumber ?? null,
+    validFrom: raw.valid_from ?? null,
+    validTo: raw.valid_to ?? null,
+    subjectCN: raw.subject?.CN ?? null,
+    issuerCN: raw.issuer?.CN ?? null,
+  };
+}
+
+/**
+ * Run one SNI probe. Resolves with a structured result regardless of
+ * success or failure. Never rejects.
+ */
+export function runSniProbe(input: SniProbeInput): Promise<SniProbeResult> {
+  const {
+    targetIp,
+    targetPort = 443,
+    hostname,
+    timeoutMs = 10_000,
+    tlsConnectFn = defaultTlsConnect,
+  } = input;
+
+  return new Promise<SniProbeResult>((resolve) => {
+    const startedAt = Date.now();
+    let settled = false;
+    let handshakeOk = false;
+    let cert: SniProbeCertDetail | null = null;
+    let responseBuf = "";
+
+    function settle(result: Omit<SniProbeResult, "latency_ms">): void {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      try {
+        socket.destroy();
+      } catch {
+        // socket may already be destroyed; ignore
+      }
+      resolve({
+        ...result,
+        latency_ms: Date.now() - startedAt,
+      });
+    }
+
+    const timer = setTimeout(() => {
+      settle({
+        handshake_ok: handshakeOk,
+        http_status: null,
+        cert,
+        redirect_platform_header_ok: false,
+        error: `probe timed out after ${String(timeoutMs)}ms`,
+      });
+    }, timeoutMs);
+
+    const options: ConnectionOptions = {
+      host: targetIp,
+      port: targetPort,
+      servername: hostname,
+      rejectUnauthorized: true,
+      // Use the system trust store (default in Node 20+ with a system ca
+      // bundle; for production containers we rely on the standard bundle).
+      ALPNProtocols: ["http/1.1"],
+      // Disable session resumption so each probe exercises a full handshake.
+      session: undefined,
+    };
+
+    const socket: TLSSocket = tlsConnectFn(options);
+
+    socket.once("secureConnect", () => {
+      handshakeOk = true;
+      cert = projectPeerCert(socket);
+      // Write the HTTP request; if the peer closes on us before we finish
+      // writing, the 'error' handler will fire.
+      try {
+        socket.write(formatHttpRequest(hostname));
+      } catch (writeErr) {
+        settle({
+          handshake_ok: true,
+          http_status: null,
+          cert,
+          redirect_platform_header_ok: false,
+          error: `socket write failed: ${String(writeErr)}`,
+        });
+      }
+    });
+
+    socket.on("data", (chunk: Buffer) => {
+      responseBuf += chunk.toString("utf8");
+    });
+
+    socket.on("end", () => {
+      const parsed = parseHttpResponse(responseBuf);
+      if (!parsed) {
+        settle({
+          handshake_ok: handshakeOk,
+          http_status: null,
+          cert,
+          redirect_platform_header_ok: false,
+          error: "could not parse HTTP response",
+        });
+        return;
+      }
+      const headerOk =
+        parsed.headers[REQUIRED_HEADER_NAME] === REQUIRED_HEADER_VALUE;
+      settle({
+        handshake_ok: handshakeOk,
+        http_status: parsed.status,
+        cert,
+        redirect_platform_header_ok: headerOk,
+        error: null,
+      });
+    });
+
+    socket.on("error", (err: Error) => {
+      settle({
+        handshake_ok: handshakeOk,
+        http_status: null,
+        cert,
+        redirect_platform_header_ok: false,
+        error: `${err.name}: ${err.message}`,
+      });
+    });
+
+    socket.on("close", () => {
+      // Fallback: if the socket closed without 'end' emitting and we have
+      // any response bytes, try to parse them. If we already settled, this
+      // is a no-op.
+      if (settled) return;
+      if (responseBuf.length > 0) {
+        const parsed = parseHttpResponse(responseBuf);
+        if (parsed) {
+          settle({
+            handshake_ok: handshakeOk,
+            http_status: parsed.status,
+            cert,
+            redirect_platform_header_ok:
+              parsed.headers[REQUIRED_HEADER_NAME] === REQUIRED_HEADER_VALUE,
+            error: null,
+          });
+          return;
+        }
+      }
+      settle({
+        handshake_ok: handshakeOk,
+        http_status: null,
+        cert,
+        redirect_platform_header_ok: false,
+        error: "socket closed without complete response",
+      });
+    });
+  });
+}
+
+/**
+ * Convenience: is a probe result "successful" by the Decision 4 criteria?
+ * Handshake OK, HTTP 200, required header present.
+ */
+export function isSniProbeSuccess(result: SniProbeResult): boolean {
+  return (
+    result.handshake_ok &&
+    result.http_status === 200 &&
+    result.redirect_platform_header_ok
+  );
+}

--- a/apps/reconciler/src/process.ts
+++ b/apps/reconciler/src/process.ts
@@ -1,75 +1,124 @@
 /**
- * Reconciler cycle entry point — scaffold stub.
+ * Reconciler cycle dispatcher — F3R5_010 (operations 1–4).
  *
- * F3R5_009 is the scaffold only. The actual reconciler operations land
- * in F3R5_010 (ops 1-4: DNS challenge validation, cert provisioning,
- * SNI probe, post-cutover DNS verification) and F3R5_011 (ops 5-8:
- * active health re-probe, tombstone cleanup, quarantine drift check,
- * periodic drift detection).
+ * Invoked once per Cloud Run job execution under a singleton lease with
+ * the heartbeat runner. This function is the top-level fan-out into the
+ * four transient-state operations defined in R5 Decision 6. Operations
+ * 5–8 will be added by F3R5_011.
  *
- * See R5 Decision 6 "Operations performed per cycle" for the
- * authoritative spec of each operation.
+ * Each operation is idempotent and short-transaction: GCP API calls
+ * happen OUTSIDE any DB transaction, every state transition is a
+ * state-guarded UPDATE, and the reconciler never holds a DB connection
+ * open across a remote call.
  */
 
+import { randomUUID } from "node:crypto";
+
 import type { ReconcilerDb } from "./db/client.js";
-import type { Lease, HeartbeatStatus } from "./lease.js";
+import {
+  createCertManagerClient,
+  loadCertManagerConfig,
+} from "./gcp/cert-manager-client.js";
+import type { CertManagerClient } from "./gcp/cert-manager-client.js";
+import type { HeartbeatStatus, Lease } from "./lease.js";
 import type { Logger } from "./logging.js";
+import {
+  loadPostCutoverConfig,
+  loadSniProbeConfig,
+  runCertProvisioning,
+  runDnsChallengeValidation,
+  runPostCutoverVerification,
+  runSniProbeOperation,
+} from "./operations/index.js";
+import type {
+  OperationContext,
+  PostCutoverConfig,
+  SniProbeOpConfig,
+} from "./operations/index.js";
 
 export interface ProcessTransientStatesInput {
   db: ReconcilerDb;
   lease: Lease;
   logger: Logger;
   heartbeat: HeartbeatStatus;
+  /** GCP region this reconciler instance is running in. */
+  region: string;
+  /** Test seam — inject custom dependencies instead of loading from env. */
+  overrides?: ProcessTransientStatesOverrides;
 }
 
-// F3R5_010 / F3R5_011 will add real awaited DB work here; until then the
-// scaffold function is async to match its final shape — hence the lint
-// suppression. Remove both this comment and the disable once the first
-// real operation lands.
-// eslint-disable-next-line @typescript-eslint/require-await
+export interface ProcessTransientStatesOverrides {
+  certManager?: CertManagerClient;
+  sniProbeConfig?: SniProbeOpConfig;
+  postCutoverConfig?: PostCutoverConfig;
+  reconcilerRunId?: string;
+}
+
 export async function processTransientStates(
   input: ProcessTransientStatesInput,
 ): Promise<void> {
-  const { logger, lease, heartbeat } = input;
+  const { logger, lease, heartbeat, region } = input;
+  const overrides = input.overrides ?? {};
+  const reconcilerRunId = overrides.reconcilerRunId ?? randomUUID();
 
-  logger.info(
-    "reconciler cycle started (scaffold stub — no operations implemented)",
-    {
-      lease_key: lease.leaseKey,
-      held_by: lease.heldBy,
-    },
-  );
+  logger.info("reconciler cycle started", {
+    lease_key: lease.leaseKey,
+    held_by: lease.heldBy,
+    reconciler_run_id: reconcilerRunId,
+    region,
+  });
 
-  // Crash recovery scan (R5 Decision 6): re-queue rows in transient states
-  // with `last_reconciled_at` older than 10 minutes. The real query will
-  // live here in F3R5_010.
-  // TODO(F3R5_010): SELECT id FROM region_custom_domains
-  //   WHERE lifecycle_state IN (...transient states...)
-  //     AND (last_reconciled_at IS NULL OR last_reconciled_at < now() - interval '10 minutes');
+  const certManager =
+    overrides.certManager ?? createCertManagerClient(loadCertManagerConfig());
+  const sniProbeConfig = overrides.sniProbeConfig ?? loadSniProbeConfig();
+  const postCutoverConfig =
+    overrides.postCutoverConfig ?? loadPostCutoverConfig();
 
-  // TODO(F3R5_010): op 1 — DNS challenge validation
-  //   awaiting_dns_challenge -> provisioning_cert
-  // TODO(F3R5_010): op 2 — Cert provisioning
-  //   provisioning_cert -> awaiting_probe | degraded
-  // TODO(F3R5_010): op 3 — Multi-vantage SNI probe (Decision 4)
-  //   awaiting_probe -> awaiting_cutover | degraded
-  // TODO(F3R5_010): op 4 — Post-cutover DNS verification
-  //   awaiting_cutover -> active
+  const ctx: OperationContext = {
+    db: input.db,
+    logger,
+    reconcilerRunId,
+    region,
+    certManager,
+  };
 
-  // TODO(F3R5_011): op 5 — Active health re-probe
-  //   active -> degraded on ≥2 consecutive SNI probe failures
-  // TODO(F3R5_011): op 6 — Tombstone cleanup
-  //   tombstoned -> quarantined
-  // TODO(F3R5_011): op 7 — Quarantine expiry with drift check
-  //   quarantined -> released (or degraded on orphan_resource)
-  // TODO(F3R5_011): op 8 — Periodic drift detection across GCP resources
+  // Before each operation, bail early if the heartbeat runner has lost
+  // the lease. Each operation is short-enough that we don't need a
+  // mid-operation check, but we gate at the boundaries to honour the R5
+  // "abort cleanly on lease loss" contract.
 
   if (heartbeat.isLost()) {
-    logger.warn(
-      "reconciler lease lost before any work; scaffold stub returning",
-    );
+    logger.warn("reconciler cycle aborted before op 1: lease lost");
     return;
   }
+  logger.info("running op 1 — DNS challenge validation");
+  await runDnsChallengeValidation(ctx);
 
-  logger.info("reconciler cycle completed (scaffold stub)");
+  if (heartbeat.isLost()) {
+    logger.warn("reconciler cycle aborted before op 2: lease lost");
+    return;
+  }
+  logger.info("running op 2 — cert provisioning");
+  await runCertProvisioning(ctx);
+
+  if (heartbeat.isLost()) {
+    logger.warn("reconciler cycle aborted before op 3: lease lost");
+    return;
+  }
+  logger.info("running op 3 — SNI probe");
+  await runSniProbeOperation(ctx, sniProbeConfig);
+
+  if (heartbeat.isLost()) {
+    logger.warn("reconciler cycle aborted before op 4: lease lost");
+    return;
+  }
+  logger.info("running op 4 — post-cutover DNS verification");
+  await runPostCutoverVerification(ctx, postCutoverConfig);
+
+  // TODO(F3R5_011): op 5 — Active health re-probe
+  // TODO(F3R5_011): op 6 — Tombstone cleanup
+  // TODO(F3R5_011): op 7 — Quarantine expiry with drift check
+  // TODO(F3R5_011): op 8 — Periodic drift detection
+
+  logger.info("reconciler cycle completed");
 }

--- a/apps/reconciler/tests/gcp/cert-manager-client.test.ts
+++ b/apps/reconciler/tests/gcp/cert-manager-client.test.ts
@@ -1,0 +1,257 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  createCertManagerClient,
+  loadCertManagerConfig,
+} from "../../src/gcp/cert-manager-client.js";
+import type { UpstreamCertManagerClient } from "../../src/gcp/cert-manager-client.js";
+import {
+  AlreadyExistsError,
+  NotFoundError,
+  PermissionDeniedError,
+} from "../../src/gcp/errors.js";
+
+function makeUpstream(
+  overrides: Partial<UpstreamCertManagerClient> = {},
+): UpstreamCertManagerClient {
+  const unimplemented = async () => {
+    throw new Error("not mocked");
+  };
+  return {
+    getDnsAuthorization: unimplemented,
+    getCertificate: unimplemented,
+    createCertificate: unimplemented,
+    getCertificateMapEntry: unimplemented,
+    createCertificateMapEntry: unimplemented,
+    ...overrides,
+  };
+}
+
+const testConfig = {
+  projectId: "f3-redirects",
+  location: "global",
+  certMapName: "redirect-platform-cert-map",
+};
+
+describe("loadCertManagerConfig", () => {
+  it("falls back to default values when env is empty", () => {
+    const config = loadCertManagerConfig({});
+    expect(config).toEqual({
+      projectId: "f3-redirects",
+      location: "global",
+      certMapName: "redirect-platform-cert-map",
+    });
+  });
+
+  it("uses GCP_PROJECT_ID and REDIRECT_CERT_MAP_NAME when set", () => {
+    const config = loadCertManagerConfig({
+      GCP_PROJECT_ID: "custom-project",
+      REDIRECT_CERT_MAP_NAME: "custom-map",
+    });
+    expect(config.projectId).toBe("custom-project");
+    expect(config.certMapName).toBe("custom-map");
+  });
+});
+
+describe("certManagerClient.getDnsAuthorization", () => {
+  it("projects the raw upstream response", async () => {
+    const getDnsAuthorization = vi.fn().mockResolvedValue([
+      {
+        name: "projects/f3-redirects/locations/global/dnsAuthorizations/dns-auth-abc",
+        domain: "f3marshall.com",
+        state: "ACTIVE",
+        dnsResourceRecord: {
+          name: "_acme-challenge.f3marshall.com.",
+          type: "CNAME",
+          data: "xyz.authorize.certificatemanager.goog.",
+        },
+      },
+    ]);
+    const upstream = makeUpstream({ getDnsAuthorization });
+    const client = createCertManagerClient(testConfig, upstream);
+
+    const result = await client.getDnsAuthorization("dns-auth-abc");
+    expect(result).not.toBeNull();
+    expect(result?.state).toBe("ACTIVE");
+    expect(result?.dnsResourceRecord?.type).toBe("CNAME");
+    expect(getDnsAuthorization).toHaveBeenCalledWith({
+      name: "projects/f3-redirects/locations/global/dnsAuthorizations/dns-auth-abc",
+    });
+  });
+
+  it("returns null on NOT_FOUND", async () => {
+    const getDnsAuthorization = vi.fn().mockImplementation(() => {
+      const err = new Error("not found") as Error & { code: number };
+      err.code = 5;
+      throw err;
+    });
+    const upstream = makeUpstream({ getDnsAuthorization });
+    const client = createCertManagerClient(testConfig, upstream);
+    expect(await client.getDnsAuthorization("dns-auth-missing")).toBeNull();
+  });
+
+  it("rethrows PERMISSION_DENIED as PermissionDeniedError", async () => {
+    const getDnsAuthorization = vi.fn().mockImplementation(() => {
+      const err = new Error("denied") as Error & { code: number };
+      err.code = 7;
+      throw err;
+    });
+    const upstream = makeUpstream({ getDnsAuthorization });
+    const client = createCertManagerClient(testConfig, upstream);
+    await expect(
+      client.getDnsAuthorization("dns-auth-x"),
+    ).rejects.toBeInstanceOf(PermissionDeniedError);
+  });
+});
+
+describe("certManagerClient.getCertificate", () => {
+  it("projects managed.authorizationAttemptInfo[0].details onto failureDetails", async () => {
+    const getCertificate = vi.fn().mockResolvedValue([
+      {
+        name: "projects/f3-redirects/locations/global/certificates/cert-abc",
+        managed: {
+          domains: ["f3marshall.com"],
+          dnsAuthorizations: [
+            "projects/f3-redirects/locations/global/dnsAuthorizations/dns-auth-abc",
+          ],
+          state: "FAILED",
+          authorizationAttemptInfo: [
+            { details: "ACME authorization failed: DNS01 challenge missing" },
+          ],
+        },
+      },
+    ]);
+    const client = createCertManagerClient(
+      testConfig,
+      makeUpstream({ getCertificate }),
+    );
+    const result = await client.getCertificate("cert-abc");
+    expect(result.managed?.state).toBe("FAILED");
+    expect(result.managed?.failureDetails).toContain("DNS01 challenge missing");
+  });
+
+  it("throws NotFoundError on 404", async () => {
+    const getCertificate = vi.fn().mockImplementation(() => {
+      const err = new Error("missing") as Error & { code: number };
+      err.code = 5;
+      throw err;
+    });
+    const client = createCertManagerClient(
+      testConfig,
+      makeUpstream({ getCertificate }),
+    );
+    await expect(client.getCertificate("cert-missing")).rejects.toBeInstanceOf(
+      NotFoundError,
+    );
+  });
+});
+
+describe("certManagerClient.createCertificate", () => {
+  it("awaits the LRO.promise() and passes the expected request shape", async () => {
+    const lroPromise = vi.fn().mockResolvedValue([{}, null, null]);
+    const createCertificate = vi
+      .fn()
+      .mockResolvedValue([{ promise: lroPromise }]);
+    const client = createCertManagerClient(
+      testConfig,
+      makeUpstream({ createCertificate }),
+    );
+    await client.createCertificate({
+      certificateId: "cert-abc",
+      domain: "f3marshall.com",
+      dnsAuthorizationName:
+        "projects/f3-redirects/locations/global/dnsAuthorizations/dns-auth-abc",
+    });
+    expect(createCertificate).toHaveBeenCalledTimes(1);
+    const [callArg] = createCertificate.mock.calls[0] as [
+      {
+        parent: string;
+        certificateId: string;
+        certificate: { managed: { domains: string[] } };
+      },
+    ];
+    expect(callArg.parent).toBe("projects/f3-redirects/locations/global");
+    expect(callArg.certificateId).toBe("cert-abc");
+    expect(callArg.certificate.managed.domains).toEqual(["f3marshall.com"]);
+    expect(lroPromise).toHaveBeenCalled();
+  });
+
+  it("throws AlreadyExistsError on ALREADY_EXISTS", async () => {
+    const createCertificate = vi.fn().mockImplementation(() => {
+      const err = new Error("exists") as Error & { code: number };
+      err.code = 6;
+      throw err;
+    });
+    const client = createCertManagerClient(
+      testConfig,
+      makeUpstream({ createCertificate }),
+    );
+    await expect(
+      client.createCertificate({
+        certificateId: "cert-abc",
+        domain: "f3marshall.com",
+        dnsAuthorizationName:
+          "projects/f3-redirects/locations/global/dnsAuthorizations/dns-auth-abc",
+      }),
+    ).rejects.toBeInstanceOf(AlreadyExistsError);
+  });
+});
+
+describe("certManagerClient.getCertificateMapEntry", () => {
+  it("returns null on 404 and projects certificates array", async () => {
+    const getCertificateMapEntry = vi
+      .fn()
+      .mockResolvedValueOnce([null])
+      .mockImplementationOnce(() => {
+        const err = new Error("not found") as Error & { code: number };
+        err.code = 5;
+        throw err;
+      });
+    const client = createCertManagerClient(
+      testConfig,
+      makeUpstream({ getCertificateMapEntry }),
+    );
+    const first = await client.getCertificateMapEntry("cme-a");
+    expect(first).not.toBeNull();
+    // null response maps to a zero-valued projection; certificates is empty array
+    expect(first?.certificates).toEqual([]);
+
+    const second = await client.getCertificateMapEntry("cme-b");
+    expect(second).toBeNull();
+  });
+});
+
+describe("certManagerClient.createCertificateMapEntry", () => {
+  it("uses the cert map parent path and awaits the LRO", async () => {
+    const lroPromise = vi.fn().mockResolvedValue([{}, null, null]);
+    const createCertificateMapEntry = vi
+      .fn()
+      .mockResolvedValue([{ promise: lroPromise }]);
+    const client = createCertManagerClient(
+      testConfig,
+      makeUpstream({ createCertificateMapEntry }),
+    );
+    await client.createCertificateMapEntry({
+      entryId: "cme-abc",
+      hostname: "f3marshall.com",
+      certificateName:
+        "projects/f3-redirects/locations/global/certificates/cert-abc",
+    });
+    const [req] = createCertificateMapEntry.mock.calls[0] as [
+      {
+        parent: string;
+        certificateMapEntryId: string;
+        certificateMapEntry: { hostname: string; certificates: string[] };
+      },
+    ];
+    expect(req.parent).toBe(
+      "projects/f3-redirects/locations/global/certificateMaps/redirect-platform-cert-map",
+    );
+    expect(req.certificateMapEntryId).toBe("cme-abc");
+    expect(req.certificateMapEntry.hostname).toBe("f3marshall.com");
+    expect(req.certificateMapEntry.certificates).toEqual([
+      "projects/f3-redirects/locations/global/certificates/cert-abc",
+    ]);
+    expect(lroPromise).toHaveBeenCalled();
+  });
+});

--- a/apps/reconciler/tests/gcp/errors.test.ts
+++ b/apps/reconciler/tests/gcp/errors.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  AlreadyExistsError,
+  GRPC_STATUS_ALREADY_EXISTS,
+  GRPC_STATUS_NOT_FOUND,
+  GRPC_STATUS_PERMISSION_DENIED,
+  NotFoundError,
+  PermissionDeniedError,
+  mapGcpError,
+} from "../../src/gcp/errors.js";
+
+describe("mapGcpError", () => {
+  it("passes through the successful value", async () => {
+    const result = await mapGcpError(
+      "Certificate",
+      "projects/p/locations/global/certificates/cert-1",
+      async () => "ok",
+    );
+    expect(result).toBe("ok");
+  });
+
+  it("translates NOT_FOUND (code 5) into NotFoundError", async () => {
+    await expect(
+      mapGcpError("DnsAuthorization", "dns-auth-x", async () => {
+        const err = new Error("not found") as Error & { code: number };
+        err.code = GRPC_STATUS_NOT_FOUND;
+        throw err;
+      }),
+    ).rejects.toBeInstanceOf(NotFoundError);
+  });
+
+  it("translates ALREADY_EXISTS (code 6) into AlreadyExistsError", async () => {
+    await expect(
+      mapGcpError("Certificate", "cert-1", async () => {
+        const err = new Error("already exists") as Error & { code: number };
+        err.code = GRPC_STATUS_ALREADY_EXISTS;
+        throw err;
+      }),
+    ).rejects.toBeInstanceOf(AlreadyExistsError);
+  });
+
+  it("translates PERMISSION_DENIED (code 7) into PermissionDeniedError", async () => {
+    await expect(
+      mapGcpError("Certificate", "cert-1", async () => {
+        const err = new Error("denied") as Error & { code: number };
+        err.code = GRPC_STATUS_PERMISSION_DENIED;
+        throw err;
+      }),
+    ).rejects.toBeInstanceOf(PermissionDeniedError);
+  });
+
+  it("rethrows unknown errors unchanged", async () => {
+    const original = new Error("unknown");
+    await expect(
+      mapGcpError("Certificate", "cert-1", async () => {
+        throw original;
+      }),
+    ).rejects.toBe(original);
+  });
+
+  it("rethrows errors without a numeric code field", async () => {
+    const original = new Error("string code") as Error & { code: string };
+    original.code = "ENOTFOUND";
+    await expect(
+      mapGcpError("Certificate", "cert-1", async () => {
+        throw original;
+      }),
+    ).rejects.toBe(original);
+  });
+});

--- a/apps/reconciler/tests/helpers/fake-db.ts
+++ b/apps/reconciler/tests/helpers/fake-db.ts
@@ -1,0 +1,288 @@
+/**
+ * In-memory fake for the tiny subset of ReconcilerDb that operations
+ * actually exercise. We do NOT attempt to emulate drizzle-orm's full query
+ * builder — instead we model:
+ *
+ *   - `db.select().from(table).where(whereExpr).limit(n)` → row array
+ *   - `db.select().from(table).where(whereExpr).orderBy(...).limit(n)`
+ *   - `db.update(table).set(values).where(whereExpr).returning()` → rows
+ *   - `db.update(table).set(values).where(whereExpr)` → void
+ *   - `db.insert(table).values(row)`
+ *
+ * The fake keeps three arrays: `regionCustomDomains`, `events`, and a
+ * recorded call log. Where-expressions from drizzle's `eq()`/`and()` are
+ * opaque SQLWrapper objects; since we don't care about matching them
+ * structurally, the fake returns rows that were pre-seeded by key. Tests
+ * stage the state directly and assert outputs.
+ */
+
+import type { ReconcilerDb } from "../../src/db/client.js";
+import type {
+  RegionCustomDomain,
+  RegionCustomDomainEvent,
+} from "@acme/redirect-platform-db";
+
+export interface FakeDbState {
+  rows: RegionCustomDomain[];
+  events: RegionCustomDomainEvent[];
+  /** Records every non-trivial call so tests can assert order. */
+  log: string[];
+}
+
+/**
+ * Matcher used by select().from().where() to decide which rows to return.
+ * Tests can override this via `fake.filter = row => ...`.
+ */
+export interface FakeDbMatchers {
+  /** Called for each select() — return the rows to hand back. */
+  filter?: (row: RegionCustomDomain) => boolean;
+}
+
+export interface FakeDb {
+  db: ReconcilerDb;
+  state: FakeDbState;
+  matchers: FakeDbMatchers;
+}
+
+export function createFakeDb(initial: Partial<FakeDbState> = {}): FakeDb {
+  const state: FakeDbState = {
+    rows: initial.rows ?? [],
+    events: initial.events ?? [],
+    log: [],
+  };
+  const matchers: FakeDbMatchers = {};
+
+  function select(): { from: (table: unknown) => SelectFrom } {
+    return {
+      from(_table) {
+        return createSelectFrom(state, matchers);
+      },
+    };
+  }
+
+  function update(table: unknown): UpdateChain {
+    return createUpdateChain(state, table);
+  }
+
+  function insert(table: unknown): InsertChain {
+    return createInsertChain(state, table);
+  }
+
+  const db = {
+    select,
+    update,
+    insert,
+  } as unknown as ReconcilerDb;
+
+  return { db, state, matchers };
+}
+
+interface SelectFrom {
+  where(expr: unknown): SelectFromWhere;
+}
+interface SelectFromWhere {
+  limit(n: number): Promise<RegionCustomDomain[]>;
+  orderBy(...exprs: unknown[]): SelectFromWhereOrderBy;
+}
+interface SelectFromWhereOrderBy {
+  limit(n: number): Promise<RegionCustomDomain[]>;
+}
+
+function createSelectFrom(
+  state: FakeDbState,
+  matchers: FakeDbMatchers,
+): SelectFrom {
+  return {
+    where(_expr) {
+      const chain = {
+        async limit(n: number) {
+          state.log.push(`select.limit(${String(n)})`);
+          const filtered = matchers.filter
+            ? state.rows.filter(matchers.filter)
+            : state.rows;
+          return filtered.slice(0, n);
+        },
+        orderBy(..._exprs: unknown[]) {
+          return {
+            async limit(n: number) {
+              state.log.push(`select.orderBy.limit(${String(n)})`);
+              const filtered = matchers.filter
+                ? state.rows.filter(matchers.filter)
+                : state.rows;
+              return filtered.slice(0, n);
+            },
+          };
+        },
+      };
+      return chain;
+    },
+  };
+}
+
+interface UpdateChain {
+  set(values: Record<string, unknown>): UpdateSet;
+}
+interface UpdateSet {
+  where(expr: unknown): UpdateWhere;
+}
+interface UpdateWhere {
+  returning(): Promise<RegionCustomDomain[]>;
+  then<TResult1 = void, TResult2 = never>(
+    onfulfilled?:
+      | ((value: void) => TResult1 | PromiseLike<TResult1>)
+      | undefined
+      | null,
+    onrejected?:
+      | ((reason: unknown) => TResult2 | PromiseLike<TResult2>)
+      | undefined
+      | null,
+  ): Promise<TResult1 | TResult2>;
+}
+
+function createUpdateChain(state: FakeDbState, _table: unknown): UpdateChain {
+  return {
+    set(values) {
+      return {
+        where(_expr) {
+          // Apply the update to any row whose id matches the current
+          // "hint" id. We use a very loose model: if `values` contains an
+          // `id` lookup we match exactly; otherwise the test drives the
+          // target via `state.rows[0]`.
+          // For our tests we call applyUpdate() with a matcher function.
+          return createUpdateWhereApply(state, values);
+        },
+      };
+    },
+  };
+}
+
+function createUpdateWhereApply(
+  state: FakeDbState,
+  values: Record<string, unknown>,
+): UpdateWhere {
+  // Heuristic: match the row whose currentStateHint matches a stored
+  // value and whose id matches patch.id if present. Tests set `state.rows`
+  // carefully and rely on the fact that our operations read a row, then
+  // update it — so we match the first row with matching lifecycleState if
+  // a newState was set (state-guarded UPDATE), otherwise all rows.
+  const newState = values.lifecycleState as string | undefined;
+  const matchIds = (state as FakeDbState & { _guardId?: string })._guardId;
+
+  function apply(): RegionCustomDomain[] {
+    const applied: RegionCustomDomain[] = [];
+    for (let i = 0; i < state.rows.length; i++) {
+      const r = state.rows[i];
+      if (!r) continue;
+      if (matchIds !== undefined && r.id !== matchIds) continue;
+      // For state-guarded updates, tests pre-set `_expectedState` so we
+      // know which row to match.
+      const expected = (state as FakeDbState & { _expectedState?: string })
+        ._expectedState;
+      if (expected !== undefined && r.lifecycleState !== expected) continue;
+      const next: RegionCustomDomain = {
+        ...r,
+        ...values,
+      } as RegionCustomDomain;
+      state.rows[i] = next;
+      applied.push(next);
+      // Only one row per call — keeps the "RETURNING *" single-row semantics.
+      break;
+    }
+    state.log.push(`update.set{newState=${String(newState ?? "<same>")}}`);
+    return applied;
+  }
+
+  const chain: UpdateWhere = {
+    async returning() {
+      return apply();
+    },
+    then(onfulfilled, onrejected) {
+      try {
+        apply();
+        return Promise.resolve().then(onfulfilled, onrejected);
+      } catch (err) {
+        return Promise.reject(err).catch(
+          onrejected ?? (() => undefined),
+        ) as Promise<never>;
+      }
+    },
+  };
+  return chain;
+}
+
+interface InsertChain {
+  values(row: Record<string, unknown>): Promise<void>;
+}
+function createInsertChain(state: FakeDbState, _table: unknown): InsertChain {
+  return {
+    async values(row) {
+      // Only used by appendDomainEvent. Best-effort cast.
+      state.events.push(row as unknown as RegionCustomDomainEvent);
+      state.log.push("insert.values");
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// State-guard helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Set the implicit state-guard filters the fake uses to match UPDATE
+ * statements. Call this before each operation under test so the fake
+ * mimics the `WHERE id = $id AND lifecycle_state = $expected` guard.
+ */
+export function setStateGuard(
+  fake: FakeDb,
+  guard: { id?: string; expectedState?: string },
+): void {
+  (
+    fake.state as FakeDbState & {
+      _guardId?: string;
+      _expectedState?: string;
+    }
+  )._guardId = guard.id;
+  (
+    fake.state as FakeDbState & {
+      _guardId?: string;
+      _expectedState?: string;
+    }
+  )._expectedState = guard.expectedState;
+}
+
+// ---------------------------------------------------------------------------
+// Sample row factory
+// ---------------------------------------------------------------------------
+
+export function makeRow(
+  overrides: Partial<RegionCustomDomain> = {},
+): RegionCustomDomain {
+  return {
+    id: "00000000-0000-0000-0000-000000000001",
+    orgId: 42,
+    regionSlug: "muletown",
+    regionId: "35838",
+    regionName: "Muletown",
+    hostname: "f3marshall.com",
+    hostnameRole: "apex",
+    gcpDnsAuthorizationId: null,
+    gcpCertificateId: null,
+    gcpCertMapEntryId: null,
+    dnsChallengeRecordName: null,
+    dnsChallengeRecordValue: null,
+    lifecycleState: "awaiting_dns_challenge",
+    probeConsecutiveSuccesses: 0,
+    probeLastAttemptedAt: null,
+    probeLastResultDetail: null,
+    probeRegionUsCentral1LastSuccess: null,
+    probeRegionEuropeWest1LastSuccess: null,
+    lastReconciledAt: null,
+    reconcilerError: null,
+    createdBy: 1,
+    createdAt: new Date("2026-04-14T10:00:00Z").toISOString(),
+    updatedAt: new Date("2026-04-14T10:00:00Z").toISOString(),
+    tombstonedAt: null,
+    releasedAt: null,
+    ...overrides,
+  };
+}

--- a/apps/reconciler/tests/helpers/fake-logger.ts
+++ b/apps/reconciler/tests/helpers/fake-logger.ts
@@ -1,0 +1,36 @@
+import { vi } from "vitest";
+
+import type { Logger } from "../../src/logging.js";
+
+export function createFakeLogger(): Logger & {
+  infoCalls: unknown[][];
+  warnCalls: unknown[][];
+  errorCalls: unknown[][];
+  driftCalls: unknown[][];
+} {
+  const infoCalls: unknown[][] = [];
+  const warnCalls: unknown[][] = [];
+  const errorCalls: unknown[][] = [];
+  const driftCalls: unknown[][] = [];
+  return {
+    info: vi.fn((...args: unknown[]) => {
+      infoCalls.push(args);
+    }),
+    warn: vi.fn((...args: unknown[]) => {
+      warnCalls.push(args);
+    }),
+    error: vi.fn((...args: unknown[]) => {
+      errorCalls.push(args);
+    }),
+    critical: vi.fn(),
+    drift: vi.fn((...args: unknown[]) => {
+      driftCalls.push(args);
+    }),
+    stuckOperation: vi.fn(),
+    certRenewal: vi.fn(),
+    infoCalls,
+    warnCalls,
+    errorCalls,
+    driftCalls,
+  };
+}

--- a/apps/reconciler/tests/operations/cert-provisioning.test.ts
+++ b/apps/reconciler/tests/operations/cert-provisioning.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it } from "vitest";
+
+import type {
+  CertManagerClient,
+  CertificateMapEntryView,
+  CertificateView,
+} from "../../src/gcp/cert-manager-client.js";
+import { NotFoundError } from "../../src/gcp/errors.js";
+import {
+  cmeSpecMatches,
+  reconcileOneCertProvisioning,
+} from "../../src/operations/cert-provisioning.js";
+import type { OperationContext } from "../../src/operations/shared.js";
+import { createFakeDb, makeRow, setStateGuard } from "../helpers/fake-db.js";
+import { createFakeLogger } from "../helpers/fake-logger.js";
+
+function certManagerStub(
+  overrides: Partial<CertManagerClient> = {},
+): CertManagerClient {
+  return {
+    dnsAuthorizationResourcePath: (id) =>
+      `projects/test/locations/global/dnsAuthorizations/${id}`,
+    certificateResourcePath: (id) =>
+      `projects/test/locations/global/certificates/${id}`,
+    async getDnsAuthorization() {
+      return null;
+    },
+    async getCertificate() {
+      throw new NotFoundError("Certificate", "unset");
+    },
+    async createCertificate() {},
+    async getCertificateMapEntry() {
+      return null;
+    },
+    async createCertificateMapEntry() {},
+    ...overrides,
+  };
+}
+
+function makeCtx(
+  fakeDb: ReturnType<typeof createFakeDb>,
+  certManager: CertManagerClient,
+): OperationContext {
+  return {
+    db: fakeDb.db,
+    logger: createFakeLogger(),
+    reconcilerRunId: "run-test",
+    region: "us-central1",
+    certManager,
+  };
+}
+
+const activeCert: CertificateView = {
+  name: "projects/test/locations/global/certificates/cert-aaa",
+  managed: {
+    domains: ["f3marshall.com"],
+    dnsAuthorizations: [
+      "projects/test/locations/global/dnsAuthorizations/dns-auth-aaa",
+    ],
+    state: "ACTIVE",
+    failureDetails: null,
+  },
+};
+
+const provisioningCert: CertificateView = {
+  ...activeCert,
+  managed: { ...activeCert.managed!, state: "PROVISIONING" },
+};
+
+const failedCert: CertificateView = {
+  ...activeCert,
+  managed: {
+    ...activeCert.managed!,
+    state: "FAILED",
+    failureDetails: "ACME challenge missing",
+  },
+};
+
+const matchingCme: CertificateMapEntryView = {
+  name: "projects/test/locations/global/certificateMaps/redirect-platform-cert-map/certificateMapEntries/cme-aaa",
+  hostname: "f3marshall.com",
+  certificates: ["projects/test/locations/global/certificates/cert-aaa"],
+};
+
+describe("cmeSpecMatches", () => {
+  it("matches when hostname and cert path align", () => {
+    expect(
+      cmeSpecMatches(matchingCme, {
+        hostname: "f3marshall.com",
+        certificateName: "projects/test/locations/global/certificates/cert-aaa",
+      }),
+    ).toBe(true);
+  });
+
+  it("rejects on hostname mismatch", () => {
+    expect(
+      cmeSpecMatches(matchingCme, {
+        hostname: "other.com",
+        certificateName: "projects/test/locations/global/certificates/cert-aaa",
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("reconcileOneCertProvisioning", () => {
+  const row = makeRow({
+    id: "aaa",
+    lifecycleState: "provisioning_cert",
+    hostname: "f3marshall.com",
+  });
+
+  it("no-ops while cert is still PROVISIONING", async () => {
+    const fake = createFakeDb({ rows: [row] });
+    const certManager = certManagerStub({
+      async getCertificate() {
+        return provisioningCert;
+      },
+    });
+    await reconcileOneCertProvisioning(makeCtx(fake, certManager), row);
+    expect(fake.state.rows[0]?.lifecycleState).toBe("provisioning_cert");
+  });
+
+  it("creates CME and advances to awaiting_probe when cert is ACTIVE and CME missing", async () => {
+    const fake = createFakeDb({ rows: [row] });
+    setStateGuard(fake, { id: "aaa", expectedState: "provisioning_cert" });
+    const certManager = certManagerStub({
+      async getCertificate() {
+        return activeCert;
+      },
+      async getCertificateMapEntry() {
+        return null;
+      },
+    });
+    await reconcileOneCertProvisioning(makeCtx(fake, certManager), row);
+    expect(fake.state.rows[0]?.lifecycleState).toBe("awaiting_probe");
+    expect(
+      fake.state.events.find(
+        (e) => e.eventType === "reconciler.cert_active_attached",
+      ),
+    ).toBeDefined();
+  });
+
+  it("reuses an existing matching CME and advances", async () => {
+    const fake = createFakeDb({ rows: [row] });
+    setStateGuard(fake, { id: "aaa", expectedState: "provisioning_cert" });
+    const certManager = certManagerStub({
+      async getCertificate() {
+        return activeCert;
+      },
+      async getCertificateMapEntry() {
+        return matchingCme;
+      },
+    });
+    await reconcileOneCertProvisioning(makeCtx(fake, certManager), row);
+    expect(fake.state.rows[0]?.lifecycleState).toBe("awaiting_probe");
+  });
+
+  it("halts on drift when CME exists with wrong hostname", async () => {
+    const fake = createFakeDb({ rows: [row] });
+    setStateGuard(fake, { id: "aaa", expectedState: "provisioning_cert" });
+    const certManager = certManagerStub({
+      async getCertificate() {
+        return activeCert;
+      },
+      async getCertificateMapEntry() {
+        return { ...matchingCme, hostname: "attacker.com" };
+      },
+    });
+    await reconcileOneCertProvisioning(makeCtx(fake, certManager), row);
+    expect(fake.state.rows[0]?.lifecycleState).toBe("degraded");
+  });
+
+  it("transitions to degraded on FAILED cert with recoverable_from=awaiting_dns_challenge", async () => {
+    const fake = createFakeDb({ rows: [row] });
+    setStateGuard(fake, { id: "aaa", expectedState: "provisioning_cert" });
+    const certManager = certManagerStub({
+      async getCertificate() {
+        return failedCert;
+      },
+    });
+    await reconcileOneCertProvisioning(makeCtx(fake, certManager), row);
+    const updated = fake.state.rows[0];
+    expect(updated?.lifecycleState).toBe("degraded");
+    const reconcilerError = updated?.reconcilerError as {
+      recoverable_from?: string;
+      details?: string;
+    } | null;
+    expect(reconcilerError?.recoverable_from).toBe("awaiting_dns_challenge");
+    expect(reconcilerError?.details).toBe("ACME challenge missing");
+  });
+});

--- a/apps/reconciler/tests/operations/dns-challenge-validation.test.ts
+++ b/apps/reconciler/tests/operations/dns-challenge-validation.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type {
+  CertManagerClient,
+  CertificateView,
+  DnsAuthorizationView,
+} from "../../src/gcp/cert-manager-client.js";
+import { NotFoundError, AlreadyExistsError } from "../../src/gcp/errors.js";
+import {
+  certSpecMatches,
+  reconcileOneDnsChallenge,
+} from "../../src/operations/dns-challenge-validation.js";
+import type { OperationContext } from "../../src/operations/shared.js";
+import { createFakeDb, makeRow, setStateGuard } from "../helpers/fake-db.js";
+import { createFakeLogger } from "../helpers/fake-logger.js";
+
+function certManagerStub(
+  overrides: Partial<CertManagerClient> = {},
+): CertManagerClient {
+  const base: CertManagerClient = {
+    dnsAuthorizationResourcePath: (id: string) =>
+      `projects/test/locations/global/dnsAuthorizations/${id}`,
+    certificateResourcePath: (id: string) =>
+      `projects/test/locations/global/certificates/${id}`,
+    async getDnsAuthorization() {
+      return null;
+    },
+    async getCertificate() {
+      throw new NotFoundError("Certificate", "unset");
+    },
+    async createCertificate() {
+      // no-op
+    },
+    async getCertificateMapEntry() {
+      return null;
+    },
+    async createCertificateMapEntry() {
+      // no-op
+    },
+  };
+  return { ...base, ...overrides };
+}
+
+function makeCtx(
+  fakeDb: ReturnType<typeof createFakeDb>,
+  certManager: CertManagerClient,
+): OperationContext {
+  return {
+    db: fakeDb.db,
+    logger: createFakeLogger(),
+    reconcilerRunId: "run-test",
+    region: "us-central1",
+    certManager,
+  };
+}
+
+const dnsAuthActive: DnsAuthorizationView = {
+  name: "projects/test/locations/global/dnsAuthorizations/dns-auth-aaa",
+  domain: "f3marshall.com",
+  state: "ACTIVE",
+  dnsResourceRecord: null,
+};
+
+const certMatching: CertificateView = {
+  name: "projects/test/locations/global/certificates/cert-aaa",
+  managed: {
+    domains: ["f3marshall.com"],
+    dnsAuthorizations: [
+      "projects/test/locations/global/dnsAuthorizations/dns-auth-aaa",
+    ],
+    state: "PROVISIONING",
+    failureDetails: null,
+  },
+};
+
+describe("certSpecMatches", () => {
+  it("returns true when domain and auth match", () => {
+    expect(
+      certSpecMatches(certMatching, {
+        domain: "f3marshall.com",
+        dnsAuthorizationName:
+          "projects/test/locations/global/dnsAuthorizations/dns-auth-aaa",
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false when domain differs", () => {
+    expect(
+      certSpecMatches(certMatching, {
+        domain: "other.com",
+        dnsAuthorizationName:
+          "projects/test/locations/global/dnsAuthorizations/dns-auth-aaa",
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("reconcileOneDnsChallenge", () => {
+  const row = makeRow({
+    id: "aaa",
+    lifecycleState: "awaiting_dns_challenge",
+    hostname: "f3marshall.com",
+  });
+
+  it("no-ops when DnsAuthorization is not yet ACTIVE", async () => {
+    const fake = createFakeDb({ rows: [row] });
+    const certManager = certManagerStub({
+      getDnsAuthorization: async () => ({
+        ...dnsAuthActive,
+        state: "PENDING",
+      }),
+    });
+    await reconcileOneDnsChallenge(makeCtx(fake, certManager), row);
+    expect(fake.state.rows[0]?.lifecycleState).toBe("awaiting_dns_challenge");
+  });
+
+  it("halts on drift when DnsAuthorization is missing", async () => {
+    const fake = createFakeDb({ rows: [row] });
+    setStateGuard(fake, {
+      id: "aaa",
+      expectedState: "awaiting_dns_challenge",
+    });
+    const certManager = certManagerStub({
+      getDnsAuthorization: async () => null,
+    });
+    const ctx = makeCtx(fake, certManager);
+    await reconcileOneDnsChallenge(ctx, row);
+    expect(fake.state.rows[0]?.lifecycleState).toBe("degraded");
+  });
+
+  it("creates the certificate on 404 and advances to provisioning_cert", async () => {
+    const fake = createFakeDb({ rows: [row] });
+    setStateGuard(fake, {
+      id: "aaa",
+      expectedState: "awaiting_dns_challenge",
+    });
+    const getCert = vi.fn().mockImplementation(() => {
+      throw new NotFoundError("Certificate", "cert-aaa");
+    });
+    const createCert = vi.fn().mockResolvedValue(undefined);
+    const certManager = certManagerStub({
+      getDnsAuthorization: async () => dnsAuthActive,
+      getCertificate: getCert,
+      createCertificate: createCert,
+    });
+    await reconcileOneDnsChallenge(makeCtx(fake, certManager), row);
+    expect(createCert).toHaveBeenCalledOnce();
+    expect(fake.state.rows[0]?.lifecycleState).toBe("provisioning_cert");
+    expect(
+      fake.state.events.find(
+        (e) => e.eventType === "reconciler.dns_challenge_validated",
+      ),
+    ).toBeDefined();
+  });
+
+  it("advances when cert already exists with matching spec (crash recovery)", async () => {
+    const fake = createFakeDb({ rows: [row] });
+    setStateGuard(fake, {
+      id: "aaa",
+      expectedState: "awaiting_dns_challenge",
+    });
+    const certManager = certManagerStub({
+      getDnsAuthorization: async () => dnsAuthActive,
+      getCertificate: async () => certMatching,
+    });
+    await reconcileOneDnsChallenge(makeCtx(fake, certManager), row);
+    expect(fake.state.rows[0]?.lifecycleState).toBe("provisioning_cert");
+  });
+
+  it("halts on drift when cert exists but spec mismatches", async () => {
+    const fake = createFakeDb({ rows: [row] });
+    setStateGuard(fake, {
+      id: "aaa",
+      expectedState: "awaiting_dns_challenge",
+    });
+    const certManager = certManagerStub({
+      getDnsAuthorization: async () => dnsAuthActive,
+      getCertificate: async () => ({
+        ...certMatching,
+        managed: {
+          ...certMatching.managed!,
+          domains: ["other.com"],
+        },
+      }),
+    });
+    await reconcileOneDnsChallenge(makeCtx(fake, certManager), row);
+    expect(fake.state.rows[0]?.lifecycleState).toBe("degraded");
+  });
+
+  it("handles ALREADY_EXISTS on create by re-GETting + verifying spec", async () => {
+    const fake = createFakeDb({ rows: [row] });
+    setStateGuard(fake, {
+      id: "aaa",
+      expectedState: "awaiting_dns_challenge",
+    });
+    let getCalls = 0;
+    const getCert = vi.fn().mockImplementation(() => {
+      getCalls++;
+      if (getCalls === 1) throw new NotFoundError("Certificate", "cert-aaa");
+      return Promise.resolve(certMatching);
+    });
+    const createCert = vi.fn().mockImplementation(() => {
+      throw new AlreadyExistsError("Certificate", "cert-aaa");
+    });
+    const certManager = certManagerStub({
+      getDnsAuthorization: async () => dnsAuthActive,
+      getCertificate: getCert,
+      createCertificate: createCert,
+    });
+    await reconcileOneDnsChallenge(makeCtx(fake, certManager), row);
+    expect(getCalls).toBe(2);
+    expect(fake.state.rows[0]?.lifecycleState).toBe("provisioning_cert");
+  });
+});

--- a/apps/reconciler/tests/operations/post-cutover-verification.test.ts
+++ b/apps/reconciler/tests/operations/post-cutover-verification.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, it } from "vitest";
+
+import type { CertManagerClient } from "../../src/gcp/cert-manager-client.js";
+import {
+  MissingPostCutoverLbIpError,
+  expectedRedirectTarget,
+  loadPostCutoverConfig,
+  reconcileOnePostCutover,
+  verifyDnsPointsAtLb,
+} from "../../src/operations/post-cutover-verification.js";
+import type { OperationContext } from "../../src/operations/shared.js";
+import { createFakeDb, makeRow, setStateGuard } from "../helpers/fake-db.js";
+import { createFakeLogger } from "../helpers/fake-logger.js";
+
+function certManagerStub(): CertManagerClient {
+  return {
+    dnsAuthorizationResourcePath: (id) => `dns-${id}`,
+    certificateResourcePath: (id) => `cert-${id}`,
+    async getDnsAuthorization() {
+      return null;
+    },
+    async getCertificate() {
+      throw new Error("not used");
+    },
+    async createCertificate() {},
+    async getCertificateMapEntry() {
+      return null;
+    },
+    async createCertificateMapEntry() {},
+  };
+}
+
+function makeCtx(fake: ReturnType<typeof createFakeDb>): OperationContext {
+  return {
+    db: fake.db,
+    logger: createFakeLogger(),
+    reconcilerRunId: "run-test",
+    region: "us-central1",
+    certManager: certManagerStub(),
+  };
+}
+
+describe("expectedRedirectTarget", () => {
+  it("returns the regions.f3nation.com URL for apex rows", () => {
+    const row = makeRow({
+      hostnameRole: "apex",
+      regionSlug: "muletown",
+      regionId: "35838",
+    });
+    expect(expectedRedirectTarget(row)).toBe(
+      "https://regions.f3nation.com/muletown",
+    );
+  });
+  it("returns the pax-vault URL for stats rows", () => {
+    const row = makeRow({
+      hostnameRole: "stats",
+      regionSlug: "muletown",
+      regionId: "35838",
+    });
+    expect(expectedRedirectTarget(row)).toBe(
+      "https://pax-vault.f3nation.com/stats/region/35838",
+    );
+  });
+});
+
+describe("loadPostCutoverConfig", () => {
+  it("throws when REDIRECT_LB_IPV4 is absent", () => {
+    expect(() => loadPostCutoverConfig({})).toThrow(
+      MissingPostCutoverLbIpError,
+    );
+  });
+});
+
+describe("verifyDnsPointsAtLb", () => {
+  it("returns a_matches=true when resolve4 returns the lb ip", async () => {
+    const result = await verifyDnsPointsAtLb("f3marshall.com", {
+      lbIpv4: "34.102.136.180",
+      dnsResolver: {
+        async resolve4() {
+          return ["34.102.136.180"];
+        },
+        async resolve6() {
+          return [];
+        },
+      },
+    });
+    expect(result.a_matches).toBe(true);
+    expect(result.aaaa_matches).toBe(true); // no IPv6 expected
+  });
+
+  it("returns a_matches=false when resolver returns a different ip", async () => {
+    const result = await verifyDnsPointsAtLb("f3marshall.com", {
+      lbIpv4: "34.102.136.180",
+      dnsResolver: {
+        async resolve4() {
+          return ["1.2.3.4"];
+        },
+        async resolve6() {
+          return [];
+        },
+      },
+    });
+    expect(result.a_matches).toBe(false);
+  });
+
+  it("captures error when DNS resolution throws", async () => {
+    const result = await verifyDnsPointsAtLb("no-such-host.invalid", {
+      lbIpv4: "34.102.136.180",
+      dnsResolver: {
+        async resolve4() {
+          throw new Error("ENOTFOUND");
+        },
+        async resolve6() {
+          return [];
+        },
+      },
+    });
+    expect(result.a_matches).toBe(false);
+    expect(result.error).toContain("A-record lookup failed");
+  });
+});
+
+describe("reconcileOnePostCutover", () => {
+  const row = makeRow({
+    id: "pc-1",
+    lifecycleState: "awaiting_cutover",
+    hostname: "f3marshall.com",
+    hostnameRole: "apex",
+    regionSlug: "muletown",
+    regionId: "35838",
+  });
+
+  const mockDns = {
+    async resolve4() {
+      return ["34.102.136.180"];
+    },
+    async resolve6() {
+      return [];
+    },
+  };
+
+  it("advances to active on DNS + 307 success", async () => {
+    const fake = createFakeDb({ rows: [row] });
+    setStateGuard(fake, { id: "pc-1", expectedState: "awaiting_cutover" });
+    const httpsHead = async () => ({
+      status: 307,
+      location: "https://regions.f3nation.com/muletown",
+    });
+    await reconcileOnePostCutover(
+      makeCtx(fake),
+      { lbIpv4: "34.102.136.180", dnsResolver: mockDns },
+      row,
+      httpsHead,
+    );
+    expect(fake.state.rows[0]?.lifecycleState).toBe("active");
+  });
+
+  it("stays in awaiting_cutover when DNS still points elsewhere", async () => {
+    const fake = createFakeDb({ rows: [row] });
+    const httpsHead = async () => ({
+      status: 307,
+      location: "https://regions.f3nation.com/muletown",
+    });
+    await reconcileOnePostCutover(
+      makeCtx(fake),
+      {
+        lbIpv4: "34.102.136.180",
+        dnsResolver: {
+          async resolve4() {
+            return ["1.2.3.4"];
+          },
+          async resolve6() {
+            return [];
+          },
+        },
+      },
+      row,
+      httpsHead,
+    );
+    expect(fake.state.rows[0]?.lifecycleState).toBe("awaiting_cutover");
+  });
+
+  it("stays in awaiting_cutover when the 307 target is wrong", async () => {
+    const fake = createFakeDb({ rows: [row] });
+    const httpsHead = async () => ({
+      status: 307,
+      location: "https://regions.f3nation.com/wrong-region",
+    });
+    await reconcileOnePostCutover(
+      makeCtx(fake),
+      { lbIpv4: "34.102.136.180", dnsResolver: mockDns },
+      row,
+      httpsHead,
+    );
+    expect(fake.state.rows[0]?.lifecycleState).toBe("awaiting_cutover");
+  });
+});

--- a/apps/reconciler/tests/operations/shared.test.ts
+++ b/apps/reconciler/tests/operations/shared.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  SpecMismatchError,
+  deterministicResourceName,
+  handleAlreadyExists,
+  haltOnDrift,
+  stateGuardedUpdate,
+} from "../../src/operations/shared.js";
+import { NotFoundError } from "../../src/gcp/errors.js";
+import { createFakeDb, makeRow, setStateGuard } from "../helpers/fake-db.js";
+import { createFakeLogger } from "../helpers/fake-logger.js";
+
+describe("deterministicResourceName", () => {
+  it("returns the R5 Decision 6 name prefixes", () => {
+    expect(deterministicResourceName("DnsAuthorization", "abc")).toBe(
+      "dns-auth-abc",
+    );
+    expect(deterministicResourceName("Certificate", "abc")).toBe("cert-abc");
+    expect(deterministicResourceName("CertificateMapEntry", "abc")).toBe(
+      "cme-abc",
+    );
+  });
+});
+
+describe("stateGuardedUpdate", () => {
+  it("advances state when the guard matches", async () => {
+    const row = makeRow({
+      id: "aaa",
+      lifecycleState: "awaiting_dns_challenge",
+    });
+    const fake = createFakeDb({ rows: [row] });
+    setStateGuard(fake, {
+      id: "aaa",
+      expectedState: "awaiting_dns_challenge",
+    });
+    const updated = await stateGuardedUpdate(fake.db, {
+      id: "aaa",
+      expectedState: "awaiting_dns_challenge",
+      newState: "provisioning_cert",
+    });
+    expect(updated).not.toBeNull();
+    expect(updated?.lifecycleState).toBe("provisioning_cert");
+    expect(fake.state.rows[0]?.lifecycleState).toBe("provisioning_cert");
+  });
+
+  it("returns null when the guard does not match", async () => {
+    const row = makeRow({ id: "aaa", lifecycleState: "active" });
+    const fake = createFakeDb({ rows: [row] });
+    setStateGuard(fake, {
+      id: "aaa",
+      expectedState: "awaiting_dns_challenge",
+    });
+    const updated = await stateGuardedUpdate(fake.db, {
+      id: "aaa",
+      expectedState: "awaiting_dns_challenge",
+      newState: "provisioning_cert",
+    });
+    expect(updated).toBeNull();
+    expect(fake.state.rows[0]?.lifecycleState).toBe("active");
+  });
+});
+
+describe("handleAlreadyExists", () => {
+  it("returns the existing resource when spec matches", async () => {
+    const result = await handleAlreadyExists({
+      resourceKind: "Certificate",
+      rowId: "x",
+      resourceName: "cert-x",
+      plannedSpec: { domain: "f3marshall.com" },
+      getFn: async () => ({ domain: "f3marshall.com", state: "ACTIVE" }),
+      specMatches: (existing, planned) => existing.domain === planned.domain,
+    });
+    expect(result.existing.domain).toBe("f3marshall.com");
+  });
+
+  it("throws SpecMismatchError on mismatch", async () => {
+    await expect(
+      handleAlreadyExists({
+        resourceKind: "Certificate",
+        rowId: "x",
+        resourceName: "cert-x",
+        plannedSpec: { domain: "f3marshall.com" },
+        getFn: async () => ({ domain: "other.com" }),
+        specMatches: (existing, planned) => existing.domain === planned.domain,
+      }),
+    ).rejects.toBeInstanceOf(SpecMismatchError);
+  });
+
+  it("throws NotFoundError when GET returns null", async () => {
+    await expect(
+      handleAlreadyExists<{ x: number }, { x: number }>({
+        resourceKind: "Certificate",
+        rowId: "x",
+        resourceName: "cert-x",
+        plannedSpec: { x: 1 },
+        getFn: async () => null,
+        specMatches: () => true,
+      }),
+    ).rejects.toBeInstanceOf(NotFoundError);
+  });
+});
+
+describe("haltOnDrift", () => {
+  it("transitions row to degraded, writes reconciler_error, emits drift log", async () => {
+    const row = makeRow({
+      id: "bbb",
+      lifecycleState: "awaiting_dns_challenge",
+    });
+    const fake = createFakeDb({ rows: [row] });
+    setStateGuard(fake, {
+      id: "bbb",
+      expectedState: "awaiting_dns_challenge",
+    });
+    const logger = createFakeLogger();
+    const result = await haltOnDrift({
+      db: fake.db,
+      logger,
+      rowId: "bbb",
+      currentState: "awaiting_dns_challenge",
+      driftKind: "spec_mismatch",
+      resourceType: "Certificate",
+      resourceName: "cert-bbb",
+      observedSpec: { managed: { state: "FAILED" } },
+      expectedSpec: { managed: { state: "ACTIVE" } },
+      recoverableFrom: "awaiting_dns_challenge",
+      reconcilerRunId: "run-1",
+    });
+    expect(result?.lifecycleState).toBe("degraded");
+    expect(logger.driftCalls).toHaveLength(1);
+    // An event should have been inserted for the halt
+    expect(fake.state.events).toHaveLength(1);
+    expect(fake.state.events[0]?.eventType).toBe("reconciler.halt_on_drift");
+  });
+
+  it("returns null (no-op) when state guard fails", async () => {
+    const row = makeRow({ id: "ccc", lifecycleState: "active" });
+    const fake = createFakeDb({ rows: [row] });
+    setStateGuard(fake, {
+      id: "ccc",
+      expectedState: "awaiting_dns_challenge",
+    });
+    const logger = createFakeLogger();
+    const result = await haltOnDrift({
+      db: fake.db,
+      logger,
+      rowId: "ccc",
+      currentState: "awaiting_dns_challenge",
+      driftKind: "spec_mismatch",
+      resourceType: "Certificate",
+      resourceName: "cert-ccc",
+      observedSpec: {},
+      expectedSpec: {},
+      recoverableFrom: "awaiting_dns_challenge",
+      reconcilerRunId: "run-1",
+    });
+    expect(result).toBeNull();
+    expect(logger.driftCalls).toHaveLength(0);
+    expect(logger.warnCalls).toHaveLength(1);
+  });
+});

--- a/apps/reconciler/tests/operations/sni-probe-op.test.ts
+++ b/apps/reconciler/tests/operations/sni-probe-op.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Unit tests for the SNI probe *operation* (op 3) — the state-machine
+ * wrapper. The underlying probe implementation is exercised separately in
+ * `tests/probe/sni-probe.test.ts` with a real in-process TLS server.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import type { CertManagerClient } from "../../src/gcp/cert-manager-client.js";
+import {
+  MissingLbIpError,
+  bothRegionsFresh,
+  loadSniProbeConfig,
+  reconcileOneSniProbe,
+} from "../../src/operations/sni-probe.js";
+import type { SniProbeOpConfig } from "../../src/operations/sni-probe.js";
+import type { OperationContext } from "../../src/operations/shared.js";
+import type { SniProbeResult } from "../../src/probe/index.js";
+import { createFakeDb, makeRow, setStateGuard } from "../helpers/fake-db.js";
+import { createFakeLogger } from "../helpers/fake-logger.js";
+
+function certManagerStub(): CertManagerClient {
+  return {
+    dnsAuthorizationResourcePath: (id) => `dns-${id}`,
+    certificateResourcePath: (id) => `cert-${id}`,
+    async getDnsAuthorization() {
+      return null;
+    },
+    async getCertificate() {
+      throw new Error("not used by op 3");
+    },
+    async createCertificate() {},
+    async getCertificateMapEntry() {
+      return null;
+    },
+    async createCertificateMapEntry() {},
+  };
+}
+
+function makeCtx(
+  fakeDb: ReturnType<typeof createFakeDb>,
+  region: string,
+): OperationContext {
+  return {
+    db: fakeDb.db,
+    logger: createFakeLogger(),
+    reconcilerRunId: "run-test",
+    region,
+    certManager: certManagerStub(),
+  };
+}
+
+const successResult: SniProbeResult = {
+  handshake_ok: true,
+  http_status: 200,
+  cert: {
+    serialNumber: "DEADBEEF",
+    validFrom: "2026-01-01T00:00:00Z",
+    validTo: "2026-12-31T00:00:00Z",
+    subjectCN: "f3marshall.com",
+    issuerCN: "GTS CA 1P5",
+  },
+  latency_ms: 42,
+  redirect_platform_header_ok: true,
+  error: null,
+};
+
+const failureResult: SniProbeResult = {
+  handshake_ok: false,
+  http_status: null,
+  cert: null,
+  latency_ms: 5,
+  redirect_platform_header_ok: false,
+  error: "self-signed certificate",
+};
+
+describe("loadSniProbeConfig", () => {
+  it("throws MissingLbIpError when REDIRECT_LB_IPV4 is not set", () => {
+    expect(() => loadSniProbeConfig({})).toThrow(MissingLbIpError);
+  });
+
+  it("loads the lbIpv4 from env", () => {
+    const config = loadSniProbeConfig({
+      REDIRECT_LB_IPV4: "34.102.136.180",
+      REDIRECT_LB_IPV6: "2600:1901:0:d0d7::",
+    });
+    expect(config.lbIpv4).toBe("34.102.136.180");
+    expect(config.lbIpv6).toBe("2600:1901:0:d0d7::");
+  });
+});
+
+describe("bothRegionsFresh", () => {
+  const now = new Date("2026-04-14T12:00:00Z");
+  it("returns true when both regions have a recent success", () => {
+    expect(
+      bothRegionsFresh({
+        probeRegionUsCentral1LastSuccess: "2026-04-14T11:58:30Z",
+        probeRegionEuropeWest1LastSuccess: "2026-04-14T11:59:00Z",
+        now,
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false when us-central1 is stale", () => {
+    expect(
+      bothRegionsFresh({
+        probeRegionUsCentral1LastSuccess: "2026-04-14T11:50:00Z",
+        probeRegionEuropeWest1LastSuccess: "2026-04-14T11:59:00Z",
+        now,
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false when a column is null", () => {
+    expect(
+      bothRegionsFresh({
+        probeRegionUsCentral1LastSuccess: null,
+        probeRegionEuropeWest1LastSuccess: "2026-04-14T11:59:00Z",
+        now,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("reconcileOneSniProbe", () => {
+  const now = new Date("2026-04-14T12:00:00Z");
+
+  it("on success, marks this region's last_success and does not increment counter alone", async () => {
+    const row = makeRow({
+      id: "row-1",
+      lifecycleState: "awaiting_probe",
+      probeConsecutiveSuccesses: 0,
+      probeRegionUsCentral1LastSuccess: null,
+      probeRegionEuropeWest1LastSuccess: null,
+    });
+    const fake = createFakeDb({ rows: [row] });
+    const config: SniProbeOpConfig = { lbIpv4: "1.2.3.4" };
+    await reconcileOneSniProbe(makeCtx(fake, "us-central1"), config, row, {
+      now,
+      probeFn: async () => successResult,
+    });
+    const updated = fake.state.rows[0];
+    expect(updated?.probeRegionUsCentral1LastSuccess).toBe(now.toISOString());
+    expect(updated?.probeConsecutiveSuccesses).toBe(0);
+    expect(updated?.lifecycleState).toBe("awaiting_probe");
+  });
+
+  it("on failure, resets consecutive successes to 0", async () => {
+    const row = makeRow({
+      id: "row-2",
+      lifecycleState: "awaiting_probe",
+      probeConsecutiveSuccesses: 2,
+    });
+    const fake = createFakeDb({ rows: [row] });
+    await reconcileOneSniProbe(
+      makeCtx(fake, "us-central1"),
+      { lbIpv4: "1.2.3.4" },
+      row,
+      {
+        now,
+        probeFn: async () => failureResult,
+      },
+    );
+    expect(fake.state.rows[0]?.probeConsecutiveSuccesses).toBe(0);
+    expect(fake.state.rows[0]?.lifecycleState).toBe("awaiting_probe");
+  });
+
+  it("on success in both regions with 3 consecutive, advances to awaiting_cutover", async () => {
+    const row = makeRow({
+      id: "row-3",
+      lifecycleState: "awaiting_probe",
+      probeConsecutiveSuccesses: 2,
+      // Simulate eu-west1 just succeeded 30 seconds ago (fresh).
+      probeRegionEuropeWest1LastSuccess: "2026-04-14T11:59:30Z",
+      probeRegionUsCentral1LastSuccess: "2026-04-14T11:57:00Z",
+    });
+    const fake = createFakeDb({ rows: [row] });
+    setStateGuard(fake, { id: "row-3", expectedState: "awaiting_probe" });
+    await reconcileOneSniProbe(
+      makeCtx(fake, "us-central1"),
+      { lbIpv4: "1.2.3.4" },
+      row,
+      {
+        now,
+        probeFn: async () => successResult,
+      },
+    );
+    expect(fake.state.rows[0]?.lifecycleState).toBe("awaiting_cutover");
+    expect(
+      fake.state.events.find(
+        (e) => e.eventType === "reconciler.probe_advanced",
+      ),
+    ).toBeDefined();
+  });
+
+  it("2-hour hard timeout transitions to degraded", async () => {
+    const longAgo = new Date(now.getTime() - 3 * 60 * 60 * 1000).toISOString();
+    const row = makeRow({
+      id: "row-4",
+      lifecycleState: "awaiting_probe",
+      probeConsecutiveSuccesses: 0,
+      createdAt: longAgo,
+      updatedAt: longAgo,
+    });
+    const fake = createFakeDb({ rows: [row] });
+    setStateGuard(fake, { id: "row-4", expectedState: "awaiting_probe" });
+    await reconcileOneSniProbe(
+      makeCtx(fake, "us-central1"),
+      { lbIpv4: "1.2.3.4" },
+      row,
+      {
+        now,
+        probeFn: async () => failureResult,
+      },
+    );
+    expect(fake.state.rows[0]?.lifecycleState).toBe("degraded");
+    const err = fake.state.rows[0]?.reconcilerError as {
+      recoverable_from?: string;
+    } | null;
+    expect(err?.recoverable_from).toBe("awaiting_probe");
+  });
+});

--- a/apps/reconciler/tests/probe/sni-probe.test.ts
+++ b/apps/reconciler/tests/probe/sni-probe.test.ts
@@ -1,0 +1,326 @@
+/**
+ * SNI probe unit tests.
+ *
+ * The probe is the architectural centerpiece of R5 Decision 4. These tests
+ * stand up an in-process TLS server using `tls.createServer` with a
+ * self-signed cert whose subject/SAN matches a synthetic hostname, then
+ * point the probe at 127.0.0.1 with SNI = the synthetic hostname. That
+ * exercises the real TLS handshake code path end-to-end.
+ *
+ * CRITICAL: these tests MUST NOT resolve public DNS for the tenant
+ * hostname. The probe always dials the numeric IP passed via `targetIp`;
+ * the hostname is only used for SNI + Host header + TLS cert validation.
+ * If any of these tests ever required an internet connection the probe
+ * was implemented wrong and the R5 rewrite's whole justification is gone.
+ */
+
+import type { AddressInfo } from "node:net";
+import {
+  connect as tlsConnect,
+  createServer as createTlsServer,
+} from "node:tls";
+import type { ConnectionOptions, TLSSocket } from "node:tls";
+import type { Server as TlsServer } from "node:tls";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { generate as generateSelfSigned } from "selfsigned";
+
+import {
+  isSniProbeSuccess,
+  parseHttpResponse,
+  runSniProbe,
+} from "../../src/probe/sni-probe.js";
+
+const TEST_HOSTNAME = "probe-test.internal";
+
+interface TestServer {
+  server: TlsServer;
+  port: number;
+  caPem: string;
+  /** Replace the current request handler for a single test. */
+  setHandler: (handler: RequestHandler) => void;
+}
+
+type RequestHandler = (
+  socket: TLSSocket,
+  requestLine: string,
+  headers: Record<string, string>,
+) => void;
+
+const sharedServer: { instance: TestServer | null } = { instance: null };
+
+async function startTlsServer(): Promise<TestServer> {
+  const pems = await generateSelfSigned(
+    [{ name: "commonName", value: TEST_HOSTNAME }],
+    {
+      algorithm: "sha256",
+      keySize: 2048,
+      extensions: [
+        {
+          name: "subjectAltName",
+          altNames: [
+            { type: 2, value: TEST_HOSTNAME },
+            { type: 7, ip: "127.0.0.1" },
+          ],
+        },
+      ],
+    },
+  );
+  let currentHandler: RequestHandler = defaultHandler;
+  const server = createTlsServer(
+    {
+      key: pems.private,
+      cert: pems.cert,
+      ca: [pems.cert],
+    },
+    (socket) => {
+      handleSocket(socket, () => currentHandler);
+    },
+  );
+  await new Promise<void>((resolve) =>
+    server.listen(0, "127.0.0.1", () => resolve()),
+  );
+  const addr = server.address() as AddressInfo;
+  return {
+    server,
+    port: addr.port,
+    caPem: pems.cert,
+    setHandler(handler) {
+      currentHandler = handler;
+    },
+  };
+}
+
+function handleSocket(
+  socket: TLSSocket,
+  getHandler: () => RequestHandler,
+): void {
+  let buffer = "";
+  socket.on("data", (chunk: Buffer) => {
+    buffer += chunk.toString("utf8");
+    const headerEnd = buffer.indexOf("\r\n\r\n");
+    if (headerEnd < 0) return;
+    const headSection = buffer.slice(0, headerEnd);
+    const lines = headSection.split("\r\n");
+    const requestLine = lines[0] ?? "";
+    const headers: Record<string, string> = {};
+    for (let i = 1; i < lines.length; i++) {
+      const line = lines[i];
+      if (!line) continue;
+      const colon = line.indexOf(":");
+      if (colon < 0) continue;
+      headers[line.slice(0, colon).toLowerCase()] = line
+        .slice(colon + 1)
+        .trim();
+    }
+    try {
+      getHandler()(socket, requestLine, headers);
+    } catch (err) {
+      try {
+        socket.end();
+      } catch {
+        // ignore
+      }
+      throw err;
+    }
+  });
+  socket.on("error", () => {
+    // swallow — client test asserts on its own result
+  });
+}
+
+function defaultHandler(
+  socket: TLSSocket,
+  _requestLine: string,
+  _headers: Record<string, string>,
+): void {
+  const body = "ok";
+  const response =
+    `HTTP/1.1 200 OK\r\n` +
+    `Content-Type: text/plain\r\n` +
+    `Content-Length: ${String(body.length)}\r\n` +
+    `x-redirect-platform: ok\r\n` +
+    `Connection: close\r\n` +
+    `\r\n` +
+    body;
+  socket.end(response);
+}
+
+beforeAll(async () => {
+  sharedServer.instance = await startTlsServer();
+});
+
+afterAll(async () => {
+  const inst = sharedServer.instance;
+  if (inst) {
+    await new Promise<void>((resolve, reject) =>
+      inst.server.close((err) => (err ? reject(err) : resolve())),
+    );
+  }
+});
+
+/**
+ * Probe helper — wires the probe to 127.0.0.1 with the test CA trusted
+ * via `NODE_EXTRA_CA_CERTS`... we can't mutate envs inside the process
+ * cleanly. Instead we inject a custom `tlsConnectFn` that adds the `ca`
+ * option to the TLS ConnectionOptions before delegating to the real
+ * `tls.connect`. This is NOT hand-mocking the handshake — it's adding a
+ * trust-store override so the system trust store doesn't fail validation.
+ */
+function probeWithTestCa(
+  hostname: string,
+  overrides: { port?: number } = {},
+): ReturnType<typeof runSniProbe> {
+  const inst = sharedServer.instance;
+  if (!inst) throw new Error("sharedServer not started");
+  return runSniProbe({
+    targetIp: "127.0.0.1",
+    targetPort: overrides.port ?? inst.port,
+    hostname,
+    timeoutMs: 3_000,
+    tlsConnectFn: (options: ConnectionOptions): TLSSocket =>
+      tlsConnect({ ...options, ca: [inst.caPem] }),
+  });
+}
+
+describe("parseHttpResponse", () => {
+  it("parses status, headers, body", () => {
+    const raw =
+      "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nx-redirect-platform: ok\r\n\r\nhello";
+    const parsed = parseHttpResponse(raw);
+    expect(parsed?.status).toBe(200);
+    expect(parsed?.headers["x-redirect-platform"]).toBe("ok");
+    expect(parsed?.body).toBe("hello");
+  });
+
+  it("returns null on malformed input", () => {
+    expect(parseHttpResponse("not an http response")).toBeNull();
+  });
+});
+
+describe("runSniProbe — happy path", () => {
+  it("succeeds when cert matches SNI and handler returns 200 + header", async () => {
+    sharedServer.instance?.setHandler(defaultHandler);
+    const result = await probeWithTestCa(TEST_HOSTNAME);
+    expect(result.handshake_ok).toBe(true);
+    expect(result.http_status).toBe(200);
+    expect(result.redirect_platform_header_ok).toBe(true);
+    expect(result.cert).not.toBeNull();
+    expect(result.cert?.subjectCN).toBe(TEST_HOSTNAME);
+    expect(result.error).toBeNull();
+    expect(isSniProbeSuccess(result)).toBe(true);
+  });
+
+  it("records latency_ms as a non-negative integer", async () => {
+    sharedServer.instance?.setHandler(defaultHandler);
+    const result = await probeWithTestCa(TEST_HOSTNAME);
+    expect(result.latency_ms).toBeGreaterThanOrEqual(0);
+  });
+});
+
+describe("runSniProbe — TLS failure", () => {
+  it("fails when SNI does not match the cert (rejectUnauthorized)", async () => {
+    sharedServer.instance?.setHandler(defaultHandler);
+    const result = await probeWithTestCa("not-the-test-hostname.example");
+    expect(result.handshake_ok).toBe(false);
+    expect(result.http_status).toBeNull();
+    expect(result.error).not.toBeNull();
+    expect(isSniProbeSuccess(result)).toBe(false);
+  });
+});
+
+describe("runSniProbe — HTTP failure", () => {
+  it("fails when handler returns 404", async () => {
+    sharedServer.instance?.setHandler((socket) => {
+      const body = "not found";
+      socket.end(
+        `HTTP/1.1 404 Not Found\r\nContent-Length: ${String(body.length)}\r\n\r\n${body}`,
+      );
+    });
+    const result = await probeWithTestCa(TEST_HOSTNAME);
+    expect(result.handshake_ok).toBe(true);
+    expect(result.http_status).toBe(404);
+    expect(result.redirect_platform_header_ok).toBe(false);
+    expect(isSniProbeSuccess(result)).toBe(false);
+  });
+
+  it("fails when x-redirect-platform header is missing", async () => {
+    sharedServer.instance?.setHandler((socket) => {
+      const body = "ok";
+      socket.end(
+        `HTTP/1.1 200 OK\r\nContent-Length: ${String(body.length)}\r\n\r\n${body}`,
+      );
+    });
+    const result = await probeWithTestCa(TEST_HOSTNAME);
+    expect(result.handshake_ok).toBe(true);
+    expect(result.http_status).toBe(200);
+    expect(result.redirect_platform_header_ok).toBe(false);
+    expect(isSniProbeSuccess(result)).toBe(false);
+  });
+});
+
+describe("runSniProbe — timeout", () => {
+  it("times out when the server never responds", async () => {
+    sharedServer.instance?.setHandler(() => {
+      // hang on purpose — do not write anything
+    });
+    const inst = sharedServer.instance;
+    if (!inst) throw new Error("no server");
+    const result = await runSniProbe({
+      targetIp: "127.0.0.1",
+      targetPort: inst.port,
+      hostname: TEST_HOSTNAME,
+      timeoutMs: 500,
+      tlsConnectFn: (options) => {
+        return tlsConnect({ ...options, ca: [inst.caPem] });
+      },
+    });
+    expect(result.handshake_ok).toBe(true);
+    expect(result.http_status).toBeNull();
+    expect(result.error).toContain("timed out");
+  });
+});
+
+describe("runSniProbe — concurrency", () => {
+  it("two concurrent probes do not interfere", async () => {
+    sharedServer.instance?.setHandler(defaultHandler);
+    const [a, b] = await Promise.all([
+      probeWithTestCa(TEST_HOSTNAME),
+      probeWithTestCa(TEST_HOSTNAME),
+    ]);
+    expect(isSniProbeSuccess(a)).toBe(true);
+    expect(isSniProbeSuccess(b)).toBe(true);
+  });
+});
+
+describe("runSniProbe — no public DNS resolution (R5 Decision 4 invariant)", () => {
+  it("passes the numeric targetIp as `host` and the hostname only as `servername`", async () => {
+    // The whole R5 rewrite hinges on the probe NEVER resolving public DNS
+    // for the tenant hostname. We prove this by inspecting the exact
+    // ConnectionOptions the probe hands to tlsConnectFn:
+    //   - options.host MUST be the numeric IP we passed in
+    //   - options.servername MUST be the tenant hostname
+    // Node's tls.connect with a numeric `host` skips dns.lookup entirely.
+    sharedServer.instance?.setHandler(defaultHandler);
+    const inst = sharedServer.instance;
+    if (!inst) throw new Error("no server");
+    let capturedHost: string | undefined;
+    let capturedServername: string | undefined;
+    const result = await runSniProbe({
+      targetIp: "127.0.0.1",
+      targetPort: inst.port,
+      hostname: TEST_HOSTNAME,
+      timeoutMs: 3_000,
+      tlsConnectFn: (options: ConnectionOptions): TLSSocket => {
+        capturedHost = options.host;
+        capturedServername = options.servername;
+        return tlsConnect({ ...options, ca: [inst.caPem] });
+      },
+    });
+    expect(capturedHost).toBe("127.0.0.1");
+    expect(capturedServername).toBe(TEST_HOSTNAME);
+    // Must be numeric — regex enforces IPv4 dotted-quad so an accidental
+    // hostname substitution would fail this assertion.
+    expect(capturedHost).toMatch(/^\d+\.\d+\.\d+\.\d+$/);
+    expect(isSniProbeSuccess(result)).toBe(true);
+  });
+});

--- a/apps/reconciler/tsconfig.json
+++ b/apps/reconciler/tsconfig.json
@@ -2,12 +2,17 @@
   "extends": "../../tooling/typescript/base.json",
   "compilerOptions": {
     // Pure Node.js app: override the base (which is shared across Next.js
-    // apps and therefore includes DOM libs) to a Node-only `lib` + `types`,
-    // and use `nodenext` module/moduleResolution so `tsc` emits real Node
-    // ESM for the `start` script (build target is a Cloud Run Job, not a
-    // bundled Next.js app).
-    "module": "nodenext",
-    "moduleResolution": "nodenext",
+    // apps and therefore includes DOM libs) to a Node-only `lib` + `types`.
+    //
+    // Module resolution notes: we inherit `moduleResolution: Bundler` from
+    // the shared base so drizzle-orm and @acme/redirect-platform-db resolve
+    // in a single mode. Earlier we tried `nodenext` here and it created
+    // dual-resolution of drizzle-orm's internal classes, which broke
+    // structural typing across package boundaries. `Bundler` matches the
+    // rest of the monorepo; Node's ESM loader still resolves correctly at
+    // runtime because every local import uses an explicit `.js` suffix.
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
     "lib": ["ES2022"],
     "types": ["node"],
     "rootDir": ".",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,7 +99,7 @@ importers:
         version: 3.1.1(react@18.3.1)
       '@scalar/nextjs-api-reference':
         specifier: ^0.9.5
-        version: 0.9.26(next@15.5.14(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
+        version: 0.9.26(next@15.5.14(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
       '@sentry/nextjs':
         specifier: ^9.15.0
         version: 9.47.1(@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1))(next@15.5.14(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(webpack@5.105.4)
@@ -607,6 +607,9 @@ importers:
       '@acme/redirect-platform-db':
         specifier: workspace:*
         version: link:../../packages/redirect-platform-db
+      '@google-cloud/certificate-manager':
+        specifier: ^2.1.1
+        version: 2.1.1
       drizzle-orm:
         specifier: ^0.39.3
         version: 0.39.3(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.20.0)(postgres@3.4.9)
@@ -632,6 +635,9 @@ importers:
       prettier:
         specifier: 3.2.5
         version: 3.2.5
+      selfsigned:
+        specifier: ^5.5.0
+        version: 5.5.0
       typescript:
         specifier: 5.3.3
         version: 5.3.3
@@ -2184,6 +2190,19 @@ packages:
   '@formkit/auto-animate@0.8.4':
     resolution: {integrity: sha512-DHHC01EJ1p70Q0z/ZFRBIY8NDnmfKccQoyoM84Tgb6omLMat6jivCdf272Y8k3nf4Lzdin/Y4R9q8uFtU0GbnA==}
 
+  '@google-cloud/certificate-manager@2.1.1':
+    resolution: {integrity: sha512-iuoiR+P4oTrcJBgaNjP///LiZENg7dck45kUox086lyvCPyineQY1hyIruM9Dq4arqTwMoDAFPQwg7XCSh5AtQ==}
+    engines: {node: '>=18'}
+
+  '@grpc/grpc-js@1.14.3':
+    resolution: {integrity: sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==}
+    engines: {node: '>=12.10.0'}
+
+  '@grpc/proto-loader@0.8.0':
+    resolution: {integrity: sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ==}
+    engines: {node: '>=6'}
+    hasBin: true
+
   '@hookform/resolvers@3.10.0':
     resolution: {integrity: sha512-79Dv+3mDF7i+2ajj7SkypSKHhl1cbln1OGavqrsF7p6mbUv11xpqpacPsGDCTRvCSjEEIez2ef1NveSVL3b0Ag==}
     peerDependencies:
@@ -2547,6 +2566,9 @@ packages:
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
 
+  '@js-sdsl/ordered-map@4.4.2':
+    resolution: {integrity: sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==}
+
   '@next/env@15.5.14':
     resolution: {integrity: sha512-aXeirLYuASxEgi4X4WhfXsShCFxWDfNn/8ZeC5YXAS2BB4A8FJi1kwwGL6nvMVboE7fZCzmJPNdMvVHc8JpaiA==}
 
@@ -2604,6 +2626,10 @@ packages:
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
+
+  '@noble/hashes@1.4.0':
+    resolution: {integrity: sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==}
+    engines: {node: '>= 16'}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -2947,6 +2973,40 @@ packages:
   '@panva/hkdf@1.2.1':
     resolution: {integrity: sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==}
 
+  '@peculiar/asn1-cms@2.6.1':
+    resolution: {integrity: sha512-vdG4fBF6Lkirkcl53q6eOdn3XYKt+kJTG59edgRZORlg/3atWWEReRCx5rYE1ZzTTX6vLK5zDMjHh7vbrcXGtw==}
+
+  '@peculiar/asn1-csr@2.6.1':
+    resolution: {integrity: sha512-WRWnKfIocHyzFYQTka8O/tXCiBquAPSrRjXbOkHbO4qdmS6loffCEGs+rby6WxxGdJCuunnhS2duHURhjyio6w==}
+
+  '@peculiar/asn1-ecc@2.6.1':
+    resolution: {integrity: sha512-+Vqw8WFxrtDIN5ehUdvlN2m73exS2JVG0UAyfVB31gIfor3zWEAQPD+K9ydCxaj3MLen9k0JhKpu9LqviuCE1g==}
+
+  '@peculiar/asn1-pfx@2.6.1':
+    resolution: {integrity: sha512-nB5jVQy3MAAWvq0KY0R2JUZG8bO/bTLpnwyOzXyEh/e54ynGTatAR+csOnXkkVD9AFZ2uL8Z7EV918+qB1qDvw==}
+
+  '@peculiar/asn1-pkcs8@2.6.1':
+    resolution: {integrity: sha512-JB5iQ9Izn5yGMw3ZG4Nw3Xn/hb/G38GYF3lf7WmJb8JZUydhVGEjK/ZlFSWhnlB7K/4oqEs8HnfFIKklhR58Tw==}
+
+  '@peculiar/asn1-pkcs9@2.6.1':
+    resolution: {integrity: sha512-5EV8nZoMSxeWmcxWmmcolg22ojZRgJg+Y9MX2fnE2bGRo5KQLqV5IL9kdSQDZxlHz95tHvIq9F//bvL1OeNILw==}
+
+  '@peculiar/asn1-rsa@2.6.1':
+    resolution: {integrity: sha512-1nVMEh46SElUt5CB3RUTV4EG/z7iYc7EoaDY5ECwganibQPkZ/Y2eMsTKB/LeyrUJ+W/tKoD9WUqIy8vB+CEdA==}
+
+  '@peculiar/asn1-schema@2.6.0':
+    resolution: {integrity: sha512-xNLYLBFTBKkCzEZIw842BxytQQATQv+lDTCEMZ8C196iJcJJMBUZxrhSTxLaohMyKK8QlzRNTRkUmanucnDSqg==}
+
+  '@peculiar/asn1-x509-attr@2.6.1':
+    resolution: {integrity: sha512-tlW6cxoHwgcQghnJwv3YS+9OO1737zgPogZ+CgWRUK4roEwIPzRH4JEiG770xe5HX2ATfCpmX60gurfWIF9dcQ==}
+
+  '@peculiar/asn1-x509@2.6.1':
+    resolution: {integrity: sha512-O9jT5F1A2+t3r7C4VT7LYGXqkGLK7Kj1xFpz7U0isPrubwU5PbDoyYtx6MiGst29yq7pXN5vZbQFKRCP+lLZlA==}
+
+  '@peculiar/x509@1.14.3':
+    resolution: {integrity: sha512-C2Xj8FZ0uHWeCXXqX5B4/gVFQmtSkiuOolzAgutjTfseNOHT3pUjljDZsTSxXFGgio54bCzVFqmEOUrIVk8RDA==}
+    engines: {node: '>=20.0.0'}
+
   '@petamoriken/float16@3.9.3':
     resolution: {integrity: sha512-8awtpHXCx/bNpFt4mt2xdkgtgVvKqty8VbjHI/WWWQuEw+KLzFot3f4+LkQY9YmOtq7A5GdOnqoIC8Pdygjk2g==}
 
@@ -2975,6 +3035,36 @@ packages:
     resolution: {integrity: sha512-mrZOev24EDhnefmnZX7WVVT7v+r9LttPRqf54ONvj6re4XMF7wFTpK2tLJi4XHB7fFp/6xhYbgRel8YV7gQiyA==}
     peerDependencies:
       '@opentelemetry/api': ^1.8
+
+  '@protobufjs/aspromise@1.1.2':
+    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
+
+  '@protobufjs/base64@1.1.2':
+    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
+
+  '@protobufjs/codegen@2.0.4':
+    resolution: {integrity: sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==}
+
+  '@protobufjs/eventemitter@1.1.0':
+    resolution: {integrity: sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==}
+
+  '@protobufjs/fetch@1.1.0':
+    resolution: {integrity: sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==}
+
+  '@protobufjs/float@1.0.2':
+    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
+
+  '@protobufjs/inquire@1.1.0':
+    resolution: {integrity: sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==}
+
+  '@protobufjs/path@1.1.2':
+    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
+
+  '@protobufjs/pool@1.1.0':
+    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
+
+  '@protobufjs/utf8@1.1.0':
+    resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
 
   '@radix-ui/number@1.0.1':
     resolution: {integrity: sha512-T5gIdVO2mmPW3NNhjNgEP3cqMXjXL9UbO0BzWcXfvdBs+BohbQxvd/K5hSVKmn9/lbTdsQVKbUcP5WLCwvUbBg==}
@@ -4755,6 +4845,10 @@ packages:
     resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
     engines: {node: '>= 0.4'}
 
+  asn1js@3.0.7:
+    resolution: {integrity: sha512-uLvq6KJu04qoQM6gvBfKFjlh6Gl0vOKQuR5cJMDHQkmwfMOQeN3F3SHCv9SNYSL+CRoHvOGFfllDlVz03GQjvQ==}
+    engines: {node: '>=12.0.0'}
+
   assertion-error@1.1.0:
     resolution: {integrity: sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==}
 
@@ -4875,6 +4969,10 @@ packages:
   bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
     engines: {node: '>=18'}
+
+  bytestreamjs@2.0.1:
+    resolution: {integrity: sha512-U1Z/ob71V/bXfVABvNr/Kumf5VyeQRBEm6Txb0PQ6S7V5GpBM3w4Cbqz/xPDicR5tN0uvDifng8C+5qECeGwyQ==}
+    engines: {node: '>=6.0.0'}
 
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
@@ -5489,6 +5587,9 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
+  duplexify@4.1.3:
+    resolution: {integrity: sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==}
+
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
@@ -5513,6 +5614,9 @@ packages:
 
   encoding-sniffer@0.2.1:
     resolution: {integrity: sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==}
+
+  end-of-stream@1.4.5:
+    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
   enhanced-resolve@5.20.1:
     resolution: {integrity: sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==}
@@ -6051,6 +6155,10 @@ packages:
 
   google-auth-library@10.6.2:
     resolution: {integrity: sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==}
+    engines: {node: '>=18'}
+
+  google-gax@5.0.6:
+    resolution: {integrity: sha512-1kGbqVQBZPAAu4+/R1XxPQKP0ydbNYoLAr4l0ZO2bMV0kLyLW4I1gAk++qBLWt7DPORTzmWRMsCZe86gDjShJA==}
     engines: {node: '>=18'}
 
   google-logging-utils@1.1.3:
@@ -6763,6 +6871,9 @@ packages:
     resolution: {integrity: sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==}
     engines: {node: '>=18'}
 
+  long@5.3.2:
+    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
+
   longest@2.0.1:
     resolution: {integrity: sha512-Ajzxb8CM6WAnFjgiloPsI3bF+WCxcvhdIG3KNA2KN962+tdBsHcuQ4k4qX/EcS/2CRkcc0iAkR956Nib6aXU/Q==}
     engines: {node: '>=0.10.0'}
@@ -7322,6 +7433,10 @@ packages:
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
 
+  pkijs@3.4.0:
+    resolution: {integrity: sha512-emEcLuomt2j03vxD54giVB4SxTjnsqkU692xZOZXHDVoYyypEm+b3jpiTcc+Cf+myooc+/Ly0z01jqeNHVgJGw==}
+    engines: {node: '>=16.0.0'}
+
   playwright-core@1.59.1:
     resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
     engines: {node: '>=18'}
@@ -7501,6 +7616,14 @@ packages:
   proto-list@1.2.4:
     resolution: {integrity: sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==}
 
+  proto3-json-serializer@3.0.4:
+    resolution: {integrity: sha512-E1sbAYg3aEbXrq0n1ojJkRHQJGE1kaE/O6GLA94y8rnJBfgvOPTOd1b9hOceQK1FFZI9qMh1vBERCyO2ifubcw==}
+    engines: {node: '>=18'}
+
+  protobufjs@7.5.4:
+    resolution: {integrity: sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==}
+    engines: {node: '>=12.0.0'}
+
   protocols@2.0.2:
     resolution: {integrity: sha512-hHVTzba3wboROl0/aWRRG9dMytgH6ow//STBZh43l/wQgmMhYhOFi0EHWAPtoCz9IAUymsyP0TSBHkhgMEGNnQ==}
 
@@ -7525,6 +7648,13 @@ packages:
   pupa@3.3.0:
     resolution: {integrity: sha512-LjgDO2zPtoXP2wJpDjZrGdojii1uqO0cnwKoIoUzkfS98HDmbeiGmYiXo3lXeFlq2xvne1QFQhwYXSUCLKtEuA==}
     engines: {node: '>=12.20'}
+
+  pvtsutils@1.3.6:
+    resolution: {integrity: sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==}
+
+  pvutils@1.1.5:
+    resolution: {integrity: sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==}
+    engines: {node: '>=16.0.0'}
 
   qr.js@0.0.0:
     resolution: {integrity: sha512-c4iYnWb+k2E+vYpRimHqSu575b1/wKl4XFeJGpFmrJQz5I88v9aY2czh7s0w36srfCM1sXgC/xpoJz5dJfq+OQ==}
@@ -7667,6 +7797,9 @@ packages:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
 
+  reflect-metadata@0.2.2:
+    resolution: {integrity: sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==}
+
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
     engines: {node: '>= 0.4'}
@@ -7750,6 +7883,10 @@ packages:
     resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
     engines: {node: '>=18'}
 
+  retry-request@8.0.2:
+    resolution: {integrity: sha512-JzFPAfklk1kjR1w76f0QOIhoDkNkSqW8wYKT08n9yysTmZfB+RQ2QoXoTAeOi1HD9ZipTyTAZg3c4pM/jeqgSw==}
+    engines: {node: '>=18'}
+
   retry@0.13.1:
     resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
     engines: {node: '>= 4'}
@@ -7761,6 +7898,10 @@ packages:
   rimraf@3.0.2:
     resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
     deprecated: Rimraf versions prior to v4 are no longer supported
+    hasBin: true
+
+  rimraf@5.0.10:
+    resolution: {integrity: sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==}
     hasBin: true
 
   rollup@4.60.1:
@@ -7827,6 +7968,10 @@ packages:
   schema-utils@4.3.3:
     resolution: {integrity: sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==}
     engines: {node: '>= 10.13.0'}
+
+  selfsigned@5.5.0:
+    resolution: {integrity: sha512-ftnu3TW4+3eBfLRFnDEkzGxSF/10BJBkaLJuBHZX0kiPS7bRdlpZGu6YGt4KngMkdTwJE6MbjavFpqHvqVt+Ew==}
+    engines: {node: '>=18'}
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
@@ -7975,6 +8120,12 @@ packages:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
     engines: {node: '>= 0.4'}
 
+  stream-events@1.0.5:
+    resolution: {integrity: sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg==}
+
+  stream-shift@1.0.3:
+    resolution: {integrity: sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==}
+
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
@@ -8062,6 +8213,9 @@ packages:
   stubborn-utils@1.0.2:
     resolution: {integrity: sha512-zOh9jPYI+xrNOyisSelgym4tolKTJCQd5GBhK0+0xJvcYDcwlOoxF/rnFKQ2KRZknXSG9jWAp66fwP6AxN9STg==}
 
+  stubs@3.0.0:
+    resolution: {integrity: sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw==}
+
   styled-jsx@5.1.6:
     resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
     engines: {node: '>= 12.0.0'}
@@ -8129,6 +8283,10 @@ packages:
   tapable@2.3.2:
     resolution: {integrity: sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==}
     engines: {node: '>=6'}
+
+  teeny-request@10.1.2:
+    resolution: {integrity: sha512-Xj0ZAQ0CeuQn6UxCDPLbFRlgcSTUEyO3+wiepr2grjIjyL/lMMs1Z4OwXn8kLvn/V1OuaEP0UY7Na6UDNNsYrQ==}
+    engines: {node: '>=18'}
 
   terser-webpack-plugin@5.4.0:
     resolution: {integrity: sha512-Bn5vxm48flOIfkdl5CaD2+1CiUVbonWQ3KQPyP7/EuIl9Gbzq/gQFOzaMFUEgVjB1396tcK0SG8XcNJ/2kDH8g==}
@@ -8261,6 +8419,10 @@ packages:
     resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
     engines: {node: '>=18.0.0'}
     hasBin: true
+
+  tsyringe@4.10.0:
+    resolution: {integrity: sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw==}
+    engines: {node: '>= 6.0.0'}
 
   turbo-darwin-64@1.13.4:
     resolution: {integrity: sha512-A0eKd73R7CGnRinTiS7txkMElg+R5rKFp9HV7baDiEL4xTG1FIg/56Vm7A5RVgg8UNgG2qNnrfatJtb+dRmNdw==}
@@ -9433,6 +9595,24 @@ snapshots:
 
   '@formkit/auto-animate@0.8.4': {}
 
+  '@google-cloud/certificate-manager@2.1.1':
+    dependencies:
+      google-gax: 5.0.6
+    transitivePeerDependencies:
+      - supports-color
+
+  '@grpc/grpc-js@1.14.3':
+    dependencies:
+      '@grpc/proto-loader': 0.8.0
+      '@js-sdsl/ordered-map': 4.4.2
+
+  '@grpc/proto-loader@0.8.0':
+    dependencies:
+      lodash.camelcase: 4.3.0
+      long: 5.3.2
+      protobufjs: 7.5.4
+      yargs: 17.7.2
+
   '@hookform/resolvers@3.10.0(react-hook-form@7.72.1(react@18.3.1))':
     dependencies:
       react-hook-form: 7.72.1(react@18.3.1)
@@ -9730,6 +9910,8 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@js-sdsl/ordered-map@4.4.2': {}
+
   '@next/env@15.5.14': {}
 
   '@next/eslint-plugin-next@14.2.35':
@@ -9759,6 +9941,8 @@ snapshots:
 
   '@next/swc-win32-x64-msvc@15.5.14':
     optional: true
+
+  '@noble/hashes@1.4.0': {}
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -10251,6 +10435,96 @@ snapshots:
 
   '@panva/hkdf@1.2.1': {}
 
+  '@peculiar/asn1-cms@2.6.1':
+    dependencies:
+      '@peculiar/asn1-schema': 2.6.0
+      '@peculiar/asn1-x509': 2.6.1
+      '@peculiar/asn1-x509-attr': 2.6.1
+      asn1js: 3.0.7
+      tslib: 2.8.1
+
+  '@peculiar/asn1-csr@2.6.1':
+    dependencies:
+      '@peculiar/asn1-schema': 2.6.0
+      '@peculiar/asn1-x509': 2.6.1
+      asn1js: 3.0.7
+      tslib: 2.8.1
+
+  '@peculiar/asn1-ecc@2.6.1':
+    dependencies:
+      '@peculiar/asn1-schema': 2.6.0
+      '@peculiar/asn1-x509': 2.6.1
+      asn1js: 3.0.7
+      tslib: 2.8.1
+
+  '@peculiar/asn1-pfx@2.6.1':
+    dependencies:
+      '@peculiar/asn1-cms': 2.6.1
+      '@peculiar/asn1-pkcs8': 2.6.1
+      '@peculiar/asn1-rsa': 2.6.1
+      '@peculiar/asn1-schema': 2.6.0
+      asn1js: 3.0.7
+      tslib: 2.8.1
+
+  '@peculiar/asn1-pkcs8@2.6.1':
+    dependencies:
+      '@peculiar/asn1-schema': 2.6.0
+      '@peculiar/asn1-x509': 2.6.1
+      asn1js: 3.0.7
+      tslib: 2.8.1
+
+  '@peculiar/asn1-pkcs9@2.6.1':
+    dependencies:
+      '@peculiar/asn1-cms': 2.6.1
+      '@peculiar/asn1-pfx': 2.6.1
+      '@peculiar/asn1-pkcs8': 2.6.1
+      '@peculiar/asn1-schema': 2.6.0
+      '@peculiar/asn1-x509': 2.6.1
+      '@peculiar/asn1-x509-attr': 2.6.1
+      asn1js: 3.0.7
+      tslib: 2.8.1
+
+  '@peculiar/asn1-rsa@2.6.1':
+    dependencies:
+      '@peculiar/asn1-schema': 2.6.0
+      '@peculiar/asn1-x509': 2.6.1
+      asn1js: 3.0.7
+      tslib: 2.8.1
+
+  '@peculiar/asn1-schema@2.6.0':
+    dependencies:
+      asn1js: 3.0.7
+      pvtsutils: 1.3.6
+      tslib: 2.8.1
+
+  '@peculiar/asn1-x509-attr@2.6.1':
+    dependencies:
+      '@peculiar/asn1-schema': 2.6.0
+      '@peculiar/asn1-x509': 2.6.1
+      asn1js: 3.0.7
+      tslib: 2.8.1
+
+  '@peculiar/asn1-x509@2.6.1':
+    dependencies:
+      '@peculiar/asn1-schema': 2.6.0
+      asn1js: 3.0.7
+      pvtsutils: 1.3.6
+      tslib: 2.8.1
+
+  '@peculiar/x509@1.14.3':
+    dependencies:
+      '@peculiar/asn1-cms': 2.6.1
+      '@peculiar/asn1-csr': 2.6.1
+      '@peculiar/asn1-ecc': 2.6.1
+      '@peculiar/asn1-pkcs9': 2.6.1
+      '@peculiar/asn1-rsa': 2.6.1
+      '@peculiar/asn1-schema': 2.6.0
+      '@peculiar/asn1-x509': 2.6.1
+      pvtsutils: 1.3.6
+      reflect-metadata: 0.2.2
+      tslib: 2.8.1
+      tsyringe: 4.10.0
+
   '@petamoriken/float16@3.9.3': {}
 
   '@pkgjs/parseargs@0.11.0':
@@ -10278,6 +10552,29 @@ snapshots:
       '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
     transitivePeerDependencies:
       - supports-color
+
+  '@protobufjs/aspromise@1.1.2': {}
+
+  '@protobufjs/base64@1.1.2': {}
+
+  '@protobufjs/codegen@2.0.4': {}
+
+  '@protobufjs/eventemitter@1.1.0': {}
+
+  '@protobufjs/fetch@1.1.0':
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/inquire': 1.1.0
+
+  '@protobufjs/float@1.0.2': {}
+
+  '@protobufjs/inquire@1.1.0': {}
+
+  '@protobufjs/path@1.1.2': {}
+
+  '@protobufjs/pool@1.1.0': {}
+
+  '@protobufjs/utf8@1.1.0': {}
 
   '@radix-ui/number@1.0.1':
     dependencies:
@@ -11342,7 +11639,7 @@ snapshots:
 
   '@scalar/helpers@0.2.18': {}
 
-  '@scalar/nextjs-api-reference@0.9.26(next@15.5.14(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)':
+  '@scalar/nextjs-api-reference@0.9.26(next@15.5.14(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@scalar/core': 0.3.45
       next: 15.5.14(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -12263,6 +12560,12 @@ snapshots:
       get-intrinsic: 1.3.0
       is-array-buffer: 3.0.5
 
+  asn1js@3.0.7:
+    dependencies:
+      pvtsutils: 1.3.6
+      pvutils: 1.1.5
+      tslib: 2.8.1
+
   assertion-error@1.1.0: {}
 
   ast-types-flow@0.0.8: {}
@@ -12386,6 +12689,8 @@ snapshots:
   bundle-name@4.1.0:
     dependencies:
       run-applescript: 7.1.0
+
+  bytestreamjs@2.0.1: {}
 
   cac@6.7.14: {}
 
@@ -12951,6 +13256,13 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
+  duplexify@4.1.3:
+    dependencies:
+      end-of-stream: 1.4.5
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+      stream-shift: 1.0.3
+
   eastasianwidth@0.2.0: {}
 
   ecdsa-sig-formatter@1.0.11:
@@ -12971,6 +13283,10 @@ snapshots:
     dependencies:
       iconv-lite: 0.6.3
       whatwg-encoding: 3.1.1
+
+  end-of-stream@1.4.5:
+    dependencies:
+      once: 1.4.0
 
   enhanced-resolve@5.20.1:
     dependencies:
@@ -13816,6 +14132,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  google-gax@5.0.6:
+    dependencies:
+      '@grpc/grpc-js': 1.14.3
+      '@grpc/proto-loader': 0.8.0
+      duplexify: 4.1.3
+      google-auth-library: 10.6.2
+      google-logging-utils: 1.1.3
+      node-fetch: 3.3.2
+      object-hash: 3.0.0
+      proto3-json-serializer: 3.0.4
+      protobufjs: 7.5.4
+      retry-request: 8.0.2
+      rimraf: 5.0.10
+    transitivePeerDependencies:
+      - supports-color
+
   google-logging-utils@1.1.3: {}
 
   gopd@1.2.0: {}
@@ -14541,6 +14873,8 @@ snapshots:
       chalk: 5.4.1
       is-unicode-supported: 1.3.0
 
+  long@5.3.2: {}
+
   longest@2.0.1: {}
 
   loose-envify@1.4.0:
@@ -15102,6 +15436,15 @@ snapshots:
       mlly: 1.8.2
       pathe: 2.0.3
 
+  pkijs@3.4.0:
+    dependencies:
+      '@noble/hashes': 1.4.0
+      asn1js: 3.0.7
+      bytestreamjs: 2.0.1
+      pvtsutils: 1.3.6
+      pvutils: 1.1.5
+      tslib: 2.8.1
+
   playwright-core@1.59.1: {}
 
   playwright@1.59.1:
@@ -15213,6 +15556,25 @@ snapshots:
 
   proto-list@1.2.4: {}
 
+  proto3-json-serializer@3.0.4:
+    dependencies:
+      protobufjs: 7.5.4
+
+  protobufjs@7.5.4:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.4
+      '@protobufjs/eventemitter': 1.1.0
+      '@protobufjs/fetch': 1.1.0
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/inquire': 1.1.0
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.0
+      '@types/node': 20.19.39
+      long: 5.3.2
+
   protocols@2.0.2: {}
 
   proxy-agent@6.5.0:
@@ -15241,6 +15603,12 @@ snapshots:
   pupa@3.3.0:
     dependencies:
       escape-goat: 4.0.0
+
+  pvtsutils@1.3.6:
+    dependencies:
+      tslib: 2.8.1
+
+  pvutils@1.1.5: {}
 
   qr.js@0.0.0: {}
 
@@ -15381,6 +15749,8 @@ snapshots:
       indent-string: 4.0.0
       strip-indent: 3.0.0
 
+  reflect-metadata@0.2.2: {}
+
   reflect.getprototypeof@1.0.10:
     dependencies:
       call-bind: 1.0.8
@@ -15508,6 +15878,13 @@ snapshots:
       onetime: 7.0.0
       signal-exit: 4.1.0
 
+  retry-request@8.0.2:
+    dependencies:
+      extend: 3.0.2
+      teeny-request: 10.1.2
+    transitivePeerDependencies:
+      - supports-color
+
   retry@0.13.1: {}
 
   reusify@1.1.0: {}
@@ -15515,6 +15892,10 @@ snapshots:
   rimraf@3.0.2:
     dependencies:
       glob: 7.2.3
+
+  rimraf@5.0.10:
+    dependencies:
+      glob: 10.3.10
 
   rollup@4.60.1:
     dependencies:
@@ -15608,6 +15989,11 @@ snapshots:
       ajv: 8.18.0
       ajv-formats: 2.1.1(ajv@8.18.0)
       ajv-keywords: 5.1.0(ajv@8.18.0)
+
+  selfsigned@5.5.0:
+    dependencies:
+      '@peculiar/x509': 1.14.3
+      pkijs: 3.4.0
 
   semver@6.3.1: {}
 
@@ -15782,6 +16168,12 @@ snapshots:
       es-errors: 1.3.0
       internal-slot: 1.1.0
 
+  stream-events@1.0.5:
+    dependencies:
+      stubs: 3.0.0
+
+  stream-shift@1.0.3: {}
+
   string-width@4.2.3:
     dependencies:
       emoji-regex: 8.0.0
@@ -15890,6 +16282,8 @@ snapshots:
 
   stubborn-utils@1.0.2: {}
 
+  stubs@3.0.0: {}
+
   styled-jsx@5.1.6(@babel/core@7.29.0)(react@18.3.1):
     dependencies:
       client-only: 0.0.1
@@ -15973,6 +16367,15 @@ snapshots:
       - yaml
 
   tapable@2.3.2: {}
+
+  teeny-request@10.1.2:
+    dependencies:
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      node-fetch: 3.3.2
+      stream-events: 1.0.5
+    transitivePeerDependencies:
+      - supports-color
 
   terser-webpack-plugin@5.4.0(webpack@5.105.4):
     dependencies:
@@ -16098,6 +16501,10 @@ snapshots:
       get-tsconfig: 4.13.7
     optionalDependencies:
       fsevents: 2.3.3
+
+  tsyringe@4.10.0:
+    dependencies:
+      tslib: 1.14.1
 
   turbo-darwin-64@1.13.4:
     optional: true


### PR DESCRIPTION
## Summary

R5 Decision 6 operations 1-4. Stacks on [#240](https://github.com/F3-Nation/f3-nation/pull/240) (reconciler scaffold).

- **Op 1** — DNS challenge validation (`awaiting_dns_challenge → provisioning_cert`)
- **Op 2** — Cert provisioning with CertificateMapEntry attach (`provisioning_cert → awaiting_probe | degraded`)
- **Op 3** — **SNI probe** (`awaiting_probe → awaiting_cutover | degraded`) — the R5 architectural centerpiece
- **Op 4** — Post-cutover DNS verification (`awaiting_cutover → active`)

## The SNI probe — R5 structural fix verified

**The probe must never resolve public DNS for the tenant hostname.** R4's probe did (via `fetch` against the hostname), which meant it certified the old per-region stack pre-cutover. R5 requires a direct TLS dial to the LB static IP with `servername` set to the hostname via SNI and a raw HTTP request over the established socket.

The agent walked the full code path and confirmed zero DNS resolution of the tenant hostname:
- `runSniProbe` takes `targetIp: string` (numeric IPv4)
- `tls.connect({ host: targetIp, port: 443, servername: hostname, rejectUnauthorized: true })` — numeric host means Node skips `dns.lookup`
- Raw HTTP written to the established socket; no `fetch`, no `URL`, no DNS
- `grep` of `src/probe/` for `node:dns|dns\.|fetch\(|new URL` returns zero matches
- Op 4 (post-cutover) is the **only** file in the reconciler that imports `node:dns` — by design, that operation verifies the user's DNS change actually happened
- `tests/probe/sni-probe.test.ts` includes an explicit test that asserts `tlsConnectFn` was called with `host` matching `/^\d+\.\d+\.\d+\.\d+$/` and `servername` equal to the tenant hostname

Real TLS handshake tests use `tls.createServer` with self-signed certs (via the `selfsigned` dev dep) for end-to-end probe validation against an in-process server.

## Operation architecture

- Shared primitives in `src/operations/shared.ts`: `stateGuardedUpdate`, `handleAlreadyExists` (ALREADY_EXISTS fall-through to GET-and-verify), `haltOnDrift` with structured `reconciler_error` payload matching the Cloud Monitoring alert policies in F3-Nation/f3-redirect#2
- GCP Certificate Manager wrapper in `src/gcp/cert-manager-client.ts` with error mapping to local `AlreadyExistsError` / `NotFoundError` / `PermissionDeniedError`
- Dispatcher in `src/process.ts` routes transient states to operations and stubs F3R5_011 for ops 5-8

## Stack

1. [#238](https://github.com/F3-Nation/f3-nation/pull/238) — `feat/r5-redirect-platform-db`
2. [#240](https://github.com/F3-Nation/f3-nation/pull/240) — `feat/r5-reconciler` (scaffold)
3. **This PR** — `feat/r5-reconciler-ops-1-4` (ops 1-4)
4. Upcoming — `feat/r5-reconciler-ops-5-8` (F3R5_011)

## Test plan

- [x] 82/82 tests pass (14 existing + 68 new)
- [x] `typecheck`, `lint`, `build` clean
- [x] Whole-repo turbo typecheck + lint pass (17/17 and 18/18 respectively)
- [x] DNS-free invariant explicitly asserted by `runSniProbe — no public DNS resolution` test
- [ ] Apply to a Neon preview branch, create test rows, observe the state machine advance
- [ ] Real probe against a staging LB with a real tenant cert

🤖 Generated with [Claude Code](https://claude.com/claude-code)