### PR TITLE
R5 Phase 1: apps/redirect-admin scaffold (registration, SSO, quota, state presenter)

### DIFF
--- a/apps/redirect-admin/.env.local.example
+++ b/apps/redirect-admin/.env.local.example
@@ -1,0 +1,26 @@
+# =============================================================================
+# F3 Redirect Admin — Local Development Environment (example)
+# =============================================================================
+
+# --- Neon (redirect_admin_ui role) ---
+NEON_REDIRECT_ADMIN_UI_URL=postgres://redirect_admin_ui:CHANGE_ME@localhost:5432/platform
+
+# --- Internal region-binding validator (Decision 11) ---
+REGION_BINDING_VALIDATOR_URL=http://localhost:3001
+REGION_BINDING_VALIDATOR_S2S_SECRET=local-dev-s2s-secret
+
+# --- f3-nation Supabase DB (read-only) ---
+DATABASE_URL=postgres://postgres:postgres@localhost:5432/f3nation_local
+
+# --- SSO ---
+OAUTH_CLIENT_ID=f3-redirect-admin-local
+OAUTH_CLIENT_SECRET=<from-gcp>
+OAUTH_REDIRECT_URI=http://localhost:3006/api/auth/callback
+AUTH_PROVIDER_URL=http://localhost:3004
+SESSION_SECRET=<from-gcp>
+NEXT_PUBLIC_SITE_URL=http://localhost:3006
+
+# --- GCP ---
+GCP_PROJECT_ID=f3-redirects
+REDIRECT_CERT_MAP_NAME=redirect-platform-cert-map
+REDIRECT_LB_IPV4=

--- a/apps/redirect-admin/Dockerfile
+++ b/apps/redirect-admin/Dockerfile
@@ -1,0 +1,63 @@
+# ---------------------------------------------------------------------------
+# apps/redirect-admin/Dockerfile
+#
+# Multi-stage build for the redirect-admin Cloud Run service.
+# Layout mirrors apps/me and apps/auth: turbo prune -> install -> build.
+# ---------------------------------------------------------------------------
+
+# ---------- Stage 1: Prune monorepo ----------
+FROM node:20-alpine AS builder
+
+ENV TURBO_TELEMETRY_DISABLED=1
+ENV PNPM_HOME="/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
+RUN apk add --no-cache libc6-compat && apk update
+WORKDIR /app
+
+RUN corepack enable && corepack prepare pnpm@10.33.0 --activate
+RUN pnpm add -g turbo@^1.12.3
+
+COPY . .
+RUN turbo prune @acme/redirect-admin --docker
+
+# ---------- Stage 2: Install + build ----------
+FROM node:20-alpine AS installer
+
+ENV NEXT_TELEMETRY_DISABLED=1
+ENV TURBO_TELEMETRY_DISABLED=1
+ENV PNPM_HOME="/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
+ENV SKIP_ENV_VALIDATION=1
+
+RUN apk add --no-cache libc6-compat openssl && apk update
+WORKDIR /app
+
+RUN corepack enable && corepack prepare pnpm@10.33.0 --activate
+RUN pnpm add -g turbo@^1.12.3
+
+COPY --from=builder /app/out/json/ .
+COPY --from=builder /app/out/pnpm-lock.yaml ./pnpm-lock.yaml
+RUN pnpm install --frozen-lockfile
+
+COPY --from=builder /app/out/full/ .
+RUN pnpm turbo build --filter=@acme/redirect-admin
+
+# ---------- Stage 3: Production runner ----------
+FROM node:20-alpine AS runner
+
+RUN apk add --no-cache libc6-compat openssl && apk update
+WORKDIR /app
+
+RUN addgroup --system --gid 1001 nodejs && \
+    adduser --system --uid 1001 redirect-admin
+
+COPY --from=installer --chown=redirect-admin:nodejs /app/apps/redirect-admin/.next/standalone ./
+COPY --from=installer --chown=redirect-admin:nodejs /app/apps/redirect-admin/.next/static ./apps/redirect-admin/.next/static
+COPY --from=installer --chown=redirect-admin:nodejs /app/apps/redirect-admin/public ./apps/redirect-admin/public
+
+USER redirect-admin
+
+ENV PORT=3006
+EXPOSE 3006
+
+CMD ["node", "apps/redirect-admin/server.js"]

--- a/apps/redirect-admin/README.md
+++ b/apps/redirect-admin/README.md
@@ -1,0 +1,141 @@
+# @acme/redirect-admin
+
+Self-serve admin UI for F3 region custom domain registration and lifecycle management.
+
+Part of the R5 redirect platform refactor — see
+`f3-redirect/docs/plans/2026-04-14-multi-tenant-saas-refactor.md`, Decisions 5–8
+and 11.
+
+## What this app does
+
+Region admins (`admin` or `editor` role on an F3 org) can:
+
+1. Sign in via F3 SSO (copied from `apps/me`).
+2. See their orgs and current binding state (`no_binding` → bind button,
+   `unverified` → stub for F3R5_013, `verified` → domain list + register).
+3. Register a custom hostname (apex or stats subdomain) for a verified-binding
+   org. The POST handler
+   - checks the domain blocklist,
+   - enforces per-org quota (`org_domain_quota.max_domains`, default 10),
+   - inserts a row into `region_custom_domains` with
+     `lifecycle_state = 'pending'`. The `trg_rcd_verified_binding` trigger in
+     `packages/redirect-platform-db/sql/0002_*.sql` enforces at the DB level
+     that the org's binding is `verified`.
+   - calls Certificate Manager `DnsAuthorization.Create` with the
+     deterministic id `dns-auth-<row.id>`, handling `ALREADY_EXISTS` by
+     GET-and-reuse (same pattern as the reconciler).
+   - surfaces the CNAME challenge record the user needs to add to their DNS.
+4. Poll domain status (`GET /api/domains/:id`) and see a user-friendly
+   rendering via `state-presenter.ts`.
+5. Tombstone a domain (`DELETE /api/domains/:id`) — the reconciler owns the
+   actual GCP teardown.
+
+## Architecture
+
+```
+apps/redirect-admin/
+├── middleware.ts             # SSO gate (session cookie signature check)
+├── src/
+│   ├── env.ts                # env validation; throws on missing required vars
+│   ├── app/
+│   │   ├── layout.tsx
+│   │   ├── page.tsx          # landing: orgs + binding state
+│   │   ├── domains/
+│   │   │   ├── page.tsx      # all domains across user's orgs
+│   │   │   └── new/page.tsx  # registration form
+│   │   └── api/
+│   │       ├── auth/…        # SSO routes copied from apps/me
+│   │       └── domains/
+│   │           ├── register/route.ts   # POST handler — thin wrapper
+│   │           └── [id]/route.ts       # GET status, DELETE tombstone
+│   ├── components/
+│   │   └── register-domain-form.tsx    # client component
+│   └── lib/
+│       ├── auth/…                      # SSO helpers (copied from apps/me)
+│       ├── supabase-client.ts          # read-only Drizzle over @acme/db
+│       ├── db-client.ts                # Drizzle over @acme/redirect-platform-db
+│       ├── cert-manager-client.ts      # @google-cloud/certificate-manager wrapper
+│       ├── validator-client.ts         # calls the internal region-binding validator
+│       ├── quota-check.ts              # pure per-org quota check
+│       ├── hostname-validation.ts      # pure syntactic hostname validation
+│       ├── state-presenter.ts          # pure lifecycle → view model
+│       └── services/
+│           ├── domain-registration.ts  # pure business logic (trigger-gated INSERT)
+│           ├── landing-data.ts         # landing-page query helper
+│           └── user-orgs.ts            # role lookup against Supabase
+```
+
+## Business logic
+
+All business logic lives in `src/lib/` (NOT in route handlers). The route
+handlers are thin wrappers that:
+
+1. Read the SSO session.
+2. Parse + validate the request body (via zod).
+3. Resolve collaborators (db clients, cert-manager factory).
+4. Delegate to a pure service function.
+5. Map the typed result to HTTP.
+
+This means `registerDomain(input, deps)` is 100%-unit-testable without an
+HTTP server or a real Postgres.
+
+## Security model (Decision 8)
+
+- The Neon connection uses the `redirect_admin_ui` role — no access to
+  `reconciler_leases`, no UPDATE on `region_custom_domain_events`.
+- The `trg_rcd_verified_binding` trigger is the authoritative gate on
+  binding verification — the app-layer check is UX sugar, the DB is truth.
+- Per-org quota is enforced in `checkQuota()` plus optional hand-tuned rows in
+  `org_domain_quota` (raised by a platform admin).
+- `domain_blocklist` rejects reserved hostnames at registration time.
+
+## Env vars
+
+Required (see `src/env.ts` for the canonical list):
+
+| Var                                       | Purpose                                                 |
+| ----------------------------------------- | ------------------------------------------------------- |
+| `NEON_REDIRECT_ADMIN_UI_URL`              | Neon conn string for `redirect_admin_ui` role           |
+| `REGION_BINDING_VALIDATOR_URL`            | Base URL for the internal validator (Decision 11)       |
+| `REGION_BINDING_VALIDATOR_S2S_SECRET`     | Bearer token for validator S2S auth                     |
+| `DATABASE_URL`                            | f3-nation Supabase DB (read-only, for org/role lookups) |
+| `OAUTH_CLIENT_ID` / `OAUTH_CLIENT_SECRET` | F3 SSO client (copy from `apps/me`)                     |
+| `OAUTH_REDIRECT_URI`                      | SSO callback URL                                        |
+| `AUTH_PROVIDER_URL`                       | F3 SSO server URL                                       |
+| `SESSION_SECRET`                          | HMAC key for signed session cookie                      |
+| `NEXT_PUBLIC_SITE_URL`                    | Public origin                                           |
+
+Optional:
+
+| Var                                   | Default                      | Purpose                                    |
+| ------------------------------------- | ---------------------------- | ------------------------------------------ |
+| `GCP_PROJECT_ID`                      | `f3-redirects`               | Certificate Manager project                |
+| `REDIRECT_CERT_MAP_NAME`              | `redirect-platform-cert-map` | Cert Map name                              |
+| `REDIRECT_LB_IPV4`                    | (none)                       | LB IPv4 shown to users after cutover-ready |
+| `REGION_BINDING_VALIDATOR_TIMEOUT_MS` | `10000`                      | Validator fetch timeout                    |
+
+## Scope (F3R5_012)
+
+**In:**
+
+- Scaffold app from `apps/me` SSO template
+- Pure state-presenter, quota-check, hostname-validation, validator-client, cert-manager-client
+- Registration POST handler (with trigger-gated INSERT)
+- Status polling, domain listing, delete handler
+- Landing page stub + unverified-binding placeholder
+
+**Out (F3R5_013):**
+
+- Decision 9 binding verification evidence UI (full verification flow)
+- Decision 6 degraded-state recovery UI
+- Binding create/verify POSTs
+
+## Tests
+
+```bash
+pnpm --filter @acme/redirect-admin test
+```
+
+Target: 40+ unit tests across `state-presenter`, `quota-check`,
+`validator-client`, `hostname-validation`, `cert-manager-client`,
+`domain-registration`, `env`.

--- a/apps/redirect-admin/middleware.ts
+++ b/apps/redirect-admin/middleware.ts
@@ -1,0 +1,51 @@
+/**
+ * SSO middleware — copied from apps/me. Verifies the session cookie
+ * signature (not just its presence) on every non-public path, and
+ * bounces unauthenticated users to the landing page.
+ *
+ * Kept at the app root per Next.js convention (same as apps/me).
+ */
+
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+import { SESSION_COOKIE_NAME } from "@/lib/auth/constants";
+import { verifySessionValue } from "@/lib/auth/session";
+
+const PUBLIC_PATHS = ["/", "/api/auth/login", "/api/auth/callback"];
+
+export function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+
+  if (PUBLIC_PATHS.includes(pathname)) {
+    return NextResponse.next();
+  }
+
+  if (pathname.startsWith("/api/auth/")) {
+    return NextResponse.next();
+  }
+
+  if (
+    pathname.startsWith("/_next/") ||
+    pathname.startsWith("/favicon") ||
+    pathname.includes(".")
+  ) {
+    return NextResponse.next();
+  }
+
+  const sessionCookie = request.cookies.get(SESSION_COOKIE_NAME);
+  const session = sessionCookie?.value
+    ? verifySessionValue(sessionCookie.value)
+    : null;
+
+  if (!session) {
+    const url = new URL("/", request.url);
+    url.searchParams.set("redirect", pathname);
+    return NextResponse.redirect(url);
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ["/((?!_next/static|_next/image|favicon.ico).*)"],
+};

--- a/apps/redirect-admin/next.config.mjs
+++ b/apps/redirect-admin/next.config.mjs
@@ -1,0 +1,8 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  output: "standalone",
+  // The redirect-admin UI is server-only — no remote image hosts needed.
+  reactStrictMode: true,
+};
+
+export default nextConfig;

--- a/apps/redirect-admin/package.json
+++ b/apps/redirect-admin/package.json
@@ -1,0 +1,67 @@
+{
+  "name": "@acme/redirect-admin",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "F3 redirect platform self-serve admin UI (R5 / F3R5_012).",
+  "scripts": {
+    "dev": "next dev --port 3006",
+    "build": "next build",
+    "start": "next start --port 3006",
+    "lint": "eslint . --max-warnings 0",
+    "format:check": "prettier --check .",
+    "format": "prettier --write .",
+    "test": "vitest --run",
+    "test:watch": "vitest -w",
+    "test:coverage": "vitest --run --coverage",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@acme/db": "workspace:*",
+    "@acme/redirect-platform-db": "workspace:*",
+    "@acme/sso": "workspace:*",
+    "@google-cloud/certificate-manager": "^2.1.1",
+    "clsx": "^2.1.0",
+    "drizzle-orm": "^0.39.3",
+    "next": "^15.3.6",
+    "postgres": "^3.4.3",
+    "react": "18.3.1",
+    "react-dom": "18.3.1",
+    "server-only": "^0.0.1",
+    "tailwind-merge": "^2.2.1",
+    "zod": "^3.25.8"
+  },
+  "devDependencies": {
+    "@acme/eslint-config": "workspace:^0.2.0",
+    "@acme/prettier-config": "workspace:^0.1.0",
+    "@testing-library/jest-dom": "^6.4.2",
+    "@types/node": "^20.11.13",
+    "@types/react": "^18.3.1",
+    "@types/react-dom": "^18.3.1",
+    "@vitejs/plugin-react": "^4.2.1",
+    "@vitest/coverage-v8": "^1.5.0",
+    "autoprefixer": "^10.4.17",
+    "eslint": "^8.56.0",
+    "postcss": "^8.4.35",
+    "prettier": "^3.2.5",
+    "tailwindcss": "^3.4.1",
+    "tailwindcss-animate": "^1.0.7",
+    "typescript": "^5.3.3",
+    "vitest": "^1.5.0"
+  },
+  "eslintConfig": {
+    "root": true,
+    "extends": [
+      "@acme/eslint-config/base",
+      "@acme/eslint-config/nextjs",
+      "@acme/eslint-config/react"
+    ],
+    "ignorePatterns": [
+      "next-env.d.ts",
+      "coverage/**",
+      "vitest.config.ts",
+      "vitest.setup.ts"
+    ]
+  },
+  "prettier": "@acme/prettier-config"
+}

--- a/apps/redirect-admin/postcss.config.mjs
+++ b/apps/redirect-admin/postcss.config.mjs
@@ -1,0 +1,9 @@
+/** @type {import('postcss-load-config').Config} */
+const config = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};
+
+export default config;

--- a/apps/redirect-admin/src/app/api/auth/callback/route.ts
+++ b/apps/redirect-admin/src/app/api/auth/callback/route.ts
@@ -1,0 +1,130 @@
+/**
+ * OAuth callback — copied from apps/me, rebranded imports only.
+ * Validates CSRF + PKCE, exchanges the code for tokens, resolves the user,
+ * then writes a signed session cookie and redirects to the original
+ * `returnTo` path (defaulting to /domains).
+ */
+
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { exchangeCodeForToken, getUserInfo } from "@/lib/auth/oauth";
+import { createSessionValue } from "@/lib/auth/session";
+import {
+  SESSION_COOKIE_MAX_AGE,
+  SESSION_COOKIE_NAME,
+} from "@/lib/auth/constants";
+import { safeReturnTo } from "@/lib/auth/validation";
+
+interface StatePayload {
+  csrfToken: string;
+  clientId: string;
+  returnTo: string;
+  timestamp: number;
+}
+
+function getPublicOrigin(): string {
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL;
+  if (!siteUrl) throw new Error("NEXT_PUBLIC_SITE_URL is not configured");
+  return siteUrl.replace(/\/+$/, "");
+}
+
+function errorRedirect(baseUrl: string, error: string, returnTo?: string) {
+  const url = new URL("/", baseUrl);
+  url.searchParams.set("error", error);
+  if (returnTo) url.searchParams.set("redirect", returnTo);
+  return NextResponse.redirect(url.toString());
+}
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = request.nextUrl;
+  const code = searchParams.get("code");
+  const stateParam = searchParams.get("state");
+  const errorParam = searchParams.get("error");
+  const baseUrl = getPublicOrigin();
+
+  if (errorParam) {
+    return errorRedirect(baseUrl, errorParam);
+  }
+
+  if (!code || !stateParam) {
+    return errorRedirect(baseUrl, "missing_params");
+  }
+
+  let state: StatePayload;
+  try {
+    state = JSON.parse(
+      Buffer.from(stateParam, "base64url").toString("utf-8"),
+    ) as StatePayload;
+  } catch {
+    return errorRedirect(baseUrl, "invalid_state");
+  }
+
+  if (Date.now() - state.timestamp > 600_000) {
+    return errorRedirect(baseUrl, "expired_state");
+  }
+
+  const csrfCookie = request.cookies.get("oauth_csrf")?.value;
+  if (!csrfCookie || csrfCookie !== state.csrfToken) {
+    return errorRedirect(baseUrl, "csrf_mismatch");
+  }
+
+  const returnTo = safeReturnTo(state.returnTo);
+
+  const codeVerifier = request.cookies.get("oauth_code_verifier")?.value;
+  if (!codeVerifier) {
+    return errorRedirect(baseUrl, "missing_code_verifier", returnTo);
+  }
+
+  let accessToken: string;
+  try {
+    const tokens = await exchangeCodeForToken({ code, codeVerifier });
+    if (!tokens.accessToken) {
+      return errorRedirect(baseUrl, "token_exchange_failed", returnTo);
+    }
+    accessToken = tokens.accessToken;
+  } catch (err) {
+    console.error("Token exchange failed", err);
+    return errorRedirect(baseUrl, "token_exchange_failed", returnTo);
+  }
+
+  let userInfo: { sub: number; email?: string; name?: string };
+  try {
+    userInfo = await getUserInfo(accessToken);
+  } catch (err) {
+    console.error("Failed to fetch user info", err);
+    return errorRedirect(baseUrl, "userinfo_failed", returnTo);
+  }
+
+  if (!userInfo.email) {
+    return errorRedirect(baseUrl, "user_not_found", returnTo);
+  }
+
+  const sessionValue = createSessionValue({
+    sub: String(userInfo.sub),
+    email: userInfo.email,
+    name: userInfo.name,
+    userId: userInfo.sub,
+  });
+
+  const response = NextResponse.redirect(new URL(returnTo, baseUrl).toString());
+
+  response.cookies.set(SESSION_COOKIE_NAME, sessionValue, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax",
+    path: "/",
+    maxAge: SESSION_COOKIE_MAX_AGE,
+  });
+
+  const clearCookieOpts = {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax" as const,
+    path: "/",
+    maxAge: 0,
+  };
+  response.cookies.set("oauth_csrf", "", clearCookieOpts);
+  response.cookies.set("oauth_code_verifier", "", clearCookieOpts);
+
+  return response;
+}

--- a/apps/redirect-admin/src/app/api/auth/login/route.ts
+++ b/apps/redirect-admin/src/app/api/auth/login/route.ts
@@ -1,0 +1,54 @@
+/**
+ * OAuth login start — copied verbatim from apps/me/src/app/api/auth/login/route.ts,
+ * rebranded imports only. Kicks off the PKCE flow against the F3 SSO server
+ * and drops a CSRF + code_verifier cookie pair for the callback to consume.
+ */
+
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { randomBytes, randomUUID, createHash } from "crypto";
+import { getOAuthConfig } from "@/lib/auth/oauth";
+import { safeReturnTo } from "@/lib/auth/validation";
+
+export async function GET(request: NextRequest) {
+  const returnTo = safeReturnTo(request.nextUrl.searchParams.get("returnTo"));
+
+  const csrfToken = randomUUID();
+  const codeVerifier = randomBytes(32).toString("base64url");
+  const codeChallenge = createHash("sha256")
+    .update(codeVerifier)
+    .digest("base64url");
+  const { clientId, authServerUrl, redirectUri } = getOAuthConfig();
+
+  const state = Buffer.from(
+    JSON.stringify({
+      csrfToken,
+      clientId,
+      returnTo,
+      timestamp: Date.now(),
+    }),
+  ).toString("base64url");
+
+  const authorizeUrl = new URL(`${authServerUrl}/api/oauth/authorize`);
+  authorizeUrl.searchParams.set("response_type", "code");
+  authorizeUrl.searchParams.set("client_id", clientId);
+  authorizeUrl.searchParams.set("redirect_uri", redirectUri);
+  authorizeUrl.searchParams.set("scope", "openid profile email");
+  authorizeUrl.searchParams.set("state", state);
+  authorizeUrl.searchParams.set("code_challenge", codeChallenge);
+  authorizeUrl.searchParams.set("code_challenge_method", "S256");
+
+  const response = NextResponse.redirect(authorizeUrl.toString(), 302);
+  const cookieOpts = {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax" as const,
+    path: "/",
+    maxAge: 600, // 10 minutes
+  };
+
+  response.cookies.set("oauth_csrf", csrfToken, cookieOpts);
+  response.cookies.set("oauth_code_verifier", codeVerifier, cookieOpts);
+
+  return response;
+}

--- a/apps/redirect-admin/src/app/api/auth/logout/route.ts
+++ b/apps/redirect-admin/src/app/api/auth/logout/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from "next/server";
+import { SESSION_COOKIE_NAME } from "@/lib/auth/constants";
+import { getOAuthConfig } from "@/lib/auth/oauth";
+
+export async function POST() {
+  const { authServerUrl } = getOAuthConfig();
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "http://localhost:3006";
+
+  const response = NextResponse.json({
+    ok: true,
+    redirectTo: `${authServerUrl}/api/oauth/logout?post_logout_redirect_uri=${encodeURIComponent(siteUrl)}`,
+  });
+  response.cookies.set(SESSION_COOKIE_NAME, "", {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax",
+    path: "/",
+    maxAge: 0,
+  });
+  return response;
+}

--- a/apps/redirect-admin/src/app/api/auth/me/route.ts
+++ b/apps/redirect-admin/src/app/api/auth/me/route.ts
@@ -1,0 +1,7 @@
+import { NextResponse } from "next/server";
+import { getSessionUser } from "@/lib/auth/server";
+
+export async function GET() {
+  const user = await getSessionUser();
+  return NextResponse.json({ user: user ?? null });
+}

--- a/apps/redirect-admin/src/app/api/domains/[id]/route.ts
+++ b/apps/redirect-admin/src/app/api/domains/[id]/route.ts
@@ -1,0 +1,155 @@
+/**
+ * GET  /api/domains/:id — status poll, returns row + presented state
+ * DELETE /api/domains/:id — tombstone the domain (reconciler handles teardown)
+ *
+ * Both route handlers check SSO and ensure the caller has admin/editor
+ * role on the owning org before reading/writing.
+ */
+
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { eq } from "drizzle-orm";
+
+import {
+  regionCustomDomainEvents,
+  regionCustomDomains,
+} from "@acme/redirect-platform-db";
+import type { RegionCustomDomain } from "@acme/redirect-platform-db";
+
+import { getSessionUser } from "@/lib/auth/server";
+import { getRedirectAdminDb } from "@/lib/db-client";
+import { getSupabaseDb } from "@/lib/supabase-client";
+import { checkUserRoleOnOrg } from "@/lib/services/user-orgs";
+import { presentLifecycleState } from "@/lib/state-presenter";
+import type { LifecycleState, ReconcilerError } from "@/lib/state-presenter";
+
+export const dynamic = "force-dynamic";
+
+interface Ctx {
+  params: Promise<{ id: string }>;
+}
+
+export async function GET(_request: NextRequest, ctx: Ctx) {
+  const user = await getSessionUser();
+  if (!user) {
+    return NextResponse.json({ error: "unauthenticated" }, { status: 401 });
+  }
+  const { id } = await ctx.params;
+
+  const { db } = getRedirectAdminDb();
+  const { db: supabase } = getSupabaseDb();
+
+  const rows = await db
+    .select()
+    .from(regionCustomDomains)
+    .where(eq(regionCustomDomains.id, id));
+  const row = rows[0];
+  if (!row) {
+    return NextResponse.json({ error: "not_found" }, { status: 404 });
+  }
+
+  const authorized = await checkUserRoleOnOrg(supabase, {
+    userId: user.userId,
+    orgId: row.orgId,
+  });
+  if (!authorized) {
+    return NextResponse.json({ error: "forbidden" }, { status: 403 });
+  }
+
+  return NextResponse.json({
+    domain: serializeDomain(row),
+    presented: presentLifecycleState(
+      row.lifecycleState as LifecycleState,
+      row.reconcilerError as ReconcilerError | null,
+    ),
+  });
+}
+
+export async function DELETE(_request: NextRequest, ctx: Ctx) {
+  const user = await getSessionUser();
+  if (!user) {
+    return NextResponse.json({ error: "unauthenticated" }, { status: 401 });
+  }
+  const { id } = await ctx.params;
+
+  const { db } = getRedirectAdminDb();
+  const { db: supabase } = getSupabaseDb();
+
+  const existing = await db
+    .select()
+    .from(regionCustomDomains)
+    .where(eq(regionCustomDomains.id, id));
+  const existingRow = existing[0];
+  if (!existingRow) {
+    return NextResponse.json({ error: "not_found" }, { status: 404 });
+  }
+
+  const authorized = await checkUserRoleOnOrg(supabase, {
+    userId: user.userId,
+    orgId: existingRow.orgId,
+  });
+  if (!authorized) {
+    return NextResponse.json({ error: "forbidden" }, { status: 403 });
+  }
+
+  // State-guarded update: tombstoning an already-tombstoned / released
+  // row is a no-op. We intentionally do NOT transition from `active` to
+  // `released` directly — the reconciler owns teardown + release.
+  if (
+    existingRow.lifecycleState === "tombstoned" ||
+    existingRow.lifecycleState === "released"
+  ) {
+    return NextResponse.json({ ok: true, already: existingRow.lifecycleState });
+  }
+
+  const tombstonedAt = new Date().toISOString();
+  const updated = await db
+    .update(regionCustomDomains)
+    .set({
+      lifecycleState: "tombstoned",
+      tombstonedAt,
+    })
+    .where(eq(regionCustomDomains.id, id))
+    .returning();
+  const updatedRow = updated[0];
+  if (!updatedRow) {
+    return NextResponse.json({ error: "not_found" }, { status: 404 });
+  }
+
+  // Best-effort audit event.
+  try {
+    await db.insert(regionCustomDomainEvents).values({
+      domainId: updatedRow.id,
+      eventType: "user_tombstoned",
+      fromState: existingRow.lifecycleState,
+      toState: "tombstoned",
+      actorUserId: user.userId,
+      details: {
+        source: "redirect-admin-ui",
+        reason: "user_initiated_delete",
+      },
+    });
+  } catch (err) {
+    console.warn("DELETE /api/domains/:id: event insert failed", err);
+  }
+
+  return NextResponse.json({ ok: true, domain: serializeDomain(updatedRow) });
+}
+
+function serializeDomain(row: RegionCustomDomain) {
+  return {
+    id: row.id,
+    org_id: row.orgId,
+    hostname: row.hostname,
+    hostname_role: row.hostnameRole,
+    lifecycle_state: row.lifecycleState,
+    region_slug: row.regionSlug,
+    region_name: row.regionName,
+    dns_challenge_record_name: row.dnsChallengeRecordName,
+    dns_challenge_record_value: row.dnsChallengeRecordValue,
+    last_reconciled_at: row.lastReconciledAt,
+    reconciler_error: row.reconcilerError,
+    created_at: row.createdAt,
+    tombstoned_at: row.tombstonedAt,
+  };
+}

--- a/apps/redirect-admin/src/app/api/domains/register/route.ts
+++ b/apps/redirect-admin/src/app/api/domains/register/route.ts
@@ -1,0 +1,112 @@
+/**
+ * POST /api/domains/register — thin wrapper over the registration
+ * service (R5 Phase 1). The service itself holds all business logic so
+ * it can be unit-tested without a real HTTP layer.
+ *
+ * Error handling:
+ *   - Return structured `{ error, ... }` JSON
+ *   - Never leak exception messages to the client — `internal_error`
+ *     collapses to a generic response body.
+ *   - Status codes come from `statusForRegisterError`.
+ */
+
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { z } from "zod";
+
+import { getRedirectAdminDb } from "@/lib/db-client";
+import { getSessionUser } from "@/lib/auth/server";
+import { getSupabaseDb } from "@/lib/supabase-client";
+import { checkUserRoleOnOrg } from "@/lib/services/user-orgs";
+import {
+  publicErrorBody,
+  registerDomain,
+  statusForRegisterError,
+} from "@/lib/services/domain-registration";
+import type { RegisterDomainDeps } from "@/lib/services/domain-registration";
+import {
+  createDefaultCertManagerClient,
+  getDefaultCertManagerClient,
+} from "@/lib/cert-manager-client";
+
+export const dynamic = "force-dynamic";
+
+const RegisterSchema = z.object({
+  org_id: z.number().int().positive(),
+  hostname: z.string().min(1).max(253),
+  hostname_role: z.enum(["apex", "stats"]),
+});
+
+export async function POST(request: NextRequest) {
+  const user = await getSessionUser();
+  if (!user) {
+    return NextResponse.json({ error: "unauthenticated" }, { status: 401 });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "invalid_json" }, { status: 400 });
+  }
+
+  const parseResult = RegisterSchema.safeParse(body);
+  if (!parseResult.success) {
+    return NextResponse.json(
+      { error: "invalid_body", detail: parseResult.error.flatten() },
+      { status: 400 },
+    );
+  }
+  const { org_id, hostname, hostname_role } = parseResult.data;
+
+  const { db: redirectAdminDb } = getRedirectAdminDb();
+  const { db: supabase } = getSupabaseDb();
+
+  // Prime the cert-manager client (dynamic import) before handing the
+  // sync factory to the service. If this fails, we want to 500 early
+  // with a clear error rather than crash mid-flow.
+  try {
+    await getDefaultCertManagerClient();
+  } catch (err) {
+    console.error("cert-manager init failed", err);
+    return NextResponse.json({ error: "internal_error" }, { status: 500 });
+  }
+
+  const deps: RegisterDomainDeps = {
+    db: redirectAdminDb,
+    certManagerFactory: createDefaultCertManagerClient,
+    checkUserRole: (params) => checkUserRoleOnOrg(supabase, params),
+  };
+
+  const result = await registerDomain(
+    {
+      orgId: org_id,
+      hostname,
+      hostnameRole: hostname_role,
+      userId: user.userId,
+    },
+    deps,
+  );
+
+  if (!result.ok) {
+    return NextResponse.json(publicErrorBody(result.error), {
+      status: statusForRegisterError(result.error),
+    });
+  }
+
+  return NextResponse.json(
+    {
+      id: result.value.domain.id,
+      hostname: result.value.domain.hostname,
+      hostname_role: result.value.domain.hostnameRole,
+      lifecycle_state: result.value.domain.lifecycleState,
+      dns_challenge: {
+        name: result.value.dnsChallenge.name,
+        value: result.value.dnsChallenge.data,
+        type: "CNAME",
+      },
+      reused_existing_authorization: result.value.reusedExistingAuthorization,
+    },
+    { status: 201 },
+  );
+}

--- a/apps/redirect-admin/src/app/domains/new/page.tsx
+++ b/apps/redirect-admin/src/app/domains/new/page.tsx
@@ -1,0 +1,101 @@
+import Link from "next/link";
+import { inArray } from "drizzle-orm";
+
+import { orgRegionBindings } from "@acme/redirect-platform-db";
+
+import { requireAuth } from "@/lib/auth/server";
+import { getRedirectAdminDb } from "@/lib/db-client";
+import { getSupabaseDb } from "@/lib/supabase-client";
+import { listUserAdminOrgs } from "@/lib/services/user-orgs";
+import { RegisterDomainForm } from "@/components/register-domain-form";
+
+export const dynamic = "force-dynamic";
+
+interface PageProps {
+  searchParams: Promise<{ org_id?: string }>;
+}
+
+export default async function NewDomainPage({ searchParams }: PageProps) {
+  const user = await requireAuth();
+  const params = await searchParams;
+
+  const { db: supabase } = getSupabaseDb();
+  const { db: redirectAdminDb } = getRedirectAdminDb();
+
+  const orgs = await listUserAdminOrgs(supabase, user.userId);
+  if (orgs.length === 0) {
+    return (
+      <div className="rounded-lg border bg-card p-8">
+        <h2 className="text-xl font-semibold">No eligible orgs</h2>
+        <p className="mt-2 text-sm text-muted-foreground">
+          You need admin or editor permissions on at least one org to register a
+          domain.
+        </p>
+        <Link
+          href="/"
+          className="mt-4 inline-block text-sm text-primary hover:underline"
+        >
+          ← Back
+        </Link>
+      </div>
+    );
+  }
+
+  // Only verified-binding orgs may appear in the org picker.
+  const bindings = await redirectAdminDb
+    .select()
+    .from(orgRegionBindings)
+    .where(
+      inArray(
+        orgRegionBindings.orgId,
+        orgs.map((o) => o.orgId),
+      ),
+    );
+  const verifiedOrgIds = new Set(
+    bindings
+      .filter((b) => b.verificationState === "verified")
+      .map((b) => b.orgId),
+  );
+
+  const eligibleOrgs = orgs.filter((o) => verifiedOrgIds.has(o.orgId));
+
+  if (eligibleOrgs.length === 0) {
+    return (
+      <div className="rounded-lg border bg-card p-8">
+        <h2 className="text-xl font-semibold">No verified bindings yet</h2>
+        <p className="mt-2 text-sm text-muted-foreground">
+          None of your orgs have a verified region binding. Bind + verify via
+          F3R5_013 (coming soon) before registering custom domains.
+        </p>
+        <Link
+          href="/"
+          className="mt-4 inline-block text-sm text-primary hover:underline"
+        >
+          ← Back
+        </Link>
+      </div>
+    );
+  }
+
+  const defaultOrgId = params.org_id ? Number(params.org_id) : undefined;
+  const initialOrgId =
+    defaultOrgId && eligibleOrgs.some((o) => o.orgId === defaultOrgId)
+      ? defaultOrgId
+      : eligibleOrgs[0]?.orgId;
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h2 className="text-xl font-semibold">Register a custom domain</h2>
+        <p className="text-sm text-muted-foreground">
+          Pick the org, enter the hostname, and choose whether this is the apex
+          (e.g. your region home page) or a stats subdomain.
+        </p>
+      </div>
+      <RegisterDomainForm
+        orgs={eligibleOrgs.map((o) => ({ id: o.orgId, name: o.orgName }))}
+        initialOrgId={initialOrgId}
+      />
+    </div>
+  );
+}

--- a/apps/redirect-admin/src/app/domains/page.tsx
+++ b/apps/redirect-admin/src/app/domains/page.tsx
@@ -1,0 +1,127 @@
+import Link from "next/link";
+import { inArray } from "drizzle-orm";
+
+import { regionCustomDomains } from "@acme/redirect-platform-db";
+import type { RegionCustomDomain } from "@acme/redirect-platform-db";
+
+import { requireAuth } from "@/lib/auth/server";
+import { getRedirectAdminDb } from "@/lib/db-client";
+import { getSupabaseDb } from "@/lib/supabase-client";
+import { listUserAdminOrgs } from "@/lib/services/user-orgs";
+import { presentLifecycleState } from "@/lib/state-presenter";
+import type { LifecycleState, ReconcilerError } from "@/lib/state-presenter";
+
+export const dynamic = "force-dynamic";
+
+export default async function DomainsPage() {
+  const user = await requireAuth();
+
+  const { db: supabase } = getSupabaseDb();
+  const { db: redirectAdminDb } = getRedirectAdminDb();
+
+  const orgs = await listUserAdminOrgs(supabase, user.userId);
+  if (orgs.length === 0) {
+    return (
+      <div className="rounded-lg border bg-card p-8">
+        <h2 className="text-xl font-semibold">No domains</h2>
+        <p className="mt-2 text-sm text-muted-foreground">
+          You don&apos;t have admin rights on any orgs, so there are no domains
+          to show.
+        </p>
+        <Link
+          href="/"
+          className="mt-4 inline-block text-sm text-primary hover:underline"
+        >
+          ← Back
+        </Link>
+      </div>
+    );
+  }
+
+  const orgIds = orgs.map((o) => o.orgId);
+  const rows: RegionCustomDomain[] = await redirectAdminDb
+    .select()
+    .from(regionCustomDomains)
+    .where(inArray(regionCustomDomains.orgId, orgIds));
+
+  const orgNameById = new Map<number, string>(
+    orgs.map((o) => [o.orgId, o.orgName]),
+  );
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-xl font-semibold">All domains</h2>
+          <p className="text-sm text-muted-foreground">
+            Every `region_custom_domains` row across the orgs you admin.
+          </p>
+        </div>
+        <Link
+          href="/domains/new"
+          className="rounded bg-primary px-4 py-2 text-sm text-primary-foreground hover:opacity-90"
+        >
+          Register new
+        </Link>
+      </div>
+
+      {rows.length === 0 ? (
+        <p className="rounded-lg border bg-card p-6 text-sm text-muted-foreground">
+          No domains registered yet.
+        </p>
+      ) : (
+        <ul className="divide-y rounded-lg border bg-card">
+          {rows
+            .sort((a, b) => a.hostname.localeCompare(b.hostname))
+            .map((row) => {
+              const presented = presentLifecycleState(
+                row.lifecycleState as LifecycleState,
+                row.reconcilerError as ReconcilerError | null,
+              );
+              return (
+                <li
+                  key={row.id}
+                  className="flex items-center justify-between gap-4 p-4"
+                >
+                  <div>
+                    <div className="font-medium">{row.hostname}</div>
+                    <div className="text-xs text-muted-foreground">
+                      {orgNameById.get(row.orgId) ?? `org #${row.orgId}`} ·{" "}
+                      {row.hostnameRole} · last reconciled{" "}
+                      {row.lastReconciledAt ?? "never"}
+                    </div>
+                  </div>
+                  <div className="flex flex-col items-end gap-1 text-right">
+                    <span
+                      className={`rounded px-3 py-1 text-xs ${variantClass(
+                        presented.variant,
+                      )}`}
+                    >
+                      {presented.label}
+                    </span>
+                    <span className="text-xs text-muted-foreground">
+                      {presented.description.slice(0, 80)}
+                      {presented.description.length > 80 ? "…" : ""}
+                    </span>
+                  </div>
+                </li>
+              );
+            })}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+function variantClass(variant: "info" | "warning" | "error" | "success") {
+  switch (variant) {
+    case "info":
+      return "bg-blue-100 text-blue-900";
+    case "warning":
+      return "bg-yellow-100 text-yellow-900";
+    case "error":
+      return "bg-red-100 text-red-900";
+    case "success":
+      return "bg-emerald-100 text-emerald-900";
+  }
+}

--- a/apps/redirect-admin/src/app/globals.css
+++ b/apps/redirect-admin/src/app/globals.css
@@ -1,0 +1,34 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@layer base {
+  :root {
+    --background: 39 33% 94%;
+    --foreground: 220 39% 11%;
+    --card: 0 0% 100%;
+    --card-foreground: 220 39% 11%;
+    --primary: 1 91% 36%;
+    --primary-foreground: 39 33% 94%;
+    --secondary: 39 26% 90%;
+    --secondary-foreground: 220 39% 11%;
+    --muted: 39 26% 90%;
+    --muted-foreground: 220 9% 46%;
+    --accent: 39 26% 90%;
+    --accent-foreground: 220 39% 11%;
+    --destructive: 0 84.2% 60.2%;
+    --destructive-foreground: 210 40% 98%;
+    --border: 220 13% 91%;
+    --input: 220 13% 91%;
+    --radius: 0.5rem;
+  }
+}
+
+@layer base {
+  * {
+    @apply border-border;
+  }
+  body {
+    @apply bg-background text-foreground;
+  }
+}

--- a/apps/redirect-admin/src/app/layout.tsx
+++ b/apps/redirect-admin/src/app/layout.tsx
@@ -1,0 +1,32 @@
+import type { Metadata } from "next";
+import "./globals.css";
+
+export const metadata: Metadata = {
+  title: "F3 Redirect Admin",
+  description:
+    "Self-serve custom domain registration for F3 regions. Register a hostname, follow the DNS setup, cut over.",
+};
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en" suppressHydrationWarning>
+      <body className="min-h-screen bg-background text-foreground antialiased">
+        <header className="border-b bg-card">
+          <div className="mx-auto flex max-w-5xl items-center justify-between px-6 py-4">
+            <div>
+              <h1 className="text-lg font-semibold">F3 Redirect Admin</h1>
+              <p className="text-xs text-muted-foreground">
+                Region custom domains — register, monitor, manage.
+              </p>
+            </div>
+          </div>
+        </header>
+        <main className="mx-auto max-w-5xl px-6 py-8">{children}</main>
+      </body>
+    </html>
+  );
+}

--- a/apps/redirect-admin/src/app/page.tsx
+++ b/apps/redirect-admin/src/app/page.tsx
@@ -1,0 +1,143 @@
+import Link from "next/link";
+
+import { getSessionUser } from "@/lib/auth/server";
+import { getSupabaseDb } from "@/lib/supabase-client";
+import { getRedirectAdminDb } from "@/lib/db-client";
+import { loadLandingData } from "@/lib/services/landing-data";
+
+interface PageProps {
+  searchParams: Promise<{ error?: string; redirect?: string }>;
+}
+
+export default async function HomePage({ searchParams }: PageProps) {
+  const params = await searchParams;
+  const user = await getSessionUser();
+
+  if (!user) {
+    return (
+      <div className="mx-auto flex max-w-md flex-col gap-4 rounded-lg border bg-card p-8 shadow-sm">
+        <h2 className="text-xl font-semibold">Sign in</h2>
+        <p className="text-sm text-muted-foreground">
+          Self-serve custom domain registration for F3 regions. You must be an
+          admin or editor on at least one F3 org to use this tool.
+        </p>
+        {params.error ? (
+          <p className="text-sm text-destructive">
+            Error: {prettyError(params.error)}
+          </p>
+        ) : null}
+        <Link
+          href={`/api/auth/login${params.redirect ? `?returnTo=${encodeURIComponent(params.redirect)}` : ""}`}
+          className="rounded bg-primary px-4 py-2 text-center text-primary-foreground hover:opacity-90"
+        >
+          Sign in with F3 SSO
+        </Link>
+      </div>
+    );
+  }
+
+  const { db: supabase } = getSupabaseDb();
+  const { db: redirectAdminDb } = getRedirectAdminDb();
+  const data = await loadLandingData(supabase, redirectAdminDb, user.userId);
+
+  if (data.rows.length === 0) {
+    return (
+      <div className="rounded-lg border bg-card p-8">
+        <h2 className="text-xl font-semibold">No orgs found</h2>
+        <p className="mt-2 text-sm text-muted-foreground">
+          Signed in as {user.email}. You don&apos;t currently have admin or
+          editor permissions on any F3 org, so there is nothing to manage here.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-xl font-semibold">Your orgs</h2>
+        <p className="text-sm text-muted-foreground">
+          Signed in as {user.email}. Each row below shows the binding state for
+          one of your orgs. Verified orgs can register custom domains.
+        </p>
+      </div>
+      <ul className="space-y-3">
+        {data.rows.map((row) => (
+          <li
+            key={row.orgId}
+            className="rounded-lg border bg-card p-4 shadow-sm"
+          >
+            <div className="flex items-center justify-between gap-4">
+              <div>
+                <div className="font-medium">{row.orgName}</div>
+                <div className="text-xs text-muted-foreground">
+                  org #{row.orgId} · {row.roleNames.join(", ")}
+                </div>
+              </div>
+              <OrgStatus row={row} />
+            </div>
+          </li>
+        ))}
+      </ul>
+      <div>
+        <Link href="/domains" className="text-sm text-primary hover:underline">
+          View all registered domains →
+        </Link>
+      </div>
+    </div>
+  );
+}
+
+function OrgStatus({
+  row,
+}: {
+  row: Awaited<ReturnType<typeof loadLandingData>>["rows"][number];
+}) {
+  switch (row.status.kind) {
+    case "no_binding":
+      return (
+        <span className="rounded bg-muted px-3 py-1 text-xs">
+          No binding — contact platform admin
+        </span>
+      );
+    case "unverified":
+      // F3R5_012 stub. F3R5_013 swaps this for the full Decision 9
+      // verification evidence UI that reads
+      // `org_region_bindings.bind_time_validator_snapshot`.
+      return (
+        <span
+          className="rounded bg-yellow-100 px-3 py-1 text-xs text-yellow-900"
+          title={`verification_state=${row.status.binding.verificationState}`}
+        >
+          Pending verification (F3R5_013 coming soon)
+        </span>
+      );
+    case "verified":
+      return (
+        <div className="flex items-center gap-3 text-sm">
+          <span className="rounded bg-emerald-100 px-3 py-1 text-xs text-emerald-900">
+            Verified · {row.status.domainCount} domains
+          </span>
+          <Link
+            href={`/domains/new?org_id=${row.orgId}`}
+            className="text-primary hover:underline"
+          >
+            Register domain
+          </Link>
+        </div>
+      );
+  }
+}
+
+function prettyError(code: string): string {
+  switch (code) {
+    case "csrf_mismatch":
+      return "Session expired during sign-in. Please try again.";
+    case "token_exchange_failed":
+      return "SSO token exchange failed.";
+    case "user_not_found":
+      return "Your SSO account is missing an email.";
+    default:
+      return code;
+  }
+}

--- a/apps/redirect-admin/src/components/register-domain-form.tsx
+++ b/apps/redirect-admin/src/components/register-domain-form.tsx
@@ -1,0 +1,181 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+
+interface OrgOption {
+  id: number;
+  name: string;
+}
+
+interface RegisterDomainFormProps {
+  orgs: OrgOption[];
+  initialOrgId?: number;
+}
+
+interface RegistrationSuccess {
+  id: string;
+  hostname: string;
+  hostname_role: "apex" | "stats";
+  lifecycle_state: string;
+  dns_challenge: { name: string; value: string; type: string };
+  reused_existing_authorization: boolean;
+}
+
+export function RegisterDomainForm({
+  orgs,
+  initialOrgId,
+}: RegisterDomainFormProps) {
+  const router = useRouter();
+  const [orgId, setOrgId] = useState<number | undefined>(initialOrgId);
+  const [hostname, setHostname] = useState("");
+  const [hostnameRole, setHostnameRole] = useState<"apex" | "stats">("apex");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<RegistrationSuccess | null>(null);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!orgId) {
+      setError("Please select an org.");
+      return;
+    }
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/domains/register", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          org_id: orgId,
+          hostname,
+          hostname_role: hostnameRole,
+        }),
+      });
+      const body = (await res.json()) as Record<string, unknown>;
+      if (!res.ok) {
+        setError(String(body.error ?? `HTTP ${res.status}`));
+        return;
+      }
+      setSuccess(body as unknown as RegistrationSuccess);
+      router.refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "unknown error");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  if (success) {
+    return (
+      <div className="space-y-4 rounded-lg border bg-card p-6">
+        <h3 className="text-lg font-semibold text-emerald-900">
+          Registered — add this CNAME to your DNS
+        </h3>
+        <p className="text-sm text-muted-foreground">
+          Your hostname{" "}
+          <code className="rounded bg-muted px-1">{success.hostname}</code> is
+          queued. Add the CNAME record below so Google can validate and issue
+          your TLS certificate.
+        </p>
+        <dl className="grid grid-cols-[max-content_1fr] gap-2 text-sm">
+          <dt className="font-medium">Record type</dt>
+          <dd>
+            <code className="rounded bg-muted px-1">CNAME</code>
+          </dd>
+          <dt className="font-medium">Name</dt>
+          <dd>
+            <code className="rounded bg-muted px-1 break-all">
+              {success.dns_challenge.name}
+            </code>
+          </dd>
+          <dt className="font-medium">Value</dt>
+          <dd>
+            <code className="rounded bg-muted px-1 break-all">
+              {success.dns_challenge.value}
+            </code>
+          </dd>
+        </dl>
+        <div className="pt-2">
+          <button
+            type="button"
+            onClick={() => router.push(`/domains`)}
+            className="rounded border px-4 py-2 text-sm hover:bg-muted"
+          >
+            Go to domain list
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="space-y-4 rounded-lg border bg-card p-6"
+    >
+      <label className="block space-y-1">
+        <span className="text-sm font-medium">Org</span>
+        <select
+          className="w-full rounded border px-3 py-2"
+          value={orgId ?? ""}
+          onChange={(e) => setOrgId(Number(e.target.value))}
+        >
+          {orgs.map((o) => (
+            <option key={o.id} value={o.id}>
+              {o.name} (#{o.id})
+            </option>
+          ))}
+        </select>
+      </label>
+
+      <label className="block space-y-1">
+        <span className="text-sm font-medium">Hostname</span>
+        <input
+          type="text"
+          placeholder="f3muletown.com or stats.f3region.org"
+          className="w-full rounded border px-3 py-2"
+          value={hostname}
+          onChange={(e) => setHostname(e.target.value)}
+          required
+        />
+      </label>
+
+      <fieldset className="space-y-2">
+        <legend className="text-sm font-medium">Hostname role</legend>
+        <label className="flex items-center gap-2 text-sm">
+          <input
+            type="radio"
+            name="hostname_role"
+            value="apex"
+            checked={hostnameRole === "apex"}
+            onChange={() => setHostnameRole("apex")}
+          />
+          Apex — my region&apos;s main domain
+        </label>
+        <label className="flex items-center gap-2 text-sm">
+          <input
+            type="radio"
+            name="hostname_role"
+            value="stats"
+            checked={hostnameRole === "stats"}
+            onChange={() => setHostnameRole("stats")}
+          />
+          Stats — a subdomain for regional stats / dashboards
+        </label>
+      </fieldset>
+
+      {error ? (
+        <p className="text-sm text-destructive">Error: {error}</p>
+      ) : null}
+
+      <button
+        type="submit"
+        disabled={submitting}
+        className="rounded bg-primary px-4 py-2 text-sm text-primary-foreground hover:opacity-90 disabled:opacity-50"
+      >
+        {submitting ? "Registering…" : "Register domain"}
+      </button>
+    </form>
+  );
+}

--- a/apps/redirect-admin/src/env.ts
+++ b/apps/redirect-admin/src/env.ts
@@ -1,0 +1,156 @@
+/**
+ * Environment variable loading + validation for the redirect-admin UI.
+ *
+ * Validated at boot (first import). Any missing REQUIRED var throws
+ * immediately so the process fails fast in container startup. Mirrors
+ * the pattern used by `apps/me/src/lib/auth/*` — intentionally simple,
+ * no `@t3-oss/env-nextjs` dependency because this app has a tiny surface.
+ *
+ * See R5 plan, Decision 5 (admin UI placement) and Decision 8 (per-role
+ * Neon connection strings). The `NEON_REDIRECT_ADMIN_UI_URL` var binds us
+ * to the `redirect_admin_ui` role defined in
+ * `packages/redirect-platform-db/sql/0001_roles_and_grants.sql`.
+ */
+
+const REQUIRED_ENV_VARS = [
+  // --- Neon (redirect_admin_ui role) ---
+  "NEON_REDIRECT_ADMIN_UI_URL",
+
+  // --- Internal region-binding validator (Decision 11) ---
+  "REGION_BINDING_VALIDATOR_URL",
+  "REGION_BINDING_VALIDATOR_S2S_SECRET",
+
+  // --- f3-nation Supabase DB (for reading org hierarchy + user roles) ---
+  // Matches the `@acme/env` var name used by `@acme/db`.
+  "DATABASE_URL",
+
+  // --- SSO (copied from apps/me) ---
+  "OAUTH_CLIENT_ID",
+  "OAUTH_CLIENT_SECRET",
+  "OAUTH_REDIRECT_URI",
+  "AUTH_PROVIDER_URL",
+  "SESSION_SECRET",
+  "NEXT_PUBLIC_SITE_URL",
+] as const;
+
+type RequiredVar = (typeof REQUIRED_ENV_VARS)[number];
+
+interface OptionalEnv {
+  /** GCP project for Certificate Manager API calls. */
+  gcpProjectId: string;
+  /** Name of the Certificate Map the redirect LB uses. */
+  redirectCertMapName: string;
+  /** LB static IPv4 shown to users as the A record they need to create. */
+  redirectLbIpv4: string | null;
+  /** Optional: override for the validator HTTP timeout (ms). */
+  validatorTimeoutMs: number;
+}
+
+export interface RedirectAdminEnv extends Record<RequiredVar, string> {
+  /** Convenience alias — same value as NEON_REDIRECT_ADMIN_UI_URL. */
+  neonAdminUiConnectionString: string;
+  /** Convenience alias — same value as DATABASE_URL. */
+  supabaseConnectionString: string;
+  options: OptionalEnv;
+}
+
+export class EnvValidationError extends Error {
+  constructor(missing: readonly string[]) {
+    super(
+      `redirect-admin env validation failed; missing required vars: ${missing.join(
+        ", ",
+      )}`,
+    );
+    this.name = "EnvValidationError";
+  }
+}
+
+/**
+ * Pure, testable env loader. Accepts `process.env`-shaped input so tests
+ * can pass synthetic envs without mutating the real process env.
+ */
+export function loadEnv(
+  source: NodeJS.ProcessEnv = process.env,
+): RedirectAdminEnv {
+  const missing: string[] = [];
+  const required: Partial<Record<RequiredVar, string>> = {};
+
+  for (const name of REQUIRED_ENV_VARS) {
+    const value = source[name];
+    if (!value) {
+      missing.push(name);
+    } else {
+      required[name] = value;
+    }
+  }
+
+  if (missing.length > 0) {
+    throw new EnvValidationError(missing);
+  }
+
+  const gcpProjectId = source.GCP_PROJECT_ID ?? "f3-redirects";
+  const redirectCertMapName =
+    source.REDIRECT_CERT_MAP_NAME ?? "redirect-platform-cert-map";
+  const redirectLbIpv4 = source.REDIRECT_LB_IPV4 ?? null;
+  const validatorTimeoutMs = source.REGION_BINDING_VALIDATOR_TIMEOUT_MS
+    ? Number(source.REGION_BINDING_VALIDATOR_TIMEOUT_MS)
+    : 10_000;
+
+  // The type cast is safe: we just populated every required key in the
+  // loop above (else we would have thrown on `missing.length > 0`).
+   
+  const base = required as Record<RequiredVar, string>;
+
+  return {
+    ...base,
+    neonAdminUiConnectionString: base.NEON_REDIRECT_ADMIN_UI_URL,
+    supabaseConnectionString: base.DATABASE_URL,
+    options: {
+      gcpProjectId,
+      redirectCertMapName,
+      redirectLbIpv4,
+      validatorTimeoutMs,
+    },
+  };
+}
+
+/**
+ * Cached singleton. Lazy so tests that import this module don't crash
+ * during module evaluation if the real process env is missing a var.
+ */
+let _cached: RedirectAdminEnv | null = null;
+export function env(): RedirectAdminEnv {
+  if (_cached) return _cached;
+  // During `next build` or test runs with explicit skip flag, return a
+  // stub so static analysis of route handlers doesn't crash.
+  if (process.env.SKIP_ENV_VALIDATION === "1") {
+    _cached = stubEnv();
+    return _cached;
+  }
+  _cached = loadEnv();
+  return _cached;
+}
+
+function stubEnv(): RedirectAdminEnv {
+  const stub = "stub";
+  return {
+    NEON_REDIRECT_ADMIN_UI_URL: stub,
+    REGION_BINDING_VALIDATOR_URL: "http://localhost:0",
+    REGION_BINDING_VALIDATOR_S2S_SECRET: stub,
+    DATABASE_URL: stub,
+    OAUTH_CLIENT_ID: stub,
+    OAUTH_CLIENT_SECRET: stub,
+    OAUTH_REDIRECT_URI: "http://localhost:3006/api/auth/callback",
+    AUTH_PROVIDER_URL: "http://localhost:3004",
+    SESSION_SECRET: stub,
+    NEXT_PUBLIC_SITE_URL: "http://localhost:3006",
+    neonAdminUiConnectionString: stub,
+    supabaseConnectionString: stub,
+    options: {
+      gcpProjectId: "f3-redirects",
+      redirectCertMapName: "redirect-platform-cert-map",
+      redirectLbIpv4: null,
+      validatorTimeoutMs: 10_000,
+    },
+  };
+}

--- a/apps/redirect-admin/src/lib/__tests__/cert-manager-client.test.ts
+++ b/apps/redirect-admin/src/lib/__tests__/cert-manager-client.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, vi } from "vitest";
+
+import {
+  buildDnsAuthorizationId,
+  buildParent,
+  buildResourceName,
+  createOrReuseDnsAuthorization,
+  extractDnsChallenge,
+  isAlreadyExistsError,
+} from "../cert-manager-client";
+import type {
+  CertManagerLike,
+  DnsAuthorizationShape,
+} from "../cert-manager-client";
+
+describe("buildDnsAuthorizationId", () => {
+  it("prefixes with dns-auth-", () => {
+    expect(buildDnsAuthorizationId("abc-123")).toBe("dns-auth-abc-123");
+  });
+});
+
+describe("buildParent / buildResourceName", () => {
+  it("builds project-scoped parent", () => {
+    expect(buildParent("f3-redirects", "global")).toBe(
+      "projects/f3-redirects/locations/global",
+    );
+  });
+  it("builds resource name", () => {
+    expect(buildResourceName("f3-redirects", "global", "dns-auth-xyz")).toBe(
+      "projects/f3-redirects/locations/global/dnsAuthorizations/dns-auth-xyz",
+    );
+  });
+});
+
+describe("extractDnsChallenge", () => {
+  it("pulls out the CNAME record", () => {
+    const authorization: DnsAuthorizationShape = {
+      name: "projects/p/locations/global/dnsAuthorizations/dns-auth-1",
+      dnsResourceRecord: {
+        name: "_acme-challenge.f3muletown.com.",
+        type: "CNAME",
+        data: "gcp-target.example.com.",
+      },
+    };
+    const challenge = extractDnsChallenge(authorization);
+    expect(challenge).toEqual({
+      name: "_acme-challenge.f3muletown.com.",
+      data: "gcp-target.example.com.",
+      type: "CNAME",
+    });
+  });
+
+  it("throws when the record is missing", () => {
+    expect(() =>
+      extractDnsChallenge({
+        dnsResourceRecord: { name: null, data: null },
+      }),
+    ).toThrow(/missing dnsResourceRecord/);
+  });
+});
+
+describe("isAlreadyExistsError", () => {
+  it("matches grpc code 6", () => {
+    expect(isAlreadyExistsError({ code: 6 })).toBe(true);
+  });
+  it("matches string message", () => {
+    expect(isAlreadyExistsError(new Error("Resource already exists"))).toBe(
+      true,
+    );
+  });
+  it("rejects unrelated errors", () => {
+    expect(isAlreadyExistsError(new Error("boom"))).toBe(false);
+    expect(isAlreadyExistsError(null)).toBe(false);
+  });
+});
+
+describe("createOrReuseDnsAuthorization", () => {
+  const hostname = "f3muletown.com";
+  const authorizationId = "dns-auth-deadbeef";
+
+  function makeAuthorization(): DnsAuthorizationShape {
+    return {
+      name: `projects/f3-redirects/locations/global/dnsAuthorizations/${authorizationId}`,
+      dnsResourceRecord: {
+        name: "_acme-challenge.f3muletown.com.",
+        type: "CNAME",
+        data: "target.googleusercontent.com.",
+      },
+    };
+  }
+
+  it("creates + returns the challenge on happy path", async () => {
+    const authorization = makeAuthorization();
+    const create = vi.fn().mockResolvedValue([
+      {
+        promise: vi.fn().mockResolvedValue([authorization]),
+      },
+    ]);
+    const get = vi.fn();
+    const fakeClient: CertManagerLike = {
+      createDnsAuthorization: create,
+      getDnsAuthorization: get,
+    };
+
+    const result = await createOrReuseDnsAuthorization(() => fakeClient, {
+      authorizationId,
+      hostname,
+      projectId: "f3-redirects",
+    });
+
+    expect(result.reused).toBe(false);
+    expect(result.challenge.name).toBe("_acme-challenge.f3muletown.com.");
+    expect(result.challenge.data).toBe("target.googleusercontent.com.");
+    expect(create).toHaveBeenCalledOnce();
+    expect(get).not.toHaveBeenCalled();
+  });
+
+  it("falls back to GET on ALREADY_EXISTS", async () => {
+    const authorization = makeAuthorization();
+    const error = Object.assign(new Error("already exists"), { code: 6 });
+    const create = vi.fn().mockRejectedValue(error);
+    const get = vi.fn().mockResolvedValue([authorization]);
+    const fakeClient: CertManagerLike = {
+      createDnsAuthorization: create,
+      getDnsAuthorization: get,
+    };
+
+    const result = await createOrReuseDnsAuthorization(() => fakeClient, {
+      authorizationId,
+      hostname,
+      projectId: "f3-redirects",
+    });
+
+    expect(result.reused).toBe(true);
+    expect(get).toHaveBeenCalledWith({
+      name: `projects/f3-redirects/locations/global/dnsAuthorizations/${authorizationId}`,
+    });
+  });
+
+  it("rethrows non-AlreadyExists errors", async () => {
+    const create = vi.fn().mockRejectedValue(new Error("permission denied"));
+    const get = vi.fn();
+    const fakeClient: CertManagerLike = {
+      createDnsAuthorization: create,
+      getDnsAuthorization: get,
+    };
+
+    await expect(
+      createOrReuseDnsAuthorization(() => fakeClient, {
+        authorizationId,
+        hostname,
+        projectId: "f3-redirects",
+      }),
+    ).rejects.toThrow(/permission denied/);
+    expect(get).not.toHaveBeenCalled();
+  });
+});

--- a/apps/redirect-admin/src/lib/__tests__/domain-registration.test.ts
+++ b/apps/redirect-admin/src/lib/__tests__/domain-registration.test.ts
@@ -1,0 +1,325 @@
+/**
+ * Unit tests for the pure domain-registration service. Route-handler
+ * tests are intentionally omitted because the handler is a 30-line
+ * wrapper — all branches are exercised through the service directly.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+
+import {
+  publicErrorBody,
+  registerDomain,
+  statusForRegisterError,
+} from "../services/domain-registration";
+import type { RegisterDomainDeps } from "../services/domain-registration";
+import type {
+  CertManagerClientFactory,
+  CertManagerLike,
+} from "../cert-manager-client";
+
+// ---------------------------------------------------------------------------
+// Fake DB — models the small surface `domain-registration` uses.
+// ---------------------------------------------------------------------------
+
+interface FakeDbConfig {
+  blocklistRows?: { hostname: string; reason: string }[];
+  bindingRows?: {
+    orgId: number;
+    regionSlug: string;
+    paxVaultRegionId: string;
+    regionName: string;
+    verificationState: "verified" | "unverified" | "revoked";
+  }[];
+  quotaRows?: { value: number }[];
+  countRows?: { value: number }[];
+  insertFailure?: Error;
+  insertReturning?: unknown[];
+  updateReturning?: unknown[];
+}
+
+function fakeDb(cfg: FakeDbConfig = {}) {
+  const blocklistRows = cfg.blocklistRows ?? [];
+  const bindingRows = cfg.bindingRows ?? [];
+  const quotaRows = cfg.quotaRows ?? [];
+  const countRows = cfg.countRows ?? [{ value: 0 }];
+  const insertReturning = cfg.insertReturning ?? [
+    {
+      id: "row-uuid",
+      orgId: bindingRows[0]?.orgId ?? 0,
+      hostname: "placeholder",
+      hostnameRole: "apex",
+      lifecycleState: "pending",
+    },
+  ];
+  const updateReturning = cfg.updateReturning ?? [
+    {
+      ...(insertReturning[0] as Record<string, unknown>),
+      lifecycleState: "awaiting_dns_challenge",
+      gcpDnsAuthorizationId:
+        "projects/f3-redirects/locations/global/dnsAuthorizations/dns-auth-row-uuid",
+      dnsChallengeRecordName: "_acme-challenge.host.",
+      dnsChallengeRecordValue: "target.gcp.",
+    },
+  ];
+
+  // Sequence of select() responses. Order matches the service flow:
+  // 1) blocklist, 2) quota max, 3) quota count, 4) binding lookup.
+  const selectResults: unknown[][] = [
+    blocklistRows,
+    quotaRows,
+    countRows,
+    bindingRows,
+  ];
+  let selectCall = 0;
+
+  return {
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(async () => {
+          const r = selectResults[selectCall] ?? [];
+          selectCall += 1;
+          return r;
+        }),
+      })),
+    })),
+    insert: vi.fn(() => ({
+      values: vi.fn(() => ({
+        returning: vi.fn(async () => {
+          if (cfg.insertFailure) throw cfg.insertFailure;
+          return insertReturning;
+        }),
+      })),
+    })),
+    update: vi.fn(() => ({
+      set: vi.fn(() => ({
+        where: vi.fn(() => ({
+          returning: vi.fn(async () => updateReturning),
+        })),
+      })),
+    })),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Fake cert-manager factory
+// ---------------------------------------------------------------------------
+
+function fakeCertFactory(): CertManagerClientFactory {
+  const client: CertManagerLike = {
+    createDnsAuthorization: vi.fn().mockResolvedValue([
+      {
+        promise: vi.fn().mockResolvedValue([
+          {
+            name: "projects/f3-redirects/locations/global/dnsAuthorizations/dns-auth-row-uuid",
+            dnsResourceRecord: {
+              name: "_acme-challenge.host.",
+              type: "CNAME",
+              data: "target.gcp.",
+            },
+          },
+        ]),
+      },
+    ]),
+    getDnsAuthorization: vi.fn(),
+  };
+  return () => client;
+}
+
+function buildDeps(overrides: Partial<RegisterDomainDeps> = {}, db = fakeDb()) {
+  return {
+    db: db as unknown as RegisterDomainDeps["db"],
+    certManagerFactory: overrides.certManagerFactory ?? fakeCertFactory(),
+    checkUserRole: overrides.checkUserRole ?? vi.fn().mockResolvedValue(true),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("registerDomain", () => {
+  const baseInput = {
+    orgId: 42,
+    hostname: "f3muletown.com",
+    hostnameRole: "apex" as const,
+    userId: 99,
+  };
+
+  const verifiedBinding = {
+    orgId: 42,
+    regionSlug: "muletown",
+    paxVaultRegionId: "pv-muletown",
+    regionName: "F3 Muletown",
+    verificationState: "verified" as const,
+  };
+
+  it("happy path — registers, creates auth, returns DNS challenge", async () => {
+    const db = fakeDb({
+      bindingRows: [verifiedBinding],
+      quotaRows: [{ value: 10 }],
+      countRows: [{ value: 2 }],
+    });
+    const deps = buildDeps({}, db);
+    const result = await registerDomain(baseInput, deps);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.dnsChallenge.type).toBe("CNAME");
+      expect(result.value.dnsChallenge.name).toBe("_acme-challenge.host.");
+      expect(result.value.dnsChallenge.data).toBe("target.gcp.");
+    }
+  });
+
+  it("rejects invalid hostname before touching DB", async () => {
+    const db = fakeDb();
+    const deps = buildDeps({}, db);
+    const result = await registerDomain(
+      { ...baseInput, hostname: "not a hostname" },
+      deps,
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("hostname_invalid");
+    }
+    expect(db.select).not.toHaveBeenCalled();
+  });
+
+  it("rejects when role check fails", async () => {
+    const db = fakeDb({ bindingRows: [verifiedBinding] });
+    const deps = buildDeps(
+      { checkUserRole: vi.fn().mockResolvedValue(false) },
+      db,
+    );
+    const result = await registerDomain(baseInput, deps);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("user_not_authorized");
+    }
+  });
+
+  it("rejects blocked hostname with reason", async () => {
+    const db = fakeDb({
+      blocklistRows: [{ hostname: "f3muletown.com", reason: "reserved" }],
+      bindingRows: [verifiedBinding],
+    });
+    const deps = buildDeps({}, db);
+    const result = await registerDomain(baseInput, deps);
+    expect(result.ok).toBe(false);
+    if (!result.ok && result.error.code === "hostname_blocked") {
+      expect(result.error.reason).toBe("reserved");
+    } else {
+      expect.fail("expected hostname_blocked");
+    }
+  });
+
+  it("rejects when quota exceeded", async () => {
+    const db = fakeDb({
+      bindingRows: [verifiedBinding],
+      quotaRows: [{ value: 5 }],
+      countRows: [{ value: 5 }],
+    });
+    const deps = buildDeps({}, db);
+    const result = await registerDomain(baseInput, deps);
+    expect(result.ok).toBe(false);
+    if (!result.ok && result.error.code === "quota_exceeded") {
+      expect(result.error.quota.current).toBe(5);
+      expect(result.error.quota.max).toBe(5);
+    } else {
+      expect.fail("expected quota_exceeded");
+    }
+  });
+
+  it("rejects when org has no binding", async () => {
+    const db = fakeDb({ bindingRows: [] });
+    const deps = buildDeps({}, db);
+    const result = await registerDomain(baseInput, deps);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("binding_missing");
+    }
+  });
+
+  it("rejects when binding is unverified", async () => {
+    const db = fakeDb({
+      bindingRows: [{ ...verifiedBinding, verificationState: "unverified" }],
+    });
+    const deps = buildDeps({}, db);
+    const result = await registerDomain(baseInput, deps);
+    expect(result.ok).toBe(false);
+    if (!result.ok && result.error.code === "binding_unverified") {
+      expect(result.error.verificationState).toBe("unverified");
+    } else {
+      expect.fail("expected binding_unverified");
+    }
+  });
+
+  it("maps Postgres check_violation (trigger) to internal_error with message", async () => {
+    const triggerError = Object.assign(new Error("trigger blocked"), {
+      code: "23514",
+    });
+    const db = fakeDb({
+      bindingRows: [verifiedBinding],
+      quotaRows: [{ value: 10 }],
+      countRows: [{ value: 0 }],
+      insertFailure: triggerError,
+    });
+    const deps = buildDeps({}, db);
+    const result = await registerDomain(baseInput, deps);
+    expect(result.ok).toBe(false);
+    if (!result.ok && result.error.code === "internal_error") {
+      expect(result.error.message).toContain("23514");
+    } else {
+      expect.fail("expected internal_error");
+    }
+  });
+});
+
+describe("publicErrorBody + statusForRegisterError", () => {
+  it("maps codes to HTTP status", () => {
+    expect(
+      statusForRegisterError({ code: "hostname_invalid", detail: "empty" }),
+    ).toBe(400);
+    expect(
+      statusForRegisterError({
+        code: "hostname_blocked",
+        reason: "reserved",
+      }),
+    ).toBe(409);
+    expect(statusForRegisterError({ code: "user_not_authorized" })).toBe(403);
+    expect(statusForRegisterError({ code: "binding_missing" })).toBe(412);
+    expect(
+      statusForRegisterError({
+        code: "binding_unverified",
+        verificationState: "unverified",
+      }),
+    ).toBe(412);
+    expect(
+      statusForRegisterError({
+        code: "quota_exceeded",
+        quota: { allowed: false, current: 5, max: 5, source: "explicit" },
+      }),
+    ).toBe(429);
+    expect(
+      statusForRegisterError({ code: "internal_error", message: "boom" }),
+    ).toBe(500);
+  });
+
+  it("scrubs internal_error message in public body", () => {
+    const body = publicErrorBody({
+      code: "internal_error",
+      message: "secret details here",
+    });
+    expect(body).toEqual({ error: "internal_error" });
+    expect(JSON.stringify(body)).not.toContain("secret");
+  });
+
+  it("leaks nothing for quota_exceeded beyond current/max", () => {
+    const body = publicErrorBody({
+      code: "quota_exceeded",
+      quota: { allowed: false, current: 5, max: 5, source: "explicit" },
+    });
+    expect(body).toEqual({
+      error: "quota_exceeded",
+      quota: { current: 5, max: 5 },
+    });
+  });
+});

--- a/apps/redirect-admin/src/lib/__tests__/env.test.ts
+++ b/apps/redirect-admin/src/lib/__tests__/env.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+
+import { EnvValidationError, loadEnv } from "../../env";
+
+const FULL_ENV = {
+  NEON_REDIRECT_ADMIN_UI_URL: "postgres://a",
+  REGION_BINDING_VALIDATOR_URL: "http://v",
+  REGION_BINDING_VALIDATOR_S2S_SECRET: "s",
+  DATABASE_URL: "postgres://b",
+  OAUTH_CLIENT_ID: "cid",
+  OAUTH_CLIENT_SECRET: "csec",
+  OAUTH_REDIRECT_URI: "http://r/cb",
+  AUTH_PROVIDER_URL: "http://auth",
+  SESSION_SECRET: "sess",
+  NEXT_PUBLIC_SITE_URL: "http://localhost:3006",
+} as unknown as NodeJS.ProcessEnv;
+
+describe("loadEnv", () => {
+  it("returns typed env on a complete source", () => {
+    const env = loadEnv(FULL_ENV);
+    expect(env.NEON_REDIRECT_ADMIN_UI_URL).toBe("postgres://a");
+    expect(env.neonAdminUiConnectionString).toBe("postgres://a");
+    expect(env.supabaseConnectionString).toBe("postgres://b");
+    expect(env.options.gcpProjectId).toBe("f3-redirects");
+    expect(env.options.redirectCertMapName).toBe("redirect-platform-cert-map");
+  });
+
+  it("applies optional overrides", () => {
+    const env = loadEnv({
+      ...FULL_ENV,
+      GCP_PROJECT_ID: "f3-test",
+      REDIRECT_CERT_MAP_NAME: "test-map",
+      REDIRECT_LB_IPV4: "1.2.3.4",
+    });
+    expect(env.options.gcpProjectId).toBe("f3-test");
+    expect(env.options.redirectCertMapName).toBe("test-map");
+    expect(env.options.redirectLbIpv4).toBe("1.2.3.4");
+  });
+
+  it("throws EnvValidationError listing missing vars", () => {
+    // Remove two required vars and ensure the error mentions them.
+    const partial: NodeJS.ProcessEnv = { ...FULL_ENV };
+    delete partial.SESSION_SECRET;
+    delete partial.OAUTH_CLIENT_ID;
+    try {
+      loadEnv(partial);
+      expect.fail("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(EnvValidationError);
+      expect((err as Error).message).toContain("SESSION_SECRET");
+      expect((err as Error).message).toContain("OAUTH_CLIENT_ID");
+    }
+  });
+});

--- a/apps/redirect-admin/src/lib/__tests__/hostname-validation.test.ts
+++ b/apps/redirect-admin/src/lib/__tests__/hostname-validation.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+
+import { validateHostname } from "../hostname-validation";
+
+describe("validateHostname", () => {
+  it("accepts a plain fqdn", () => {
+    expect(validateHostname("f3muletown.com")).toEqual({
+      valid: true,
+      normalized: "f3muletown.com",
+    });
+  });
+
+  it("accepts a subdomain", () => {
+    expect(validateHostname("stats.f3region.org")).toEqual({
+      valid: true,
+      normalized: "stats.f3region.org",
+    });
+  });
+
+  it("lowercases and strips trailing dot", () => {
+    expect(validateHostname("F3NATION.COM.")).toEqual({
+      valid: true,
+      normalized: "f3nation.com",
+    });
+  });
+
+  it("rejects empty", () => {
+    expect(validateHostname("")).toEqual({ valid: false, reason: "empty" });
+    expect(validateHostname("   ")).toEqual({ valid: false, reason: "empty" });
+  });
+
+  it("rejects URLs with a scheme", () => {
+    expect(validateHostname("https://f3muletown.com")).toEqual({
+      valid: false,
+      reason: "contains_scheme",
+    });
+  });
+
+  it("rejects URLs with a path", () => {
+    expect(validateHostname("f3muletown.com/path")).toEqual({
+      valid: false,
+      reason: "contains_path_or_query",
+    });
+  });
+
+  it("rejects bare labels with no dots", () => {
+    expect(validateHostname("localhost")).toEqual({
+      valid: false,
+      reason: "too_few_labels",
+    });
+  });
+
+  it("rejects labels starting with a hyphen", () => {
+    expect(validateHostname("-bad.com")).toEqual({
+      valid: false,
+      reason: "label_invalid",
+    });
+  });
+
+  it("rejects labels over 63 chars", () => {
+    const label = "a".repeat(64);
+    expect(validateHostname(`${label}.com`)).toEqual({
+      valid: false,
+      reason: "label_invalid",
+    });
+  });
+
+  it("rejects FQDN over 253 chars", () => {
+    const labels = Array.from({ length: 20 }, () => "a".repeat(15));
+    const hostname = labels.join(".") + ".com"; // comfortably > 253
+    expect(validateHostname(hostname).valid).toBe(false);
+  });
+});

--- a/apps/redirect-admin/src/lib/__tests__/quota-check.test.ts
+++ b/apps/redirect-admin/src/lib/__tests__/quota-check.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi } from "vitest";
+
+import { checkQuota, DEFAULT_MAX_DOMAINS_PER_ORG } from "../quota-check";
+import type { QuotaDbRunner } from "../quota-check";
+
+/**
+ * Tiny fake DB. The `select()` chain swaps implementations across calls
+ * so we can model the two queries `checkQuota` makes (max_domains, count).
+ */
+function fakeDb(params: {
+  quotaRows: { value: number }[];
+  countRows: { value: number }[];
+}): QuotaDbRunner {
+  let call = 0;
+  const runner = {
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(async () => {
+          call += 1;
+          return call === 1 ? params.quotaRows : params.countRows;
+        }),
+      })),
+    })),
+  };
+  return runner as unknown as QuotaDbRunner;
+}
+
+describe("checkQuota", () => {
+  it("allows when current < explicit max", async () => {
+    const db = fakeDb({
+      quotaRows: [{ value: 25 }],
+      countRows: [{ value: 3 }],
+    });
+    const result = await checkQuota(db, 42);
+    expect(result).toEqual({
+      allowed: true,
+      current: 3,
+      max: 25,
+      source: "explicit",
+    });
+  });
+
+  it("falls back to default max when no quota row", async () => {
+    const db = fakeDb({
+      quotaRows: [],
+      countRows: [{ value: 0 }],
+    });
+    const result = await checkQuota(db, 1);
+    expect(result.max).toBe(DEFAULT_MAX_DOMAINS_PER_ORG);
+    expect(result.source).toBe("default");
+    expect(result.allowed).toBe(true);
+  });
+
+  it("rejects when current equals max", async () => {
+    const db = fakeDb({
+      quotaRows: [{ value: 10 }],
+      countRows: [{ value: 10 }],
+    });
+    const result = await checkQuota(db, 1);
+    expect(result.allowed).toBe(false);
+    expect(result.current).toBe(10);
+    expect(result.max).toBe(10);
+  });
+
+  it("rejects when current exceeds max (race with another inserter)", async () => {
+    const db = fakeDb({
+      quotaRows: [{ value: 5 }],
+      countRows: [{ value: 6 }],
+    });
+    const result = await checkQuota(db, 1);
+    expect(result.allowed).toBe(false);
+  });
+
+  it("defaults current to 0 when count returns nothing", async () => {
+    const db = fakeDb({
+      quotaRows: [{ value: 10 }],
+      countRows: [],
+    });
+    const result = await checkQuota(db, 1);
+    expect(result.current).toBe(0);
+    expect(result.allowed).toBe(true);
+  });
+
+  it("coerces count strings to numbers", async () => {
+    // Postgres count() comes back as string unless cast; we call ::int
+    // in the query but defend against legacy behavior in the helper too.
+    const db = fakeDb({
+      quotaRows: [{ value: 10 }],
+      countRows: [{ value: "4" as unknown as number }],
+    });
+    const result = await checkQuota(db, 1);
+    expect(result.current).toBe(4);
+    expect(result.allowed).toBe(true);
+  });
+});

--- a/apps/redirect-admin/src/lib/__tests__/state-presenter.test.ts
+++ b/apps/redirect-admin/src/lib/__tests__/state-presenter.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from "vitest";
+
+import { presentLifecycleState } from "../state-presenter";
+import type { LifecycleState } from "../state-presenter";
+
+describe("presentLifecycleState", () => {
+  const ALL_STATES: LifecycleState[] = [
+    "pending",
+    "awaiting_dns_challenge",
+    "validating",
+    "provisioning_cert",
+    "awaiting_probe",
+    "awaiting_cutover",
+    "active",
+    "degraded",
+    "tombstoned",
+    "quarantined",
+    "released",
+  ];
+
+  it.each(ALL_STATES)("returns a populated view model for %s", (state) => {
+    const presented = presentLifecycleState(state);
+    expect(presented.state).toBe(state);
+    expect(presented.label.length).toBeGreaterThan(0);
+    expect(presented.description.length).toBeGreaterThan(10);
+    expect(["info", "warning", "error", "success"]).toContain(
+      presented.variant,
+    );
+  });
+
+  it("marks awaiting_dns_challenge with an actionable CTA", () => {
+    const p = presentLifecycleState("awaiting_dns_challenge");
+    expect(p.actionable).toBeDefined();
+    expect(p.actionable?.button).toBe("View DNS Records");
+    expect(p.variant).toBe("warning");
+  });
+
+  it("marks awaiting_cutover as success with CTA", () => {
+    const p = presentLifecycleState("awaiting_cutover");
+    expect(p.variant).toBe("success");
+    expect(p.actionable?.button).toBe("View Cutover Instructions");
+  });
+
+  it("marks active as success with no CTA", () => {
+    const p = presentLifecycleState("active");
+    expect(p.variant).toBe("success");
+    expect(p.actionable).toBeUndefined();
+  });
+
+  it("marks degraded as error and folds reconciler error into description", () => {
+    const p = presentLifecycleState("degraded", {
+      drift_kind: "cert_missing",
+      resource_name: "dns-auth-foo",
+    });
+    expect(p.variant).toBe("error");
+    expect(p.description).toContain("dns-auth-foo");
+    expect(p.description).toContain("cert_missing");
+    expect(p.actionable?.button).toBe("View Recovery Steps");
+  });
+
+  it("degraded without an error payload still renders", () => {
+    const p = presentLifecycleState("degraded");
+    expect(p.variant).toBe("error");
+    expect(p.description).toContain("unknown");
+  });
+
+  it("marks quarantined as error", () => {
+    const p = presentLifecycleState("quarantined");
+    expect(p.variant).toBe("error");
+  });
+
+  it("marks pending as info without actionable", () => {
+    const p = presentLifecycleState("pending");
+    expect(p.variant).toBe("info");
+    expect(p.actionable).toBeUndefined();
+  });
+
+  it("returns stable label wording for snapshot stability", () => {
+    // Lock a few labels so UI layouts can rely on them without
+    // re-approving a snapshot on every minor tweak.
+    expect(presentLifecycleState("awaiting_dns_challenge").label).toBe(
+      "Awaiting DNS Challenge",
+    );
+    expect(presentLifecycleState("awaiting_probe").label).toBe(
+      "Awaiting Health Probe",
+    );
+    expect(presentLifecycleState("released").label).toBe("Released");
+  });
+});

--- a/apps/redirect-admin/src/lib/__tests__/validator-client.test.ts
+++ b/apps/redirect-admin/src/lib/__tests__/validator-client.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi } from "vitest";
+
+import {
+  CallerNotAuthorizedError,
+  OrgNotFoundError,
+  TripleMismatchError,
+  ValidatorClient,
+  ValidatorUnavailableError,
+} from "../validator-client";
+
+function buildJsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("ValidatorClient", () => {
+  const baseConfig = {
+    baseUrl: "http://validator.test",
+    s2sSecret: "shhh",
+  };
+
+  it("returns parsed body on 200", async () => {
+    const body = {
+      org: {
+        id: 1,
+        name: "F3 Muletown",
+        last_modified: "2026-04-14T00:00:00.000Z",
+        admin_count: 3,
+        caller_roles: ["admin"],
+      },
+      pax_vault: { region_id: "pv-123", region_name: "F3 Muletown" },
+      f3_region_pages: { slug: "muletown" },
+      cross_check: { triple_matches: true, match_strategy: "exact" },
+      validated_at: "2026-04-14T00:00:01.000Z",
+    };
+    const fetchImpl = vi.fn().mockResolvedValue(buildJsonResponse(200, body));
+    const client = new ValidatorClient({ ...baseConfig, fetchImpl });
+
+    const result = await client.validate({
+      orgId: 1,
+      paxVaultRegionId: "pv-123",
+      regionSlug: "muletown",
+      callingUserId: 99,
+    });
+
+    expect(result).toEqual(body);
+    const firstCall = fetchImpl.mock.calls[0] as unknown as
+      | [string, { headers: Record<string, string> }]
+      | undefined;
+    expect(firstCall).toBeDefined();
+    const calledUrl = firstCall?.[0] ?? "";
+    expect(calledUrl).toContain("org_id=1");
+    expect(calledUrl).toContain("pax_vault_region_id=pv-123");
+    expect(calledUrl).toContain("region_slug=muletown");
+    expect(calledUrl).toContain("calling_user_id=99");
+    expect(firstCall?.[1].headers.Authorization).toBe("Bearer shhh");
+  });
+
+  it("throws OrgNotFoundError on 404", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(buildJsonResponse(404, { error: "org_not_found" }));
+    const client = new ValidatorClient({ ...baseConfig, fetchImpl });
+    await expect(
+      client.validate({
+        orgId: 77,
+        paxVaultRegionId: "pv-x",
+        regionSlug: "nope",
+        callingUserId: 1,
+      }),
+    ).rejects.toBeInstanceOf(OrgNotFoundError);
+  });
+
+  it("throws CallerNotAuthorizedError on 403", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(
+        buildJsonResponse(403, { error: "caller_not_authorized_on_org" }),
+      );
+    const client = new ValidatorClient({ ...baseConfig, fetchImpl });
+    await expect(
+      client.validate({
+        orgId: 1,
+        paxVaultRegionId: "p",
+        regionSlug: "s",
+        callingUserId: 1,
+      }),
+    ).rejects.toBeInstanceOf(CallerNotAuthorizedError);
+  });
+
+  it("throws TripleMismatchError on 422 with structured detail", async () => {
+    const mismatches = [
+      {
+        field: "region_slug",
+        sources: { query_param: "foo", f3_region_pages: "bar" },
+        reason: "slug mismatch",
+      },
+    ];
+    const fetchImpl = vi.fn().mockResolvedValue(
+      buildJsonResponse(422, {
+        error: "triple_mismatch",
+        detail: { mismatches },
+      }),
+    );
+    const client = new ValidatorClient({ ...baseConfig, fetchImpl });
+    try {
+      await client.validate({
+        orgId: 1,
+        paxVaultRegionId: "p",
+        regionSlug: "s",
+        callingUserId: 1,
+      });
+      expect.fail("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(TripleMismatchError);
+      expect((err as TripleMismatchError).mismatches).toEqual(mismatches);
+    }
+  });
+
+  it("throws ValidatorUnavailableError on 5xx", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(
+        buildJsonResponse(503, { error: "source_unavailable" }),
+      );
+    const client = new ValidatorClient({ ...baseConfig, fetchImpl });
+    await expect(
+      client.validate({
+        orgId: 1,
+        paxVaultRegionId: "p",
+        regionSlug: "s",
+        callingUserId: 1,
+      }),
+    ).rejects.toBeInstanceOf(ValidatorUnavailableError);
+  });
+
+  it("throws ValidatorUnavailableError when fetch rejects", async () => {
+    const fetchImpl = vi.fn().mockRejectedValue(new Error("ECONNREFUSED"));
+    const client = new ValidatorClient({ ...baseConfig, fetchImpl });
+    await expect(
+      client.validate({
+        orgId: 1,
+        paxVaultRegionId: "p",
+        regionSlug: "s",
+        callingUserId: 1,
+      }),
+    ).rejects.toBeInstanceOf(ValidatorUnavailableError);
+  });
+});

--- a/apps/redirect-admin/src/lib/auth/constants.ts
+++ b/apps/redirect-admin/src/lib/auth/constants.ts
@@ -1,0 +1,3 @@
+export const SESSION_COOKIE_NAME = "__redirect_admin_session";
+export const SESSION_COOKIE_DAYS = 10;
+export const SESSION_COOKIE_MAX_AGE = SESSION_COOKIE_DAYS * 24 * 60 * 60;

--- a/apps/redirect-admin/src/lib/auth/oauth.ts
+++ b/apps/redirect-admin/src/lib/auth/oauth.ts
@@ -1,0 +1,48 @@
+import { AuthClient } from "@acme/sso";
+import type {
+  AuthClientConfig,
+  AuthTokens,
+  AuthUser,
+  OauthClient,
+} from "@acme/sso";
+
+function getRequiredEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) throw new Error(`${name} env var is required`);
+  return value;
+}
+
+function buildAuthConfig(): AuthClientConfig {
+  return {
+    clientId: getRequiredEnv("OAUTH_CLIENT_ID"),
+    clientSecret: getRequiredEnv("OAUTH_CLIENT_SECRET"),
+    redirectUri: getRequiredEnv("OAUTH_REDIRECT_URI"),
+    authServerUrl: getRequiredEnv("AUTH_PROVIDER_URL"),
+  };
+}
+
+let _authClient: AuthClient | null = null;
+function getAuthClient(): AuthClient {
+  if (!_authClient) {
+    _authClient = new AuthClient(buildAuthConfig());
+  }
+  return _authClient;
+}
+
+export function getOAuthConfig(): OauthClient {
+  return getAuthClient().getOAuthConfig();
+}
+
+export async function exchangeCodeForToken(params: {
+  code: string;
+  codeVerifier: string;
+}): Promise<AuthTokens> {
+  return getAuthClient().exchangeCodeForToken({
+    code: params.code,
+    codeVerifier: params.codeVerifier,
+  });
+}
+
+export async function getUserInfo(accessToken: string): Promise<AuthUser> {
+  return getAuthClient().getUserInfo(accessToken);
+}

--- a/apps/redirect-admin/src/lib/auth/server.ts
+++ b/apps/redirect-admin/src/lib/auth/server.ts
@@ -1,0 +1,22 @@
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+import { SESSION_COOKIE_NAME } from "./constants";
+import { verifySessionValue } from "./session";
+import type { SessionPayload } from "./session";
+
+export type { SessionPayload };
+
+export async function getSessionUser(): Promise<SessionPayload | null> {
+  const cookieStore = await cookies();
+  const sessionCookie = cookieStore.get(SESSION_COOKIE_NAME)?.value;
+  if (!sessionCookie) return null;
+  return verifySessionValue(sessionCookie);
+}
+
+export async function requireAuth(): Promise<SessionPayload> {
+  const user = await getSessionUser();
+  if (!user) {
+    redirect("/");
+  }
+  return user;
+}

--- a/apps/redirect-admin/src/lib/auth/session.ts
+++ b/apps/redirect-admin/src/lib/auth/session.ts
@@ -1,0 +1,83 @@
+/**
+ * HMAC-signed session cookie — copied from apps/me with the cookie name
+ * rebranded. Both apps share the same SSO provider and session shape.
+ *
+ * Intentionally a plain HMAC over JSON rather than a JWT: the payload is
+ * tiny, we don't need cross-system verification, and the smaller surface
+ * area is easier to audit.
+ */
+
+import { createHmac, timingSafeEqual } from "crypto";
+import { SESSION_COOKIE_MAX_AGE } from "./constants";
+
+export interface SessionPayload {
+  sub: string;
+  email: string;
+  name?: string;
+  userId: number;
+  iat: number;
+}
+
+function getSecret(): string {
+  const secret = process.env.SESSION_SECRET;
+  if (!secret) throw new Error("SESSION_SECRET env var is required");
+  return secret;
+}
+
+function sign(data: string): string {
+  return createHmac("sha256", getSecret()).update(data).digest("base64url");
+}
+
+export function createSessionValue(
+  payload: Omit<SessionPayload, "iat">,
+): string {
+  const full: SessionPayload = {
+    ...payload,
+    iat: Math.floor(Date.now() / 1000),
+  };
+  const json = Buffer.from(JSON.stringify(full)).toString("base64url");
+  const signature = sign(json);
+  return `${json}.${signature}`;
+}
+
+export function verifySessionValue(cookie: string): SessionPayload | null {
+  const dotIdx = cookie.lastIndexOf(".");
+  if (dotIdx === -1) return null;
+
+  const json = cookie.slice(0, dotIdx);
+  const signature = cookie.slice(dotIdx + 1);
+
+  const expected = sign(json);
+  if (
+    signature.length !== expected.length ||
+    !timingSafeEqual(Buffer.from(signature), Buffer.from(expected))
+  ) {
+    return null;
+  }
+
+  try {
+    const raw: unknown = JSON.parse(
+      Buffer.from(json, "base64url").toString("utf-8"),
+    );
+
+    if (
+      typeof raw !== "object" ||
+      raw === null ||
+      typeof (raw as Record<string, unknown>).sub !== "string" ||
+      typeof (raw as Record<string, unknown>).email !== "string" ||
+      typeof (raw as Record<string, unknown>).userId !== "number" ||
+      typeof (raw as Record<string, unknown>).iat !== "number"
+    ) {
+      return null;
+    }
+
+    const payload = raw as SessionPayload;
+
+    const age = Math.floor(Date.now() / 1000) - payload.iat;
+    if (age > SESSION_COOKIE_MAX_AGE) return null;
+
+    return payload;
+  } catch {
+    return null;
+  }
+}

--- a/apps/redirect-admin/src/lib/auth/validation.ts
+++ b/apps/redirect-admin/src/lib/auth/validation.ts
@@ -1,0 +1,13 @@
+/**
+ * Validate that a return-to path is safe (relative, no open-redirect).
+ * Rejects absolute URLs, protocol-relative URLs, and non-path values.
+ */
+export function isValidReturnTo(path: string): boolean {
+  return path.startsWith("/") && !path.startsWith("//");
+}
+
+/** Sanitize a return-to value, falling back to /domains if invalid. */
+export function safeReturnTo(path: string | null | undefined): string {
+  if (!path) return "/domains";
+  return isValidReturnTo(path) ? path : "/domains";
+}

--- a/apps/redirect-admin/src/lib/cert-manager-client.ts
+++ b/apps/redirect-admin/src/lib/cert-manager-client.ts
@@ -1,0 +1,224 @@
+/**
+ * Thin wrapper over `@google-cloud/certificate-manager` for
+ * DnsAuthorization.Create — the only GCP API call the registration
+ * flow makes synchronously (R5 Phase 1, step 6).
+ *
+ * Responsibilities:
+ *   - Build the deterministic resource name (`dns-auth-<row.id>`).
+ *   - Call CertificateManagerClient.createDnsAuthorization + await the
+ *     returned LRO.
+ *   - On ALREADY_EXISTS (from a retry), GET the existing resource and
+ *     return its challenge record. Same pattern used by the reconciler.
+ *   - Pluck the CNAME challenge record (`dnsResourceRecord.name` +
+ *     `dnsResourceRecord.data`) into a plain typed object.
+ *
+ * The real GCP client is injected via `CertManagerClientFactory` so tests
+ * can pass a fake. Route handlers use `createDefaultCertManagerClient()`
+ * which wires the real `@google-cloud/certificate-manager` package.
+ */
+
+import "server-only";
+
+import { env } from "@/env";
+
+export interface DnsChallengeRecord {
+  /** The fully-qualified CNAME name the user must create. */
+  name: string;
+  /** The CNAME record's target value (what it should resolve to). */
+  data: string;
+  /** Record type — always "CNAME" for Certificate Manager DNS-01. */
+  type: "CNAME";
+}
+
+export interface CreateDnsAuthorizationInput {
+  /** Deterministic id, derived from the `region_custom_domains.id` UUID. */
+  authorizationId: string;
+  /** Fully-qualified hostname being authorized. */
+  hostname: string;
+  /** GCP project id — defaults to `env().options.gcpProjectId`. */
+  projectId?: string;
+  /** Location — Certificate Manager DnsAuthorizations are `global`. */
+  location?: string;
+}
+
+export interface CreateDnsAuthorizationResult {
+  /** Full GCP resource name — `projects/.../dnsAuthorizations/<id>`. */
+  resourceName: string;
+  /** Parsed DNS challenge the caller must persist + surface to the user. */
+  challenge: DnsChallengeRecord;
+  /**
+   * Whether this call created a new resource or reused an existing one
+   * (ALREADY_EXISTS path). Useful for structured logging.
+   */
+  reused: boolean;
+}
+
+/**
+ * Minimal type for the injected GCP client — only the two methods we
+ * call are typed here. Keeps tests dependency-free and avoids pulling
+ * the full `@google-cloud/certificate-manager` type surface into unit
+ * tests.
+ */
+export interface CertManagerLike {
+  createDnsAuthorization: (request: {
+    parent: string;
+    dnsAuthorizationId: string;
+    dnsAuthorization: { domain: string };
+  }) => Promise<[{ promise: () => Promise<[DnsAuthorizationShape]> }]>;
+  getDnsAuthorization: (request: {
+    name: string;
+  }) => Promise<[DnsAuthorizationShape]>;
+}
+
+export interface DnsAuthorizationShape {
+  name?: string | null;
+  dnsResourceRecord?: {
+    name?: string | null;
+    type?: string | null;
+    data?: string | null;
+  } | null;
+}
+
+export type CertManagerClientFactory = () => CertManagerLike;
+
+// ---------------------------------------------------------------------------
+// Pure helpers (exported for direct unit testing)
+// ---------------------------------------------------------------------------
+
+/**
+ * Derive the deterministic DnsAuthorization resource id from a
+ * `region_custom_domains.id` UUID. The reconciler uses this same shape
+ * so retries across processes land on the same GCP resource.
+ */
+export function buildDnsAuthorizationId(domainRowId: string): string {
+  return `dns-auth-${domainRowId}`;
+}
+
+/**
+ * Pluck the CNAME challenge out of a GCP DnsAuthorization response.
+ * Throws if the record isn't present — the GCP API is supposed to
+ * always include it on successful create/get of a DNS-01 authorization.
+ */
+export function extractDnsChallenge(
+  authorization: DnsAuthorizationShape,
+): DnsChallengeRecord {
+  const record = authorization.dnsResourceRecord;
+  if (!record?.name || !record.data) {
+    throw new Error(
+      "DnsAuthorization response missing dnsResourceRecord.{name,data}",
+    );
+  }
+  return {
+    name: record.name,
+    data: record.data,
+    type: "CNAME",
+  };
+}
+
+export function buildParent(projectId: string, location: string): string {
+  return `projects/${projectId}/locations/${location}`;
+}
+
+export function buildResourceName(
+  projectId: string,
+  location: string,
+  authorizationId: string,
+): string {
+  return `${buildParent(projectId, location)}/dnsAuthorizations/${authorizationId}`;
+}
+
+/** Returned when a duplicate create is reconciled via GET. */
+export function isAlreadyExistsError(err: unknown): boolean {
+  if (!err || typeof err !== "object") return false;
+  const code = (err as { code?: number }).code;
+  // gRPC ALREADY_EXISTS = 6
+  if (code === 6) return true;
+  const message = (err as { message?: string }).message;
+  if (message && /already exists/i.test(message)) return true;
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Main entry point
+// ---------------------------------------------------------------------------
+
+export async function createOrReuseDnsAuthorization(
+  factory: CertManagerClientFactory,
+  input: CreateDnsAuthorizationInput,
+): Promise<CreateDnsAuthorizationResult> {
+  const client = factory();
+  const projectId = input.projectId ?? env().options.gcpProjectId;
+  const location = input.location ?? "global";
+  const parent = buildParent(projectId, location);
+  const resourceName = buildResourceName(
+    projectId,
+    location,
+    input.authorizationId,
+  );
+
+  try {
+    const [operation] = await client.createDnsAuthorization({
+      parent,
+      dnsAuthorizationId: input.authorizationId,
+      dnsAuthorization: { domain: input.hostname },
+    });
+    const [authorization] = await operation.promise();
+    return {
+      resourceName: authorization.name ?? resourceName,
+      challenge: extractDnsChallenge(authorization),
+      reused: false,
+    };
+  } catch (err) {
+    if (!isAlreadyExistsError(err)) throw err;
+    // Existing resource (probably from a prior failed attempt). GET it.
+    const [authorization] = await client.getDnsAuthorization({
+      name: resourceName,
+    });
+    return {
+      resourceName: authorization.name ?? resourceName,
+      challenge: extractDnsChallenge(authorization),
+      reused: true,
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Default (real) factory — lazy import so tests never touch GCP.
+// ---------------------------------------------------------------------------
+
+let _cachedClient: CertManagerLike | null = null;
+
+/**
+ * Wraps the real `@google-cloud/certificate-manager` client. Returns a
+ * `CertManagerLike` rather than the full client so unit tests don't need
+ * GCP auth to run. Prod code calls this from the route handler, tests
+ * pass their own factory.
+ */
+export async function getDefaultCertManagerClient(): Promise<CertManagerLike> {
+  if (_cachedClient) return _cachedClient;
+  // Dynamic import keeps `@google-cloud/certificate-manager` out of the
+  // unit-test path. The module is declared as a dependency in
+  // package.json but only loaded when prod code calls this factory.
+  const mod = (await import(
+    "@google-cloud/certificate-manager"
+  )) as unknown as {
+    CertificateManagerClient: new () => CertManagerLike;
+  };
+  _cachedClient = new mod.CertificateManagerClient();
+  return _cachedClient;
+}
+
+/**
+ * Sync factory used by the registration flow. Throws if the async
+ * initializer hasn't been primed yet — call `getDefaultCertManagerClient`
+ * once during server startup (or await it in the route) before invoking
+ * this.
+ */
+export function createDefaultCertManagerClient(): CertManagerLike {
+  if (!_cachedClient) {
+    throw new Error(
+      "cert-manager client not initialized — call getDefaultCertManagerClient() first",
+    );
+  }
+  return _cachedClient;
+}

--- a/apps/redirect-admin/src/lib/db-client.ts
+++ b/apps/redirect-admin/src/lib/db-client.ts
@@ -1,0 +1,50 @@
+/**
+ * Drizzle client factory for the redirect-admin UI, wired to the
+ * `redirect_admin_ui` Neon role (R5 Decision 8). Pool size is small
+ * (8) because every request does at most a handful of statements and
+ * Cloud Run scales horizontally.
+ *
+ * Matches the shape of `apps/reconciler/src/db/client.ts` — we
+ * instantiate Drizzle locally rather than calling
+ * `createRedirectPlatformDb()` so we can share the `postgres.Sql` handle
+ * if we ever need raw-SQL template strings for the trigger-gated
+ * INSERT path.
+ */
+
+import "server-only";
+
+import { schema } from "@acme/redirect-platform-db";
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
+import type { Sql } from "postgres";
+
+import { env } from "@/env";
+
+export type RedirectAdminDb = ReturnType<typeof drizzle<typeof schema>>;
+
+export interface RedirectAdminDbHandle {
+  db: RedirectAdminDb;
+  client: Sql;
+  end(): Promise<void>;
+}
+
+let _cached: RedirectAdminDbHandle | null = null;
+
+export function getRedirectAdminDb(): RedirectAdminDbHandle {
+  if (_cached) return _cached;
+  const connectionString = env().neonAdminUiConnectionString;
+  const client = postgres(connectionString, {
+    ssl: "require",
+    max: 8,
+  });
+  const db = drizzle(client, { schema });
+  _cached = {
+    db,
+    client,
+    async end() {
+      await client.end({ timeout: 5 });
+      _cached = null;
+    },
+  };
+  return _cached;
+}

--- a/apps/redirect-admin/src/lib/hostname-validation.ts
+++ b/apps/redirect-admin/src/lib/hostname-validation.ts
@@ -1,0 +1,57 @@
+/**
+ * Plausible-domain check for user-supplied hostnames on the registration
+ * form. Deliberately strict (ASCII only, DNS label rules), but leaves the
+ * final reservation/blocklist call to the DB.
+ *
+ * Pure — no I/O. Unit-testable in isolation.
+ */
+
+const LABEL_RE = /^(?!-)[a-z0-9-]{1,63}(?<!-)$/;
+
+export type HostnameValidationResult =
+  | { valid: true; normalized: string }
+  | { valid: false; reason: HostnameValidationError };
+
+export type HostnameValidationError =
+  | "empty"
+  | "too_long"
+  | "contains_scheme"
+  | "contains_path_or_query"
+  | "too_few_labels"
+  | "label_invalid";
+
+const MAX_FQDN_LENGTH = 253;
+
+export function validateHostname(
+  raw: string | null | undefined,
+): HostnameValidationResult {
+  if (!raw) return { valid: false, reason: "empty" };
+  const trimmed = raw.trim().toLowerCase();
+  if (!trimmed) return { valid: false, reason: "empty" };
+
+  if (trimmed.length > MAX_FQDN_LENGTH) {
+    return { valid: false, reason: "too_long" };
+  }
+
+  if (/^https?:\/\//.test(trimmed) || trimmed.includes("://")) {
+    return { valid: false, reason: "contains_scheme" };
+  }
+  if (/[/?#]/.test(trimmed)) {
+    return { valid: false, reason: "contains_path_or_query" };
+  }
+
+  // Strip trailing dot (FQDN form) for label checks.
+  const hostname = trimmed.replace(/\.$/, "");
+
+  const labels = hostname.split(".");
+  if (labels.length < 2) {
+    return { valid: false, reason: "too_few_labels" };
+  }
+  for (const label of labels) {
+    if (!LABEL_RE.test(label)) {
+      return { valid: false, reason: "label_invalid" };
+    }
+  }
+
+  return { valid: true, normalized: hostname };
+}

--- a/apps/redirect-admin/src/lib/quota-check.ts
+++ b/apps/redirect-admin/src/lib/quota-check.ts
@@ -1,0 +1,81 @@
+/**
+ * Per-org domain quota enforcement (R5 Decision 7 / 8).
+ *
+ * - Looks up `org_domain_quota.max_domains`; default 10 if no row.
+ * - Counts non-released `region_custom_domains` rows for the org.
+ * - Returns a verdict the route handler can gate on.
+ *
+ * The `db` parameter is typed as the loose `QuotaDbRunner` — a purely
+ * structural interface that the real `RedirectAdminDb` satisfies
+ * (checked at the route handler layer) and that unit tests can
+ * trivially fake. We keep the type loose here so tests don't need to
+ * materialize the full Drizzle relational type surface.
+ */
+
+import { and, eq, ne, sql } from "drizzle-orm";
+
+import {
+  orgDomainQuota,
+  regionCustomDomains,
+} from "@acme/redirect-platform-db";
+
+export const DEFAULT_MAX_DOMAINS_PER_ORG = 10;
+
+export interface QuotaCheckResult {
+  allowed: boolean;
+  current: number;
+  max: number;
+  /** Whether the max came from an explicit row or the default fallback. */
+  source: "explicit" | "default";
+}
+
+/**
+ * Minimal Drizzle surface — `select/from/where` returning an awaitable
+ * that yields rows. Typed as `unknown` tails so the real Drizzle type
+ * is assignable to this interface by structural widening.
+ */
+export interface QuotaDbRunner {
+  select(projection?: unknown): {
+    from(table: unknown): {
+      where(predicate: unknown): Promise<unknown[]>;
+    };
+  };
+}
+
+export async function checkQuota(
+  db: QuotaDbRunner,
+  orgId: number,
+): Promise<QuotaCheckResult> {
+  // 1. Resolve max
+  const quotaRowsRaw = await db
+    .select({ value: orgDomainQuota.maxDomains })
+    .from(orgDomainQuota)
+    .where(eq(orgDomainQuota.orgId, orgId));
+  const quotaRows = quotaRowsRaw as { value: number }[];
+
+  const explicit = quotaRows[0]?.value;
+  const max = explicit ?? DEFAULT_MAX_DOMAINS_PER_ORG;
+  const source: "explicit" | "default" =
+    explicit !== undefined ? "explicit" : "default";
+
+  // 2. Count non-released domains
+  const countRowsRaw = await db
+    .select({ value: sql<number>`count(*)::int` })
+    .from(regionCustomDomains)
+    .where(
+      and(
+        eq(regionCustomDomains.orgId, orgId),
+        ne(regionCustomDomains.lifecycleState, "released"),
+      ),
+    );
+  const countRows = countRowsRaw as { value: number | string }[];
+
+  const current = Number(countRows[0]?.value ?? 0);
+
+  return {
+    allowed: current < max,
+    current,
+    max,
+    source,
+  };
+}

--- a/apps/redirect-admin/src/lib/services/domain-registration.ts
+++ b/apps/redirect-admin/src/lib/services/domain-registration.ts
@@ -1,0 +1,421 @@
+/**
+ * Domain registration service — the extracted business logic behind
+ * `POST /api/domains/register`. Route handler is a thin wrapper that
+ * reads the session + request body and delegates here.
+ *
+ * Flow (R5 plan Phase 1):
+ *   1. hostname validation + blocklist check
+ *   2. per-org quota check
+ *   3. binding verification state check (application layer — the DB
+ *      trigger is the authority, this is UX)
+ *   4. transactional INSERT into region_custom_domains + an event row
+ *   5. Certificate Manager DnsAuthorization.Create
+ *   6. UPDATE row with DNS challenge + advance lifecycle_state
+ *
+ * All external collaborators (db, validator, cert-manager) are injected
+ * so unit tests can exercise the branches without real clients.
+ */
+
+import { eq } from "drizzle-orm";
+
+import {
+  domainBlocklist,
+  orgRegionBindings,
+  regionCustomDomainEvents,
+  regionCustomDomains,
+} from "@acme/redirect-platform-db";
+import type {
+  OrgRegionBinding,
+  RegionCustomDomain,
+} from "@acme/redirect-platform-db";
+
+import { validateHostname } from "../hostname-validation";
+import type { HostnameValidationError } from "../hostname-validation";
+import { checkQuota } from "../quota-check";
+import type { QuotaCheckResult, QuotaDbRunner } from "../quota-check";
+import {
+  buildDnsAuthorizationId,
+  createOrReuseDnsAuthorization,
+} from "../cert-manager-client";
+import type {
+  CertManagerClientFactory,
+  DnsChallengeRecord,
+} from "../cert-manager-client";
+
+// ---------------------------------------------------------------------------
+// Public input / output types
+// ---------------------------------------------------------------------------
+
+export interface RegisterDomainInput {
+  orgId: number;
+  hostname: string;
+  hostnameRole: "apex" | "stats";
+  userId: number;
+}
+
+export type RegisterDomainError =
+  | {
+      code: "hostname_invalid";
+      detail: HostnameValidationError;
+    }
+  | { code: "hostname_blocked"; reason: string }
+  | { code: "binding_missing" }
+  | { code: "binding_unverified"; verificationState: string }
+  | { code: "quota_exceeded"; quota: QuotaCheckResult }
+  | { code: "user_not_authorized" }
+  | { code: "internal_error"; message: string };
+
+export interface RegisterDomainSuccess {
+  domain: RegionCustomDomain;
+  dnsChallenge: DnsChallengeRecord;
+  /** True if the GCP DnsAuthorization existed from a prior attempt. */
+  reusedExistingAuthorization: boolean;
+}
+
+export type RegisterDomainResult =
+  | { ok: true; value: RegisterDomainSuccess }
+  | { ok: false; error: RegisterDomainError };
+
+// ---------------------------------------------------------------------------
+// Collaborators (injectable)
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal Drizzle surface the service needs. Deliberately loose so:
+ *   (a) unit tests can fake it without materializing the full schema
+ *   (b) the real `RedirectAdminDb` from `@acme/redirect-platform-db`
+ *       is structurally assignable at the route handler layer
+ */
+export interface RegistrationDbRunner extends QuotaDbRunner {
+  insert(table: unknown): {
+    values(row: unknown): {
+      returning(): Promise<unknown[]>;
+    };
+  };
+  update(table: unknown): {
+    set(values: unknown): {
+      where(predicate: unknown): {
+        returning(): Promise<unknown[]>;
+      };
+    };
+  };
+}
+
+/** Role-check callback — returns true if the user is admin/editor on org. */
+export type UserOrgRoleChecker = (params: {
+  userId: number;
+  orgId: number;
+}) => Promise<boolean>;
+
+export interface RegisterDomainDeps {
+  db: RegistrationDbRunner;
+  certManagerFactory: CertManagerClientFactory;
+  checkUserRole: UserOrgRoleChecker;
+}
+
+// ---------------------------------------------------------------------------
+// Main entry point
+// ---------------------------------------------------------------------------
+
+export async function registerDomain(
+  input: RegisterDomainInput,
+  deps: RegisterDomainDeps,
+): Promise<RegisterDomainResult> {
+  // --- 1. Hostname validation ---
+  const hostnameResult = validateHostname(input.hostname);
+  if (!hostnameResult.valid) {
+    return {
+      ok: false,
+      error: { code: "hostname_invalid", detail: hostnameResult.reason },
+    };
+  }
+  const hostname = hostnameResult.normalized;
+
+  // --- 2. Role check ---
+  const isAuthorized = await deps.checkUserRole({
+    userId: input.userId,
+    orgId: input.orgId,
+  });
+  if (!isAuthorized) {
+    return { ok: false, error: { code: "user_not_authorized" } };
+  }
+
+  // --- 3. Blocklist check ---
+  const blocklistRowsRaw = await deps.db
+    .select()
+    .from(domainBlocklist)
+    .where(eq(domainBlocklist.hostname, hostname));
+  const blocklistRows = blocklistRowsRaw as {
+    hostname: string;
+    reason: string;
+  }[];
+  if (blocklistRows.length > 0) {
+    const first = blocklistRows[0];
+    return {
+      ok: false,
+      error: {
+        code: "hostname_blocked",
+        reason: first?.reason ?? "blocked",
+      },
+    };
+  }
+
+  // --- 4. Quota check ---
+  const quota = await checkQuota(deps.db, input.orgId);
+  if (!quota.allowed) {
+    return { ok: false, error: { code: "quota_exceeded", quota } };
+  }
+
+  // --- 5. Binding verification (app-layer UX check; trigger is the DB authority) ---
+  const bindingRowsRaw = await deps.db
+    .select()
+    .from(orgRegionBindings)
+    .where(eq(orgRegionBindings.orgId, input.orgId));
+  const bindingRows = bindingRowsRaw as OrgRegionBinding[];
+  const binding = bindingRows[0];
+  if (!binding) {
+    return { ok: false, error: { code: "binding_missing" } };
+  }
+  if (binding.verificationState !== "verified") {
+    return {
+      ok: false,
+      error: {
+        code: "binding_unverified",
+        verificationState: binding.verificationState,
+      },
+    };
+  }
+
+  // --- 6. INSERT region_custom_domains + event row ---
+  // NOTE: we do NOT wrap these in a SQL transaction object here because
+  // the injected `db` surface is deliberately minimal. Route handlers
+  // that want a real transaction can swap the injected runner for a
+  // `db.transaction(tx => ...)` callback. For F3R5_012 (scaffold) the
+  // two-statement sequence is tolerable: if the event-insert fails, the
+  // row still exists and the reconciler will pick it up from the
+  // `pending` state on the next tick. The verified-binding trigger
+  // fires on the first INSERT so we cannot create an orphaned row in
+  // an unverified-binding state.
+  let createdDomain: RegionCustomDomain;
+  try {
+    const insertedRowsRaw = await deps.db
+      .insert(regionCustomDomains)
+      .values({
+        orgId: input.orgId,
+        regionSlug: binding.regionSlug,
+        regionId: binding.paxVaultRegionId,
+        regionName: binding.regionName,
+        hostname,
+        hostnameRole: input.hostnameRole,
+        lifecycleState: "pending",
+        createdBy: input.userId,
+      })
+      .returning();
+    const insertedRows = insertedRowsRaw as RegionCustomDomain[];
+    const first = insertedRows[0];
+    if (!first) {
+      return {
+        ok: false,
+        error: {
+          code: "internal_error",
+          message: "INSERT region_custom_domains returned no row",
+        },
+      };
+    }
+    createdDomain = first;
+  } catch (err) {
+    return {
+      ok: false,
+      error: {
+        code: "internal_error",
+        message: formatError(err, "failed to insert region_custom_domains"),
+      },
+    };
+  }
+
+  // Append a domain-event row. If this fails we log + continue — the
+  // reconciler's audit-event machinery backfills on next tick.
+  await appendEventSafely(deps.db, {
+    domainId: createdDomain.id,
+    eventType: "registered",
+    fromState: null,
+    toState: "pending",
+    actorUserId: input.userId,
+    details: {
+      hostname,
+      hostname_role: input.hostnameRole,
+      source: "redirect-admin-ui",
+    },
+  });
+
+  // --- 7. Certificate Manager DnsAuthorization.Create ---
+  const authorizationId = buildDnsAuthorizationId(createdDomain.id);
+  let dnsChallenge: DnsChallengeRecord;
+  let reusedExistingAuthorization = false;
+  try {
+    const authResult = await createOrReuseDnsAuthorization(
+      deps.certManagerFactory,
+      { authorizationId, hostname },
+    );
+    dnsChallenge = authResult.challenge;
+    reusedExistingAuthorization = authResult.reused;
+
+    // --- 8. UPDATE row with challenge record + advance lifecycle state ---
+    const updatedRowsRaw = await deps.db
+      .update(regionCustomDomains)
+      .set({
+        lifecycleState: "awaiting_dns_challenge",
+        gcpDnsAuthorizationId: authResult.resourceName,
+        dnsChallengeRecordName: dnsChallenge.name,
+        dnsChallengeRecordValue: dnsChallenge.data,
+      })
+      .where(eq(regionCustomDomains.id, createdDomain.id))
+      .returning();
+    const updatedRows = updatedRowsRaw as RegionCustomDomain[];
+    if (updatedRows[0]) {
+      createdDomain = updatedRows[0];
+    }
+
+    await appendEventSafely(deps.db, {
+      domainId: createdDomain.id,
+      eventType: "dns_authorization_created",
+      fromState: "pending",
+      toState: "awaiting_dns_challenge",
+      actorUserId: input.userId,
+      details: {
+        gcp_dns_authorization_id: authResult.resourceName,
+        reused_existing: reusedExistingAuthorization,
+      },
+    });
+  } catch (err) {
+    // Leave the row in `pending` — the reconciler will retry Cert Manager.
+    return {
+      ok: false,
+      error: {
+        code: "internal_error",
+        message: formatError(err, "DnsAuthorization.Create failed"),
+      },
+    };
+  }
+
+  return {
+    ok: true,
+    value: {
+      domain: createdDomain,
+      dnsChallenge,
+      reusedExistingAuthorization,
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+interface EventRowInput {
+  domainId: string;
+  eventType: string;
+  fromState: string | null;
+  toState: string | null;
+  actorUserId: number;
+  details: Record<string, unknown>;
+}
+
+async function appendEventSafely(
+  db: RegistrationDbRunner,
+  row: EventRowInput,
+): Promise<void> {
+  try {
+    // We always call .returning() — Drizzle's insert().values() returns
+    // a "PgInsertBase" that is thenable, but calling `.returning()` is
+    // the simplest way to force the SQL to execute and return a typed
+    // Promise that tests can mirror.
+    await db
+      .insert(regionCustomDomainEvents)
+      .values({
+        domainId: row.domainId,
+        eventType: row.eventType,
+        fromState: row.fromState,
+        toState: row.toState,
+        actorUserId: row.actorUserId,
+        details: row.details,
+      })
+      .returning();
+  } catch (err) {
+    // Events are best-effort during registration. Don't break the user
+    // flow for an audit-log insert. The reconciler has its own event
+    // emission path (Decision 7) which will backfill.
+    console.warn(
+      "appendEventSafely: failed to insert audit event",
+      row.eventType,
+      err,
+    );
+  }
+}
+
+function formatError(err: unknown, prefix: string): string {
+  if (err instanceof Error) {
+    // Check for Postgres check_violation from the verified-binding trigger.
+    const code = (err as unknown as { code?: string }).code;
+    if (code === "23514") {
+      return `${prefix}: verified-binding trigger rejected insert (23514) — binding is not verified`;
+    }
+    return `${prefix}: ${err.message}`;
+  }
+  return `${prefix}: ${String(err)}`;
+}
+
+/**
+ * Stable structured-error → HTTP status mapping for route handlers.
+ */
+export function statusForRegisterError(error: RegisterDomainError): number {
+  switch (error.code) {
+    case "hostname_invalid":
+      return 400;
+    case "hostname_blocked":
+      return 409;
+    case "user_not_authorized":
+      return 403;
+    case "binding_missing":
+    case "binding_unverified":
+      return 412;
+    case "quota_exceeded":
+      return 429;
+    case "internal_error":
+      return 500;
+  }
+}
+
+/**
+ * Map a typed service error to the public JSON body shape. Never leaks
+ * internal messages — `internal_error` collapses to a generic code.
+ */
+export function publicErrorBody(
+  error: RegisterDomainError,
+): Record<string, unknown> {
+  switch (error.code) {
+    case "hostname_invalid":
+      return { error: "hostname_invalid", detail: error.detail };
+    case "hostname_blocked":
+      return { error: "hostname_blocked", reason: error.reason };
+    case "user_not_authorized":
+      return { error: "user_not_authorized" };
+    case "binding_missing":
+      return { error: "binding_missing" };
+    case "binding_unverified":
+      return {
+        error: "binding_unverified",
+        verification_state: error.verificationState,
+      };
+    case "quota_exceeded":
+      return {
+        error: "quota_exceeded",
+        quota: {
+          current: error.quota.current,
+          max: error.quota.max,
+        },
+      };
+    case "internal_error":
+      return { error: "internal_error" };
+  }
+}

--- a/apps/redirect-admin/src/lib/services/landing-data.ts
+++ b/apps/redirect-admin/src/lib/services/landing-data.ts
@@ -1,0 +1,115 @@
+/**
+ * Landing-page data loader. Given a logged-in user, assembles:
+ *
+ *   - their admin/editor orgs (via Supabase)
+ *   - for each org, the matching `org_region_bindings` row (may be
+ *     absent, may be unverified, may be verified)
+ *   - for each verified binding, a count of non-released
+ *     `region_custom_domains` rows
+ *
+ * Returns a typed view model the landing page can render with zero
+ * further business logic.
+ */
+
+import "server-only";
+
+import { and, count, inArray, ne } from "drizzle-orm";
+
+import {
+  orgRegionBindings,
+  regionCustomDomains,
+} from "@acme/redirect-platform-db";
+import type { OrgRegionBinding } from "@acme/redirect-platform-db";
+
+import type { RedirectAdminDb } from "../db-client";
+import type { SupabaseDb } from "../supabase-client";
+import { listUserAdminOrgs } from "./user-orgs";
+import type { BindingRole } from "./user-orgs";
+
+export type OrgBindingStatus =
+  | { kind: "no_binding" }
+  | { kind: "unverified"; binding: OrgRegionBinding }
+  | {
+      kind: "verified";
+      binding: OrgRegionBinding;
+      domainCount: number;
+    };
+
+export interface LandingOrgRow {
+  orgId: number;
+  orgName: string;
+  roleNames: BindingRole[];
+  status: OrgBindingStatus;
+}
+
+export interface LandingData {
+  rows: LandingOrgRow[];
+}
+
+export async function loadLandingData(
+  supabase: SupabaseDb,
+  redirectAdminDb: RedirectAdminDb,
+  userId: number,
+): Promise<LandingData> {
+  const orgs = await listUserAdminOrgs(supabase, userId);
+  if (orgs.length === 0) return { rows: [] };
+
+  const orgIds = orgs.map((o) => o.orgId);
+
+  const bindings = await redirectAdminDb
+    .select()
+    .from(orgRegionBindings)
+    .where(inArray(orgRegionBindings.orgId, orgIds));
+  const bindingsByOrgId = new Map<number, OrgRegionBinding>(
+    bindings.map((b) => [b.orgId, b]),
+  );
+
+  // Count non-released domains per verified-binding org in one query.
+  const verifiedOrgIds = bindings
+    .filter((b) => b.verificationState === "verified")
+    .map((b) => b.orgId);
+
+  const countByOrgId = new Map<number, number>();
+  if (verifiedOrgIds.length > 0) {
+    const countRows = await redirectAdminDb
+      .select({
+        orgId: regionCustomDomains.orgId,
+        value: count(regionCustomDomains.id),
+      })
+      .from(regionCustomDomains)
+      .where(
+        and(
+          inArray(regionCustomDomains.orgId, verifiedOrgIds),
+          ne(regionCustomDomains.lifecycleState, "released"),
+        ),
+      )
+      .groupBy(regionCustomDomains.orgId);
+    for (const r of countRows) {
+      countByOrgId.set(r.orgId, Number(r.value));
+    }
+  }
+
+  const rows: LandingOrgRow[] = orgs.map((org) => {
+    const binding = bindingsByOrgId.get(org.orgId);
+    let status: OrgBindingStatus;
+    if (!binding) {
+      status = { kind: "no_binding" };
+    } else if (binding.verificationState === "verified") {
+      status = {
+        kind: "verified",
+        binding,
+        domainCount: countByOrgId.get(org.orgId) ?? 0,
+      };
+    } else {
+      status = { kind: "unverified", binding };
+    }
+    return {
+      orgId: org.orgId,
+      orgName: org.orgName,
+      roleNames: org.roleNames,
+      status,
+    };
+  });
+
+  return { rows };
+}

--- a/apps/redirect-admin/src/lib/services/user-orgs.ts
+++ b/apps/redirect-admin/src/lib/services/user-orgs.ts
@@ -1,0 +1,111 @@
+/**
+ * User → orgs query layer. Reads from the f3-nation Supabase DB to
+ * resolve which orgs a given user has `admin` or `editor` role on.
+ *
+ * Used by the landing page to populate the "your orgs" list, and by
+ * the registration flow (indirectly via `checkUserRoleOnOrg`) to gate
+ * POST /api/domains/register.
+ *
+ * This is intentionally NOT using `packages/api/check-has-role-on-org.ts`
+ * — that helper requires a pre-populated `@acme/auth` Session with
+ * roles attached, which the apps/me-style HMAC session doesn't carry.
+ * Instead we query `rolesXUsersXOrg` + `roles` directly.
+ */
+
+import "server-only";
+
+import { and, eq, inArray } from "drizzle-orm";
+
+import { supabaseSchema } from "../supabase-client";
+import type { SupabaseDb } from "../supabase-client";
+
+const BINDING_ROLES = ["admin", "editor"] as const;
+export type BindingRole = (typeof BINDING_ROLES)[number];
+
+export interface UserOrgSummary {
+  orgId: number;
+  orgName: string;
+  roleNames: BindingRole[];
+}
+
+/**
+ * Find all orgs where the user has admin/editor. Returns an empty array
+ * for users with no matching roles (e.g. PAX who aren't region admins).
+ */
+export async function listUserAdminOrgs(
+  db: SupabaseDb,
+  userId: number,
+): Promise<UserOrgSummary[]> {
+  // 1. Fetch the user's roles on every org.
+  const roleRows = await db
+    .select({
+      orgId: supabaseSchema.rolesXUsersXOrg.orgId,
+      roleName: supabaseSchema.roles.name,
+    })
+    .from(supabaseSchema.rolesXUsersXOrg)
+    .innerJoin(
+      supabaseSchema.roles,
+      eq(supabaseSchema.roles.id, supabaseSchema.rolesXUsersXOrg.roleId),
+    )
+    .where(eq(supabaseSchema.rolesXUsersXOrg.userId, userId));
+
+  // 2. Keep only binding-capable roles, group by orgId.
+  const byOrgId = new Map<number, Set<BindingRole>>();
+  for (const row of roleRows) {
+    if (!isBindingRole(row.roleName)) continue;
+    const set = byOrgId.get(row.orgId) ?? new Set<BindingRole>();
+    set.add(row.roleName);
+    byOrgId.set(row.orgId, set);
+  }
+
+  if (byOrgId.size === 0) return [];
+
+  // 3. Hydrate org names in one query.
+  const orgRows = await db
+    .select({
+      id: supabaseSchema.orgs.id,
+      name: supabaseSchema.orgs.name,
+    })
+    .from(supabaseSchema.orgs)
+    .where(inArray(supabaseSchema.orgs.id, Array.from(byOrgId.keys())));
+
+  const orgNameById = new Map<number, string>(
+    orgRows.map((r) => [r.id, r.name]),
+  );
+
+  return Array.from(byOrgId.entries())
+    .map(([orgId, roles]) => ({
+      orgId,
+      orgName: orgNameById.get(orgId) ?? `org #${orgId}`,
+      roleNames: Array.from(roles),
+    }))
+    .sort((a, b) => a.orgName.localeCompare(b.orgName));
+}
+
+/**
+ * Does `userId` have an admin or editor role on `orgId`? Used by the
+ * registration POST handler as the authorization gate.
+ */
+export async function checkUserRoleOnOrg(
+  db: SupabaseDb,
+  params: { userId: number; orgId: number },
+): Promise<boolean> {
+  const rows = await db
+    .select({ roleName: supabaseSchema.roles.name })
+    .from(supabaseSchema.rolesXUsersXOrg)
+    .innerJoin(
+      supabaseSchema.roles,
+      eq(supabaseSchema.roles.id, supabaseSchema.rolesXUsersXOrg.roleId),
+    )
+    .where(
+      and(
+        eq(supabaseSchema.rolesXUsersXOrg.userId, params.userId),
+        eq(supabaseSchema.rolesXUsersXOrg.orgId, params.orgId),
+      ),
+    );
+  return rows.some((r) => isBindingRole(r.roleName));
+}
+
+function isBindingRole(name: string): name is BindingRole {
+  return name === "admin" || name === "editor";
+}

--- a/apps/redirect-admin/src/lib/state-presenter.ts
+++ b/apps/redirect-admin/src/lib/state-presenter.ts
@@ -1,0 +1,177 @@
+/**
+ * Pure presentation layer for `region_custom_domains.lifecycle_state`.
+ *
+ * This is a 100%-unit-testable function. It maps the 11 lifecycle states
+ * (R5 Decision 7) to user-facing strings plus an optional call-to-action.
+ * Route handlers and UI components call this — never hard-code state
+ * strings in JSX.
+ *
+ * When the `reconcilerError` payload is populated on the row, the
+ * presenter folds it in so the user sees WHY their domain is degraded,
+ * not just THAT it is.
+ */
+
+// Mirrors packages/redirect-platform-db/src/schema.ts `lifecycleState` enum.
+export type LifecycleState =
+  | "pending"
+  | "awaiting_dns_challenge"
+  | "validating"
+  | "provisioning_cert"
+  | "awaiting_probe"
+  | "awaiting_cutover"
+  | "active"
+  | "degraded"
+  | "tombstoned"
+  | "quarantined"
+  | "released";
+
+export interface ReconcilerError {
+  drift_kind?: string;
+  resource_type?: string;
+  resource_name?: string;
+  recoverable_from?: string[];
+  detected_at?: string;
+  reconciler_run_id?: string;
+}
+
+export type PresenterVariant = "info" | "warning" | "error" | "success";
+
+export interface PresenterActionable {
+  /** Short label for the primary button the user should click. */
+  button: string;
+  /** Either a same-app route (`/…`) or an external absolute URL. */
+  action: string;
+}
+
+export interface PresentedLifecycle {
+  state: LifecycleState;
+  label: string;
+  description: string;
+  variant: PresenterVariant;
+  actionable?: PresenterActionable;
+}
+
+/**
+ * Map a lifecycle state (and optional reconciler error payload) to the
+ * user-facing view model. Pure — no I/O, no globals.
+ */
+export function presentLifecycleState(
+  state: LifecycleState,
+  error?: ReconcilerError | null,
+): PresentedLifecycle {
+  switch (state) {
+    case "pending":
+      return {
+        state,
+        label: "Pending",
+        description:
+          "Your registration was accepted and is queued for DNS challenge setup. This usually completes within a minute — refresh to check progress.",
+        variant: "info",
+      };
+
+    case "awaiting_dns_challenge":
+      return {
+        state,
+        label: "Awaiting DNS Challenge",
+        description:
+          "We created a DNS challenge record for your hostname. Add the CNAME shown below to your DNS zone so we can issue a TLS certificate for you.",
+        variant: "warning",
+        actionable: {
+          button: "View DNS Records",
+          action: "details",
+        },
+      };
+
+    case "validating":
+      return {
+        state,
+        label: "Validating DNS",
+        description:
+          "Your CNAME record is being validated by Google Certificate Manager. This normally completes within 10–15 minutes.",
+        variant: "info",
+      };
+
+    case "provisioning_cert":
+      return {
+        state,
+        label: "Issuing Certificate",
+        description:
+          "DNS validation succeeded. A TLS certificate is being issued for your hostname — no action needed on your side.",
+        variant: "info",
+      };
+
+    case "awaiting_probe":
+      return {
+        state,
+        label: "Awaiting Health Probe",
+        description:
+          "Your certificate is attached to the load balancer. We're waiting for multi-region health probes to confirm the endpoint is reachable before marking this safe to cut over.",
+        variant: "info",
+      };
+
+    case "awaiting_cutover":
+      return {
+        state,
+        label: "Safe to Cut Over",
+        description:
+          "All health probes succeeded. You can now update your apex DNS record to point at the F3 redirect load balancer — see the details view for the exact A record value.",
+        variant: "success",
+        actionable: {
+          button: "View Cutover Instructions",
+          action: "details",
+        },
+      };
+
+    case "active":
+      return {
+        state,
+        label: "Active",
+        description:
+          "Your hostname is live and serving redirects. Nothing more to do — we will renew the certificate automatically.",
+        variant: "success",
+      };
+
+    case "degraded": {
+      const driftKind = error?.drift_kind ?? "unknown";
+      const resource =
+        error?.resource_name ?? error?.resource_type ?? "a GCP resource";
+      return {
+        state,
+        label: "Degraded — Attention Needed",
+        description: `The reconciler detected drift on ${resource} (${driftKind}). Redirects may still be serving from the edge cache; follow the recovery steps to restore parity.`,
+        variant: "error",
+        actionable: {
+          button: "View Recovery Steps",
+          action: "details",
+        },
+      };
+    }
+
+    case "tombstoned":
+      return {
+        state,
+        label: "Tombstoned",
+        description:
+          "You marked this domain for removal. The reconciler is tearing down its GCP resources and will release the hostname for reuse shortly.",
+        variant: "warning",
+      };
+
+    case "quarantined":
+      return {
+        state,
+        label: "Quarantined",
+        description:
+          "This hostname is quarantined (a platform admin action). It cannot be re-registered until the quarantine lifts — contact platform support if this is unexpected.",
+        variant: "error",
+      };
+
+    case "released":
+      return {
+        state,
+        label: "Released",
+        description:
+          "This domain has been fully released. The hostname is free to re-register by any org whose binding is verified.",
+        variant: "info",
+      };
+  }
+}

--- a/apps/redirect-admin/src/lib/supabase-client.ts
+++ b/apps/redirect-admin/src/lib/supabase-client.ts
@@ -1,0 +1,53 @@
+/**
+ * Read-side client for the f3-nation Supabase DB. We intentionally do
+ * NOT import `@acme/db/client` because that module eagerly loads
+ * `@acme/env`, which pulls in the full monorepo env schema — way more
+ * than this app needs. Instead we instantiate our own Drizzle handle
+ * against the same schema using `DATABASE_URL` directly.
+ *
+ * Scope: read-only queries on `orgs`, `rolesXUsersXOrg`, and `roles`
+ * for populating the landing page's "orgs you admin" list. The admin
+ * UI never WRITES to Supabase; that's owned by the F3 Nation API.
+ */
+
+import "server-only";
+
+import { schema as supabaseSchema } from "@acme/db";
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
+import type { Sql } from "postgres";
+
+import { env } from "@/env";
+
+export type SupabaseDb = ReturnType<typeof drizzle<typeof supabaseSchema>>;
+
+export interface SupabaseDbHandle {
+  db: SupabaseDb;
+  client: Sql;
+  end(): Promise<void>;
+}
+
+let _cached: SupabaseDbHandle | null = null;
+
+export function getSupabaseDb(): SupabaseDbHandle {
+  if (_cached) return _cached;
+  const connectionString = env().supabaseConnectionString;
+  const client = postgres(connectionString, {
+    // PgBouncer compatibility in dev; prod is handled by the f3-nation
+    // deploy stack.
+    ssl: false,
+    max: 4,
+  });
+  const db = drizzle(client, { schema: supabaseSchema });
+  _cached = {
+    db,
+    client,
+    async end() {
+      await client.end({ timeout: 5 });
+      _cached = null;
+    },
+  };
+  return _cached;
+}
+
+export { supabaseSchema };

--- a/apps/redirect-admin/src/lib/validator-client.ts
+++ b/apps/redirect-admin/src/lib/validator-client.ts
@@ -1,0 +1,215 @@
+/**
+ * HTTP client for the internal region-binding validator (R5 Decision 11).
+ *
+ * Matches the route contract defined by
+ * `apps/api/src/app/api/internal/region-binding/validate/route.ts` on the
+ * `feat/r5-region-binding-validator` branch:
+ *
+ *   GET /api/internal/region-binding/validate
+ *     ?org_id=<int>&pax_vault_region_id=<string>&region_slug=<string>
+ *     &calling_user_id=<int>
+ *   Authorization: Bearer <REGION_BINDING_VALIDATOR_S2S_SECRET>
+ *
+ * Returns typed successes + typed errors so route handlers can branch
+ * cleanly and surface user-friendly messages. NEVER logs the shared
+ * secret or the full Authorization header.
+ *
+ * F3R5_012 note: the registration flow does NOT use this client on its
+ * happy path — by the time a user registers a domain the binding is
+ * already verified and the trigger enforces that at insert time. This
+ * module exists now so F3R5_013 (binding verification UI) can import it
+ * without touching the scaffold.
+ */
+
+export interface ValidatorQueryInput {
+  orgId: number;
+  paxVaultRegionId: string;
+  regionSlug: string;
+  callingUserId: number;
+}
+
+export interface ValidatorOrgFacts {
+  id: number;
+  name: string;
+  last_modified: string;
+  admin_count: number;
+  caller_roles: string[];
+}
+
+export interface ValidatorPaxVaultFacts {
+  region_id: string;
+  region_name: string;
+}
+
+export interface ValidatorRegionPageFacts {
+  slug: string;
+}
+
+export interface ValidatorResponseBody {
+  org: ValidatorOrgFacts;
+  pax_vault: ValidatorPaxVaultFacts;
+  f3_region_pages: ValidatorRegionPageFacts;
+  cross_check: {
+    triple_matches: boolean;
+    match_strategy: "exact" | "fuzzy" | "failed";
+  };
+  validated_at: string;
+}
+
+export interface ValidatorTripleMismatchDetail {
+  field: string;
+  sources: Record<string, string>;
+  reason: string;
+}
+
+// ---------------------------------------------------------------------------
+// Typed errors
+// ---------------------------------------------------------------------------
+
+/** Thrown when the validator itself is down / unreachable / 5xx. */
+export class ValidatorUnavailableError extends Error {
+  constructor(
+    message: string,
+    public cause?: unknown,
+  ) {
+    super(message);
+    this.name = "ValidatorUnavailableError";
+  }
+}
+
+/** Thrown when the validator replies 403 (caller lacks role on org). */
+export class CallerNotAuthorizedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "CallerNotAuthorizedError";
+  }
+}
+
+/** Thrown when the validator replies 422 with a triangulation failure. */
+export class TripleMismatchError extends Error {
+  constructor(
+    message: string,
+    public mismatches: ValidatorTripleMismatchDetail[],
+  ) {
+    super(message);
+    this.name = "TripleMismatchError";
+  }
+}
+
+/** Thrown when the validator replies 404 (org not in f3-nation DB). */
+export class OrgNotFoundError extends Error {
+  constructor(orgId: number) {
+    super(`org ${orgId} not found`);
+    this.name = "OrgNotFoundError";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Client
+// ---------------------------------------------------------------------------
+
+export interface ValidatorClientConfig {
+  baseUrl: string;
+  s2sSecret: string;
+  timeoutMs?: number;
+  /** Injected for tests — defaults to global `fetch`. */
+  fetchImpl?: typeof fetch;
+}
+
+export class ValidatorClient {
+  private readonly config: Required<
+    Omit<ValidatorClientConfig, "fetchImpl">
+  > & {
+    fetchImpl: typeof fetch;
+  };
+
+  constructor(config: ValidatorClientConfig) {
+    this.config = {
+      baseUrl: config.baseUrl.replace(/\/+$/, ""),
+      s2sSecret: config.s2sSecret,
+      timeoutMs: config.timeoutMs ?? 10_000,
+      fetchImpl: config.fetchImpl ?? fetch,
+    };
+  }
+
+  /**
+   * Call the internal validator. Throws typed errors on non-2xx, returns
+   * the parsed body on success.
+   */
+  async validate(input: ValidatorQueryInput): Promise<ValidatorResponseBody> {
+    const url = new URL(
+      "/api/internal/region-binding/validate",
+      this.config.baseUrl,
+    );
+    url.searchParams.set("org_id", String(input.orgId));
+    url.searchParams.set("pax_vault_region_id", input.paxVaultRegionId);
+    url.searchParams.set("region_slug", input.regionSlug);
+    url.searchParams.set("calling_user_id", String(input.callingUserId));
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.config.timeoutMs);
+
+    let res: Response;
+    try {
+      res = await this.config.fetchImpl(url.toString(), {
+        method: "GET",
+        headers: {
+          Authorization: `Bearer ${this.config.s2sSecret}`,
+          Accept: "application/json",
+        },
+        signal: controller.signal,
+      });
+    } catch (err) {
+      throw new ValidatorUnavailableError(
+        "validator fetch failed (network or timeout)",
+        err,
+      );
+    } finally {
+      clearTimeout(timer);
+    }
+
+    if (res.status >= 500) {
+      throw new ValidatorUnavailableError(`validator returned ${res.status}`);
+    }
+
+    let body: unknown;
+    try {
+      body = await res.json();
+    } catch (err) {
+      throw new ValidatorUnavailableError(
+        "validator returned non-JSON body",
+        err,
+      );
+    }
+
+    if (res.status === 404) {
+      throw new OrgNotFoundError(input.orgId);
+    }
+
+    if (res.status === 403) {
+      throw new CallerNotAuthorizedError(
+        "calling user is not authorized on this org",
+      );
+    }
+
+    if (res.status === 422) {
+      const detail = (
+        body as {
+          detail?: { mismatches?: ValidatorTripleMismatchDetail[] };
+        }
+      ).detail;
+      throw new TripleMismatchError(
+        "validator triple-mismatch",
+        detail?.mismatches ?? [],
+      );
+    }
+
+    if (!res.ok) {
+      throw new ValidatorUnavailableError(
+        `validator returned unexpected status ${res.status}`,
+      );
+    }
+
+    return body as ValidatorResponseBody;
+  }
+}

--- a/apps/redirect-admin/src/test/server-only-stub.ts
+++ b/apps/redirect-admin/src/test/server-only-stub.ts
@@ -1,0 +1,5 @@
+// Vitest stub for `server-only`. The real module throws on import so
+// that a client bundle can never ship server-only code; tests don't
+// have that concern, so this empty module lets the server modules be
+// imported without side effects.
+export {};

--- a/apps/redirect-admin/tailwind.config.ts
+++ b/apps/redirect-admin/tailwind.config.ts
@@ -1,0 +1,52 @@
+import type { Config } from "tailwindcss";
+import tailwindcssAnimate from "tailwindcss-animate";
+
+export default {
+  darkMode: "class",
+  content: [
+    "./src/pages/**/*.{js,ts,jsx,tsx,mdx}",
+    "./src/components/**/*.{js,ts,jsx,tsx,mdx}",
+    "./src/app/**/*.{js,ts,jsx,tsx,mdx}",
+  ],
+  theme: {
+    extend: {
+      colors: {
+        border: "hsl(var(--border))",
+        input: "hsl(var(--input))",
+        ring: "hsl(var(--ring))",
+        background: "hsl(var(--background))",
+        foreground: "hsl(var(--foreground))",
+        primary: {
+          DEFAULT: "hsl(var(--primary))",
+          foreground: "hsl(var(--primary-foreground))",
+        },
+        secondary: {
+          DEFAULT: "hsl(var(--secondary))",
+          foreground: "hsl(var(--secondary-foreground))",
+        },
+        destructive: {
+          DEFAULT: "hsl(var(--destructive))",
+          foreground: "hsl(var(--destructive-foreground))",
+        },
+        muted: {
+          DEFAULT: "hsl(var(--muted))",
+          foreground: "hsl(var(--muted-foreground))",
+        },
+        accent: {
+          DEFAULT: "hsl(var(--accent))",
+          foreground: "hsl(var(--accent-foreground))",
+        },
+        card: {
+          DEFAULT: "hsl(var(--card))",
+          foreground: "hsl(var(--card-foreground))",
+        },
+      },
+      borderRadius: {
+        lg: "var(--radius)",
+        md: "calc(var(--radius) - 2px)",
+        sm: "calc(var(--radius) - 4px)",
+      },
+    },
+  },
+  plugins: [tailwindcssAnimate],
+} satisfies Config;

--- a/apps/redirect-admin/tsconfig.json
+++ b/apps/redirect-admin/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "types": ["node", "react", "react-dom"],
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules", "vitest.config.ts", "vitest.setup.ts"]
+}

--- a/apps/redirect-admin/vitest.config.ts
+++ b/apps/redirect-admin/vitest.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig } from "vitest/config";
+import react from "@vitejs/plugin-react";
+import path from "path";
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.{ts,tsx}", "__tests__/**/*.test.{ts,tsx}"],
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "json", "html"],
+      reportsDirectory: "./coverage",
+    },
+  },
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+      // `server-only` throws during unit tests because it's designed to
+      // guard against client-bundle imports. We alias it to an empty
+      // module so modules that import it can still be exercised.
+      "server-only": path.resolve(__dirname, "./src/test/server-only-stub.ts"),
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -602,6 +602,97 @@ importers:
         specifier: ^0.3.3
         version: 0.3.3(vitest@1.6.1(@types/node@20.19.39)(jsdom@24.1.3)(terser@5.46.1))
 
+  apps/redirect-admin:
+    dependencies:
+      '@acme/db':
+        specifier: workspace:*
+        version: link:../../packages/db
+      '@acme/redirect-platform-db':
+        specifier: workspace:*
+        version: link:../../packages/redirect-platform-db
+      '@acme/sso':
+        specifier: workspace:*
+        version: link:../../packages/sso
+      '@google-cloud/certificate-manager':
+        specifier: ^2.1.1
+        version: 2.1.1
+      clsx:
+        specifier: ^2.1.0
+        version: 2.1.1
+      drizzle-orm:
+        specifier: ^0.39.3
+        version: 0.39.3(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.20.0)(postgres@3.4.9)
+      next:
+        specifier: ^15.3.6
+        version: 15.5.14(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      postgres:
+        specifier: ^3.4.3
+        version: 3.4.9
+      react:
+        specifier: 18.3.1
+        version: 18.3.1
+      react-dom:
+        specifier: 18.3.1
+        version: 18.3.1(react@18.3.1)
+      server-only:
+        specifier: ^0.0.1
+        version: 0.0.1
+      tailwind-merge:
+        specifier: ^2.2.1
+        version: 2.6.1
+      zod:
+        specifier: ^3.25.8
+        version: 3.25.76
+    devDependencies:
+      '@acme/eslint-config':
+        specifier: workspace:^0.2.0
+        version: link:../../tooling/eslint
+      '@acme/prettier-config':
+        specifier: workspace:^0.1.0
+        version: link:../../tooling/prettier
+      '@testing-library/jest-dom':
+        specifier: ^6.4.2
+        version: 6.9.1
+      '@types/node':
+        specifier: ^20.11.13
+        version: 20.19.39
+      '@types/react':
+        specifier: ^18.3.1
+        version: 18.3.28
+      '@types/react-dom':
+        specifier: ^18.3.1
+        version: 18.3.7(@types/react@18.3.28)
+      '@vitejs/plugin-react':
+        specifier: ^4.2.1
+        version: 4.7.0(vite@5.4.21(@types/node@20.19.39)(terser@5.46.1))
+      '@vitest/coverage-v8':
+        specifier: ^1.5.0
+        version: 1.6.1(vitest@1.6.1(@types/node@20.19.39)(jsdom@24.1.3)(terser@5.46.1))
+      autoprefixer:
+        specifier: ^10.4.17
+        version: 10.4.27(postcss@8.5.8)
+      eslint:
+        specifier: ^8.56.0
+        version: 8.57.1
+      postcss:
+        specifier: ^8.4.35
+        version: 8.5.8
+      prettier:
+        specifier: 3.2.5
+        version: 3.2.5
+      tailwindcss:
+        specifier: ^3.4.1
+        version: 3.4.19(tsx@4.21.0)
+      tailwindcss-animate:
+        specifier: ^1.0.7
+        version: 1.0.7(tailwindcss@3.4.19(tsx@4.21.0))
+      typescript:
+        specifier: 5.3.3
+        version: 5.3.3
+      vitest:
+        specifier: ^1.5.0
+        version: 1.6.1(@types/node@20.19.39)(jsdom@24.1.3)(terser@5.46.1)
+
   packages/api:
     dependencies:
       '@acme/auth':
@@ -2147,6 +2238,19 @@ packages:
   '@formkit/auto-animate@0.8.4':
     resolution: {integrity: sha512-DHHC01EJ1p70Q0z/ZFRBIY8NDnmfKccQoyoM84Tgb6omLMat6jivCdf272Y8k3nf4Lzdin/Y4R9q8uFtU0GbnA==}
 
+  '@google-cloud/certificate-manager@2.1.1':
+    resolution: {integrity: sha512-iuoiR+P4oTrcJBgaNjP///LiZENg7dck45kUox086lyvCPyineQY1hyIruM9Dq4arqTwMoDAFPQwg7XCSh5AtQ==}
+    engines: {node: '>=18'}
+
+  '@grpc/grpc-js@1.14.3':
+    resolution: {integrity: sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==}
+    engines: {node: '>=12.10.0'}
+
+  '@grpc/proto-loader@0.8.0':
+    resolution: {integrity: sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ==}
+    engines: {node: '>=6'}
+    hasBin: true
+
   '@hookform/resolvers@3.10.0':
     resolution: {integrity: sha512-79Dv+3mDF7i+2ajj7SkypSKHhl1cbln1OGavqrsF7p6mbUv11xpqpacPsGDCTRvCSjEEIez2ef1NveSVL3b0Ag==}
     peerDependencies:
@@ -2509,6 +2613,9 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
+
+  '@js-sdsl/ordered-map@4.4.2':
+    resolution: {integrity: sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==}
 
   '@next/env@15.5.14':
     resolution: {integrity: sha512-aXeirLYuASxEgi4X4WhfXsShCFxWDfNn/8ZeC5YXAS2BB4A8FJi1kwwGL6nvMVboE7fZCzmJPNdMvVHc8JpaiA==}
@@ -2938,6 +3045,36 @@ packages:
     resolution: {integrity: sha512-mrZOev24EDhnefmnZX7WVVT7v+r9LttPRqf54ONvj6re4XMF7wFTpK2tLJi4XHB7fFp/6xhYbgRel8YV7gQiyA==}
     peerDependencies:
       '@opentelemetry/api': ^1.8
+
+  '@protobufjs/aspromise@1.1.2':
+    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
+
+  '@protobufjs/base64@1.1.2':
+    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
+
+  '@protobufjs/codegen@2.0.4':
+    resolution: {integrity: sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==}
+
+  '@protobufjs/eventemitter@1.1.0':
+    resolution: {integrity: sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==}
+
+  '@protobufjs/fetch@1.1.0':
+    resolution: {integrity: sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==}
+
+  '@protobufjs/float@1.0.2':
+    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
+
+  '@protobufjs/inquire@1.1.0':
+    resolution: {integrity: sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==}
+
+  '@protobufjs/path@1.1.2':
+    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
+
+  '@protobufjs/pool@1.1.0':
+    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
+
+  '@protobufjs/utf8@1.1.0':
+    resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
 
   '@radix-ui/number@1.0.1':
     resolution: {integrity: sha512-T5gIdVO2mmPW3NNhjNgEP3cqMXjXL9UbO0BzWcXfvdBs+BohbQxvd/K5hSVKmn9/lbTdsQVKbUcP5WLCwvUbBg==}
@@ -5452,6 +5589,9 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
+  duplexify@4.1.3:
+    resolution: {integrity: sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==}
+
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
@@ -5476,6 +5616,9 @@ packages:
 
   encoding-sniffer@0.2.1:
     resolution: {integrity: sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==}
+
+  end-of-stream@1.4.5:
+    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
   enhanced-resolve@5.20.1:
     resolution: {integrity: sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==}
@@ -6014,6 +6157,10 @@ packages:
 
   google-auth-library@10.6.2:
     resolution: {integrity: sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==}
+    engines: {node: '>=18'}
+
+  google-gax@5.0.6:
+    resolution: {integrity: sha512-1kGbqVQBZPAAu4+/R1XxPQKP0ydbNYoLAr4l0ZO2bMV0kLyLW4I1gAk++qBLWt7DPORTzmWRMsCZe86gDjShJA==}
     engines: {node: '>=18'}
 
   google-logging-utils@1.1.3:
@@ -6725,6 +6872,9 @@ packages:
   log-symbols@6.0.0:
     resolution: {integrity: sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==}
     engines: {node: '>=18'}
+
+  long@5.3.2:
+    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
 
   longest@2.0.1:
     resolution: {integrity: sha512-Ajzxb8CM6WAnFjgiloPsI3bF+WCxcvhdIG3KNA2KN962+tdBsHcuQ4k4qX/EcS/2CRkcc0iAkR956Nib6aXU/Q==}
@@ -7464,6 +7614,14 @@ packages:
   proto-list@1.2.4:
     resolution: {integrity: sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==}
 
+  proto3-json-serializer@3.0.4:
+    resolution: {integrity: sha512-E1sbAYg3aEbXrq0n1ojJkRHQJGE1kaE/O6GLA94y8rnJBfgvOPTOd1b9hOceQK1FFZI9qMh1vBERCyO2ifubcw==}
+    engines: {node: '>=18'}
+
+  protobufjs@7.5.4:
+    resolution: {integrity: sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==}
+    engines: {node: '>=12.0.0'}
+
   protocols@2.0.2:
     resolution: {integrity: sha512-hHVTzba3wboROl0/aWRRG9dMytgH6ow//STBZh43l/wQgmMhYhOFi0EHWAPtoCz9IAUymsyP0TSBHkhgMEGNnQ==}
 
@@ -7713,6 +7871,10 @@ packages:
     resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
     engines: {node: '>=18'}
 
+  retry-request@8.0.2:
+    resolution: {integrity: sha512-JzFPAfklk1kjR1w76f0QOIhoDkNkSqW8wYKT08n9yysTmZfB+RQ2QoXoTAeOi1HD9ZipTyTAZg3c4pM/jeqgSw==}
+    engines: {node: '>=18'}
+
   retry@0.13.1:
     resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
     engines: {node: '>= 4'}
@@ -7724,6 +7886,10 @@ packages:
   rimraf@3.0.2:
     resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
     deprecated: Rimraf versions prior to v4 are no longer supported
+    hasBin: true
+
+  rimraf@5.0.10:
+    resolution: {integrity: sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==}
     hasBin: true
 
   rollup@4.60.1:
@@ -7938,6 +8104,12 @@ packages:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
     engines: {node: '>= 0.4'}
 
+  stream-events@1.0.5:
+    resolution: {integrity: sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg==}
+
+  stream-shift@1.0.3:
+    resolution: {integrity: sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==}
+
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
@@ -8025,6 +8197,9 @@ packages:
   stubborn-utils@1.0.2:
     resolution: {integrity: sha512-zOh9jPYI+xrNOyisSelgym4tolKTJCQd5GBhK0+0xJvcYDcwlOoxF/rnFKQ2KRZknXSG9jWAp66fwP6AxN9STg==}
 
+  stubs@3.0.0:
+    resolution: {integrity: sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw==}
+
   styled-jsx@5.1.6:
     resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
     engines: {node: '>= 12.0.0'}
@@ -8092,6 +8267,10 @@ packages:
   tapable@2.3.2:
     resolution: {integrity: sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==}
     engines: {node: '>=6'}
+
+  teeny-request@10.1.2:
+    resolution: {integrity: sha512-Xj0ZAQ0CeuQn6UxCDPLbFRlgcSTUEyO3+wiepr2grjIjyL/lMMs1Z4OwXn8kLvn/V1OuaEP0UY7Na6UDNNsYrQ==}
+    engines: {node: '>=18'}
 
   terser-webpack-plugin@5.4.0:
     resolution: {integrity: sha512-Bn5vxm48flOIfkdl5CaD2+1CiUVbonWQ3KQPyP7/EuIl9Gbzq/gQFOzaMFUEgVjB1396tcK0SG8XcNJ/2kDH8g==}
@@ -9396,6 +9575,24 @@ snapshots:
 
   '@formkit/auto-animate@0.8.4': {}
 
+  '@google-cloud/certificate-manager@2.1.1':
+    dependencies:
+      google-gax: 5.0.6
+    transitivePeerDependencies:
+      - supports-color
+
+  '@grpc/grpc-js@1.14.3':
+    dependencies:
+      '@grpc/proto-loader': 0.8.0
+      '@js-sdsl/ordered-map': 4.4.2
+
+  '@grpc/proto-loader@0.8.0':
+    dependencies:
+      lodash.camelcase: 4.3.0
+      long: 5.3.2
+      protobufjs: 7.5.4
+      yargs: 17.7.2
+
   '@hookform/resolvers@3.10.0(react-hook-form@7.72.1(react@18.3.1))':
     dependencies:
       react-hook-form: 7.72.1(react@18.3.1)
@@ -9692,6 +9889,8 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@js-sdsl/ordered-map@4.4.2': {}
 
   '@next/env@15.5.14': {}
 
@@ -10241,6 +10440,29 @@ snapshots:
       '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
     transitivePeerDependencies:
       - supports-color
+
+  '@protobufjs/aspromise@1.1.2': {}
+
+  '@protobufjs/base64@1.1.2': {}
+
+  '@protobufjs/codegen@2.0.4': {}
+
+  '@protobufjs/eventemitter@1.1.0': {}
+
+  '@protobufjs/fetch@1.1.0':
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/inquire': 1.1.0
+
+  '@protobufjs/float@1.0.2': {}
+
+  '@protobufjs/inquire@1.1.0': {}
+
+  '@protobufjs/path@1.1.2': {}
+
+  '@protobufjs/pool@1.1.0': {}
+
+  '@protobufjs/utf8@1.1.0': {}
 
   '@radix-ui/number@1.0.1':
     dependencies:
@@ -12914,6 +13136,13 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
+  duplexify@4.1.3:
+    dependencies:
+      end-of-stream: 1.4.5
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+      stream-shift: 1.0.3
+
   eastasianwidth@0.2.0: {}
 
   ecdsa-sig-formatter@1.0.11:
@@ -12934,6 +13163,10 @@ snapshots:
     dependencies:
       iconv-lite: 0.6.3
       whatwg-encoding: 3.1.1
+
+  end-of-stream@1.4.5:
+    dependencies:
+      once: 1.4.0
 
   enhanced-resolve@5.20.1:
     dependencies:
@@ -13779,6 +14012,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  google-gax@5.0.6:
+    dependencies:
+      '@grpc/grpc-js': 1.14.3
+      '@grpc/proto-loader': 0.8.0
+      duplexify: 4.1.3
+      google-auth-library: 10.6.2
+      google-logging-utils: 1.1.3
+      node-fetch: 3.3.2
+      object-hash: 3.0.0
+      proto3-json-serializer: 3.0.4
+      protobufjs: 7.5.4
+      retry-request: 8.0.2
+      rimraf: 5.0.10
+    transitivePeerDependencies:
+      - supports-color
+
   google-logging-utils@1.1.3: {}
 
   gopd@1.2.0: {}
@@ -14504,6 +14753,8 @@ snapshots:
       chalk: 5.4.1
       is-unicode-supported: 1.3.0
 
+  long@5.3.2: {}
+
   longest@2.0.1: {}
 
   loose-envify@1.4.0:
@@ -15176,6 +15427,25 @@ snapshots:
 
   proto-list@1.2.4: {}
 
+  proto3-json-serializer@3.0.4:
+    dependencies:
+      protobufjs: 7.5.4
+
+  protobufjs@7.5.4:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.4
+      '@protobufjs/eventemitter': 1.1.0
+      '@protobufjs/fetch': 1.1.0
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/inquire': 1.1.0
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.0
+      '@types/node': 20.19.39
+      long: 5.3.2
+
   protocols@2.0.2: {}
 
   proxy-agent@6.5.0:
@@ -15471,6 +15741,13 @@ snapshots:
       onetime: 7.0.0
       signal-exit: 4.1.0
 
+  retry-request@8.0.2:
+    dependencies:
+      extend: 3.0.2
+      teeny-request: 10.1.2
+    transitivePeerDependencies:
+      - supports-color
+
   retry@0.13.1: {}
 
   reusify@1.1.0: {}
@@ -15478,6 +15755,10 @@ snapshots:
   rimraf@3.0.2:
     dependencies:
       glob: 7.2.3
+
+  rimraf@5.0.10:
+    dependencies:
+      glob: 10.3.10
 
   rollup@4.60.1:
     dependencies:
@@ -15745,6 +16026,12 @@ snapshots:
       es-errors: 1.3.0
       internal-slot: 1.1.0
 
+  stream-events@1.0.5:
+    dependencies:
+      stubs: 3.0.0
+
+  stream-shift@1.0.3: {}
+
   string-width@4.2.3:
     dependencies:
       emoji-regex: 8.0.0
@@ -15853,6 +16140,8 @@ snapshots:
 
   stubborn-utils@1.0.2: {}
 
+  stubs@3.0.0: {}
+
   styled-jsx@5.1.6(@babel/core@7.29.0)(react@18.3.1):
     dependencies:
       client-only: 0.0.1
@@ -15936,6 +16225,15 @@ snapshots:
       - yaml
 
   tapable@2.3.2: {}
+
+  teeny-request@10.1.2:
+    dependencies:
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      node-fetch: 3.3.2
+      stream-events: 1.0.5
+    transitivePeerDependencies:
+      - supports-color
 
   terser-webpack-plugin@5.4.0(webpack@5.105.4):
     dependencies:


### PR DESCRIPTION
## Summary

R5 Decision 5 — the self-serve admin UI for F3 region admins to register custom domains. Stacks on [#238](https://github.com/F3-Nation/f3-nation/pull/238) (schema package).

- **`@acme/redirect-admin`** — new Next.js 15 App Router app with SSO (copied from `apps/me` via `git show feat/me:...`)
- **Registration flow** — form → validator API (stubbed for F3R5_013) → quota check → `INSERT region_custom_domains` → Certificate Manager `DnsAuthorization.Create` → display CNAME instructions
- **Registration relies on the `trg_rcd_verified_binding` DB trigger** — app-layer binding-state check is a fast-UX early 412 only, the database is the authority
- **Landing page + domain listing + DELETE (tombstone) handler**
- Pure functions for quota check, hostname validation, and state presentation (all 11 lifecycle states)
- **66/66 tests** (target was 20+)

## Stack

1. [#238](https://github.com/F3-Nation/f3-nation/pull/238) — `feat/r5-redirect-platform-db` (base)
2. **This PR** — `feat/r5-redirect-admin`
3. Upcoming (F3R5_013) — `feat/r5-admin-verification` — Decision 9 binding verification evidence UI + Decision 6 degraded-state recovery flow

## Deliberate out-of-scope for this PR (handled in F3R5_013)

- Decision 9 binding verification evidence UI — the landing page stubs unverified bindings with "pending verification (F3R5_013 coming soon)" but exposes the full `bindTimeValidatorSnapshot` so the next PR needs zero data-layer changes
- Decision 6 degraded-state recovery flow — the `state-presenter` covers degraded labels; the action buttons land in F3R5_013

## Agent decisions worth flagging

1. **Did NOT use `@acme/db/client`** — it eagerly pulls `@acme/env` which requires every monorepo env var. Agent instantiated its own Drizzle handle against the same `@acme/db` schema using `DATABASE_URL` directly. Reasonable for an admin UI with narrow DB needs.
2. **Did NOT use `check-has-role-on-org` from `packages/api`** — it requires a pre-populated `@acme/auth` Session with roles attached; the apps/me SSO cookie does not carry roles. Agent replaced with a direct `rolesXUsersXOrg + roles` query matching the pattern the validator endpoint (PR #239) uses. Flagged as a follow-up to unify via `checkHasRoleOnOrgByUserId`.
3. **No SQL transaction wrapping the two-statement registration INSERT sequence** — the injected `RegistrationDbRunner` type is deliberately loose for testability. The `trg_rcd_verified_binding` trigger fires on the first INSERT so there's no orphan-row risk. Inline comment explains.
4. **vitest `server-only` stub** — tests importing server modules would otherwise explode at import time. Aliased to an empty stub via vitest.config.ts.

## Test plan

- [x] 66/66 tests pass across 7 test files (state presenter, quota, validator client, cert manager, domain registration, hostname validation, env)
- [x] `typecheck`, `lint`, `build` clean
- [x] Whole-repo turbo typecheck + lint pass
- [x] Trigger-enforced binding check path covered by test (asserts `code === "23514"` is handled)
- [ ] End-to-end: register a domain against a real Neon dev branch + real Certificate Manager
- [ ] Integration test for the full registration → reconciler pickup → cert-issued flow

## Known pre-existing issue (not caused by this PR)

`f3-nation-api` build fails on base branch due to `/docs/openapi.json` route needing a real `DATABASE_URL` at static-page-collection time. Verified identical on the base branch. Tracked for a separate cleanup task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)