### PR TITLE
R5 Phase 0: GHA image build workflow + WIF setup script

### DIFF
--- a/.github/workflows/r5-build-push-images-README.md
+++ b/.github/workflows/r5-build-push-images-README.md
@@ -1,0 +1,189 @@
+# R5 Build & Push Images
+
+Workflow: [`r5-build-push-images.yml`](./r5-build-push-images.yml)
+
+Builds and pushes Docker images for the three R5 apps in the multi-tenant
+redirect platform to Google Artifact Registry:
+
+| App              | Package                | Dockerfile                       |
+| ---------------- | ---------------------- | -------------------------------- |
+| `runtime`        | `@acme/runtime`        | `apps/runtime/Dockerfile`        |
+| `reconciler`     | `@acme/reconciler`     | `apps/reconciler/Dockerfile`     |
+| `redirect-admin` | `@acme/redirect-admin` | `apps/redirect-admin/Dockerfile` |
+
+All three Dockerfiles use `turbo prune --docker` against the repo root as
+the build context — the workflow matches that by running `docker buildx
+build` with `context: .` and `file: apps/<app>/Dockerfile`.
+
+Images land at:
+
+```
+us-central1-docker.pkg.dev/f3-redirects/f3-redirect-platform/<app>:<git-sha>
+us-central1-docker.pkg.dev/f3-redirects/f3-redirect-platform/<app>:latest
+```
+
+## Triggers
+
+- **`push`** on `feat/r5-runtime`, `feat/r5-reconciler-ops-5-8`,
+  `feat/r5-redirect-admin`, `feat/r5-admin-verification`, and `dev`, scoped
+  to paths under `apps/runtime/**`, `apps/reconciler/**`,
+  `apps/redirect-admin/**`, or `packages/redirect-platform-db/**`.
+  `dorny/paths-filter` narrows the matrix to only the apps whose code or
+  shared schema package actually changed.
+- **`workflow_dispatch`** with three inputs:
+  - `app` — `all` | `runtime` | `reconciler` | `redirect-admin`
+  - `target_ref` — git ref to build (defaults to the ref the workflow was
+    dispatched on; accepts branches, tags, or SHAs)
+  - `push` — whether to push the built image (`true` by default)
+
+> **Known limitation — push triggers.** The `push` triggers only fire on
+> branches that already exist on `origin`. The R5 Dockerfiles currently
+> live on feature branches (`feat/r5-runtime`,
+> `feat/r5-reconciler-ops-5-8`, `feat/r5-redirect-admin`) — **not on
+> `dev`**. Until those feature branches merge, the `push` trigger for
+> `dev` will be a no-op. Use `workflow_dispatch` with `target_ref` set to
+> the feature branch for ad-hoc builds in the meantime.
+
+## Jobs
+
+1. **`detect-changes`** — resolves the target ref, checks out the repo
+   once at that ref, and computes the build matrix.
+   - `workflow_dispatch`: matrix reflects the `app` input
+     (`all` -> all three).
+   - `push`: matrix is derived from `dorny/paths-filter@v3` comparing
+     against `github.event.before`.
+2. **`build-push`** — matrix job that runs once per selected app:
+   - Checks out at `target_ref`.
+   - Sets up Docker Buildx.
+   - Authenticates to GCP via Workload Identity Federation
+     (`google-github-actions/auth@v2` with `GCP_WIF_PROVIDER` +
+     `GCP_CI_SERVICE_ACCOUNT`).
+   - Runs `gcloud auth configure-docker us-central1-docker.pkg.dev`.
+   - Builds and pushes via `docker/build-push-action@v6` with
+     `platforms: linux/amd64`, SHA + `latest` tags, and a per-app GHA
+     buildx cache scope.
+   - Writes a step summary with the pushed tag.
+3. **`notify-deploy-ready`** — aggregates matrix results and:
+   - Writes a step summary listing every pushed image and the exact
+     `terraform apply` invocation to deploy them.
+   - If the triggering ref has an open PR, posts the same summary as a
+     PR comment.
+
+## Secrets
+
+Two secrets are required on the `F3-Nation/f3-nation` repo. No long-lived
+service-account keys — everything flows through Workload Identity
+Federation.
+
+| Secret                   | Example value                                                                                          |
+| ------------------------ | ------------------------------------------------------------------------------------------------------ |
+| `GCP_WIF_PROVIDER`       | `projects/355149658273/locations/global/workloadIdentityPools/f3r5-gh-pool/providers/f3r5-gh-provider` |
+| `GCP_CI_SERVICE_ACCOUNT` | `f3r5-ci-builder@f3-redirects.iam.gserviceaccount.com`                                                 |
+
+Set them with `gh`:
+
+```bash
+gh secret set GCP_WIF_PROVIDER \
+  --repo F3-Nation/f3-nation \
+  --body 'projects/355149658273/locations/global/workloadIdentityPools/f3r5-gh-pool/providers/f3r5-gh-provider'
+
+gh secret set GCP_CI_SERVICE_ACCOUNT \
+  --repo F3-Nation/f3-nation \
+  --body 'f3r5-ci-builder@f3-redirects.iam.gserviceaccount.com'
+```
+
+> Note: the existing `deploy-auth.yml` workflow authenticates with
+> `vars.WIF_PROVIDER` / `vars.WIF_SA` for the **f3-authentication**
+> project. That pool and service account are scoped to a different GCP
+> project and AR repo — R5 needs its own dedicated pool, provider, and
+> service account in the `f3-redirects` project, created by
+> `infra/scripts/r5-wif-setup.sh`.
+
+## One-time WIF setup
+
+The project owner runs `infra/scripts/r5-wif-setup.sh` once against the
+`f3-redirects` GCP project. The script is idempotent — rerunning it is
+safe and will no-op against already-provisioned resources.
+
+```bash
+# Requires gcloud auth with:
+#   - roles/iam.workloadIdentityPoolAdmin on f3-redirects
+#   - roles/iam.serviceAccountAdmin on f3-redirects
+#   - roles/artifactregistry.admin on the f3-redirect-platform AR repo
+
+gcloud auth login
+./infra/scripts/r5-wif-setup.sh
+```
+
+The script creates:
+
+1. Workload Identity Pool `f3r5-gh-pool` in `f3-redirects`.
+2. OIDC provider `f3r5-gh-provider` bound to
+   `https://token.actions.githubusercontent.com`, with attribute mapping
+   `google.subject=assertion.sub`, `attribute.repository=assertion.repository`,
+   `attribute.ref=assertion.ref`, and an attribute condition pinning the
+   pool to `F3-Nation/f3-nation`.
+3. CI service account `f3r5-ci-builder@f3-redirects.iam.gserviceaccount.com`.
+4. `roles/artifactregistry.writer` grant on the `f3-redirect-platform`
+   Artifact Registry repo (scoped to the repo, **not** the project).
+5. `roles/iam.workloadIdentityUser` binding allowing the
+   `F3-Nation/f3-nation` repo principal set to impersonate the CI
+   service account via `iam.serviceAccounts.getAccessToken`.
+
+The script finishes by printing the exact values to save as
+`GCP_WIF_PROVIDER` and `GCP_CI_SERVICE_ACCOUNT`.
+
+Reference:
+<https://cloud.google.com/iam/docs/workload-identity-federation-with-deployment-pipelines>
+
+## Triggering a manual build
+
+```bash
+# Build all three apps from the current state of a feature branch
+gh workflow run r5-build-push-images.yml \
+  --repo F3-Nation/f3-nation \
+  --ref feat/r5-ci-image-builds \
+  -f app=all \
+  -f target_ref=feat/r5-runtime
+
+# Build just the reconciler against a specific SHA
+gh workflow run r5-build-push-images.yml \
+  --repo F3-Nation/f3-nation \
+  --ref feat/r5-ci-image-builds \
+  -f app=reconciler \
+  -f target_ref=<sha>
+
+# Dry run — build without pushing
+gh workflow run r5-build-push-images.yml \
+  --repo F3-Nation/f3-nation \
+  --ref feat/r5-ci-image-builds \
+  -f app=runtime \
+  -f target_ref=feat/r5-runtime \
+  -f push=false
+```
+
+`--ref feat/r5-ci-image-builds` is the branch the workflow file itself
+lives on; `-f target_ref=...` is the branch whose source code is built.
+
+## Known limitations
+
+- **`push` triggers don't fire until Dockerfiles land on `dev`.** The
+  R5 Dockerfiles only exist on the feature branches today. Once those
+  feature branches merge into `dev` via the R5 integration PRs, the
+  `push` trigger on `dev` will start firing automatically. Until then,
+  use `workflow_dispatch` with `target_ref` for every build.
+- **Single architecture.** Images are built for `linux/amd64` only.
+  Cloud Run amd64 runners are the deploy target; arm64 is not currently
+  needed. Add a second platform here if that changes.
+- **No image scanning.** The workflow does not run Trivy/Grype or
+  Artifact Registry vulnerability scanning beyond whatever is enabled
+  at the AR repo level. Add a scan step before production rollout if
+  the security posture demands it.
+- **Cache is scoped to the GHA cache.** Buildx uses
+  `type=gha,scope=r5-<app>` — fast on the same app/branch pair, cold
+  across branches. No registry cache mirror is configured yet.
+
+## Files
+
+- [`.github/workflows/r5-build-push-images.yml`](./r5-build-push-images.yml)
+- [`infra/scripts/r5-wif-setup.sh`](../../infra/scripts/r5-wif-setup.sh)

--- a/.github/workflows/r5-build-push-images.yml
+++ b/.github/workflows/r5-build-push-images.yml
@@ -1,0 +1,307 @@
+name: R5 Build & Push Images
+
+# Builds and pushes Docker images for the three R5 apps (runtime, reconciler,
+# redirect-admin) to the shared Artifact Registry repo in the `f3-redirects`
+# GCP project. Authenticates via Workload Identity Federation — no long-lived
+# service-account keys are stored in GitHub secrets.
+#
+# See .github/workflows/r5-build-push-images-README.md for setup.
+
+on:
+  workflow_dispatch:
+    inputs:
+      app:
+        description: "Which app(s) to build"
+        required: true
+        default: "all"
+        type: choice
+        options:
+          - all
+          - runtime
+          - reconciler
+          - redirect-admin
+      target_ref:
+        description: "Git ref to build (branch, tag, or SHA). Defaults to the ref the workflow is dispatched on."
+        required: false
+        default: ""
+        type: string
+      push:
+        description: "Push the built image to Artifact Registry"
+        required: false
+        default: true
+        type: boolean
+
+  push:
+    branches:
+      - feat/r5-runtime
+      - feat/r5-reconciler-ops-5-8
+      - feat/r5-redirect-admin
+      - feat/r5-admin-verification
+      - dev
+    paths:
+      - "apps/runtime/**"
+      - "apps/reconciler/**"
+      - "apps/redirect-admin/**"
+      - "packages/redirect-platform-db/**"
+      - ".github/workflows/r5-build-push-images.yml"
+
+concurrency:
+  group: r5-build-push-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  GCP_PROJECT: f3-redirects
+  GCP_REGION: us-central1
+  AR_REPO: f3-redirect-platform
+  AR_HOST: us-central1-docker.pkg.dev
+
+permissions:
+  contents: read
+  id-token: write
+  pull-requests: write
+
+jobs:
+  detect-changes:
+    name: Detect changed apps
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.matrix.outputs.matrix }}
+      has_any: ${{ steps.matrix.outputs.has_any }}
+      target_ref: ${{ steps.resolve-ref.outputs.ref }}
+      target_sha: ${{ steps.matrix.outputs.sha }}
+    steps:
+      - name: Resolve target ref
+        id: resolve-ref
+        shell: bash
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" && -n "${{ inputs.target_ref }}" ]]; then
+            echo "ref=${{ inputs.target_ref }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "ref=${{ github.ref }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout target ref
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.resolve-ref.outputs.ref }}
+          fetch-depth: 2
+
+      - name: Detect app changes (push events)
+        id: changes
+        if: github.event_name == 'push'
+        uses: dorny/paths-filter@v3
+        with:
+          base: ${{ github.event.before }}
+          filters: |
+            runtime:
+              - 'apps/runtime/**'
+              - 'packages/redirect-platform-db/**'
+            reconciler:
+              - 'apps/reconciler/**'
+              - 'packages/redirect-platform-db/**'
+            redirect-admin:
+              - 'apps/redirect-admin/**'
+              - 'packages/redirect-platform-db/**'
+
+      - name: Build matrix
+        id: matrix
+        shell: bash
+        run: |
+          set -euo pipefail
+          apps=()
+
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            case "${{ inputs.app }}" in
+              all)
+                apps=(runtime reconciler redirect-admin)
+                ;;
+              runtime|reconciler|redirect-admin)
+                apps=("${{ inputs.app }}")
+                ;;
+              *)
+                echo "Unknown app input: ${{ inputs.app }}" >&2
+                exit 1
+                ;;
+            esac
+          else
+            [[ "${{ steps.changes.outputs.runtime }}" == "true" ]] && apps+=("runtime")
+            [[ "${{ steps.changes.outputs.reconciler }}" == "true" ]] && apps+=("reconciler")
+            [[ "${{ steps.changes.outputs.redirect-admin }}" == "true" ]] && apps+=("redirect-admin")
+          fi
+
+          if [[ ${#apps[@]} -eq 0 ]]; then
+            echo "matrix={\"app\":[]}" >> "$GITHUB_OUTPUT"
+            echo "has_any=false" >> "$GITHUB_OUTPUT"
+          else
+            printf -v joined '"%s",' "${apps[@]}"
+            joined="${joined%,}"
+            echo "matrix={\"app\":[${joined}]}" >> "$GITHUB_OUTPUT"
+            echo "has_any=true" >> "$GITHUB_OUTPUT"
+          fi
+
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+  build-push:
+    name: Build & push ${{ matrix.app }}
+    needs: detect-changes
+    if: needs.detect-changes.outputs.has_any == 'true'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.detect-changes.outputs.matrix) }}
+    steps:
+      - name: Checkout target ref
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.detect-changes.outputs.target_ref }}
+
+      - name: Record target SHA
+        id: sha
+        shell: bash
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Authenticate to GCP (Workload Identity Federation)
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER }}
+          service_account: ${{ secrets.GCP_CI_SERVICE_ACCOUNT }}
+
+      - name: Set up gcloud
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Configure Docker for Artifact Registry
+        run: gcloud auth configure-docker ${{ env.AR_HOST }} --quiet
+
+      - name: Compute image tags
+        id: meta
+        shell: bash
+        run: |
+          set -euo pipefail
+          base="${AR_HOST}/${GCP_PROJECT}/${AR_REPO}/${{ matrix.app }}"
+          sha="${{ steps.sha.outputs.sha }}"
+          {
+            echo "image_sha=${base}:${sha}"
+            echo "image_latest=${base}:latest"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Resolve push flag
+        id: push
+        shell: bash
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "push=${{ inputs.push }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "push=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: apps/${{ matrix.app }}/Dockerfile
+          platforms: linux/amd64
+          push: ${{ steps.push.outputs.push == 'true' }}
+          tags: |
+            ${{ steps.meta.outputs.image_sha }}
+            ${{ steps.meta.outputs.image_latest }}
+          cache-from: type=gha,scope=r5-${{ matrix.app }}
+          cache-to: type=gha,scope=r5-${{ matrix.app }},mode=max
+          provenance: false
+
+      - name: Write step summary
+        shell: bash
+        run: |
+          {
+            echo "### R5 image: \`${{ matrix.app }}\`"
+            echo
+            echo "- **SHA tag:** \`${{ steps.meta.outputs.image_sha }}\`"
+            echo "- **Latest tag:** \`${{ steps.meta.outputs.image_latest }}\`"
+            echo "- **Git SHA:** \`${{ steps.sha.outputs.sha }}\`"
+            echo "- **Pushed:** \`${{ steps.push.outputs.push }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  notify-deploy-ready:
+    name: Notify deploy ready
+    needs: [detect-changes, build-push]
+    if: always() && needs.detect-changes.outputs.has_any == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Build summary
+        id: summary
+        shell: bash
+        env:
+          MATRIX_JSON: ${{ needs.detect-changes.outputs.matrix }}
+          TARGET_SHA: ${{ needs.detect-changes.outputs.target_sha }}
+          BUILD_RESULT: ${{ needs.build-push.result }}
+        run: |
+          set -euo pipefail
+
+          apps="$(echo "${MATRIX_JSON}" | jq -r '.app[]')"
+
+          {
+            echo "## R5 images ready to deploy"
+            echo
+            echo "**Build status:** \`${BUILD_RESULT}\`"
+            echo "**Git SHA:** \`${TARGET_SHA}\`"
+            echo
+            echo "**Images pushed:**"
+            while IFS= read -r a; do
+              [[ -z "$a" ]] && continue
+              echo "- \`us-central1-docker.pkg.dev/f3-redirects/f3-redirect-platform/${a}:${TARGET_SHA}\`"
+            done <<< "$apps"
+            echo
+            echo "**Deploy command:**"
+            echo
+            echo '```bash'
+            echo "cd f3-redirect/infra/terraform/cloud-run"
+            echo "terraform apply \\"
+            echo "  -var=\"runtime_image_tag=${TARGET_SHA}\" \\"
+            echo "  -var=\"reconciler_image_tag=${TARGET_SHA}\" \\"
+            echo "  -var=\"redirect_admin_image_tag=${TARGET_SHA}\""
+            echo '```'
+          } > summary.md
+
+          cat summary.md >> "$GITHUB_STEP_SUMMARY"
+
+          {
+            echo 'body<<SUMMARY_EOF'
+            cat summary.md
+            echo 'SUMMARY_EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Find PR for branch
+        id: find-pr
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const ref = (context.ref || '').replace('refs/heads/', '');
+            if (!ref) {
+              core.setOutput('number', '');
+              return;
+            }
+            const { data: prs } = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              head: `${context.repo.owner}:${ref}`,
+            });
+            core.setOutput('number', prs.length ? String(prs[0].number) : '');
+
+      - name: Comment on PR
+        if: steps.find-pr.outputs.number != ''
+        uses: actions/github-script@v7
+        env:
+          COMMENT_BODY: ${{ steps.summary.outputs.body }}
+          PR_NUMBER: ${{ steps.find-pr.outputs.number }}
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: Number(process.env.PR_NUMBER),
+              body: process.env.COMMENT_BODY,
+            });

--- a/infra/scripts/r5-wif-setup.sh
+++ b/infra/scripts/r5-wif-setup.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+#
+# r5-wif-setup.sh
+#
+# One-time setup for GitHub Actions -> GCP Workload Identity Federation
+# for the R5 multi-tenant redirect platform image builds.
+#
+# Creates (idempotently):
+#   1. Workload Identity Pool           : f3r5-gh-pool
+#   2. OIDC Provider (GitHub Actions)   : f3r5-gh-provider
+#   3. CI service account               : f3r5-ci-builder@f3-redirects.iam.gserviceaccount.com
+#   4. Artifact Registry IAM binding    : roles/artifactregistry.writer on f3-redirect-platform
+#   5. WIF impersonation binding        : F3-Nation/f3-nation -> f3r5-ci-builder
+#
+# Run as a user with:
+#   - roles/iam.workloadIdentityPoolAdmin on the project
+#   - roles/iam.serviceAccountAdmin on the project
+#   - roles/artifactregistry.admin on the f3-redirect-platform repo
+#
+# Reference:
+#   https://cloud.google.com/iam/docs/workload-identity-federation-with-deployment-pipelines
+#
+# After running, the script prints the two values that must be saved as
+# GitHub repo secrets:
+#   - GCP_WIF_PROVIDER
+#   - GCP_CI_SERVICE_ACCOUNT
+
+set -euo pipefail
+
+# --- Configuration ----------------------------------------------------------
+
+PROJECT_ID="${PROJECT_ID:-f3-redirects}"
+PROJECT_NUMBER="${PROJECT_NUMBER:-355149658273}"
+REGION="${REGION:-us-central1}"
+
+POOL_ID="${POOL_ID:-f3r5-gh-pool}"
+POOL_DISPLAY_NAME="F3 R5 GitHub Actions Pool"
+PROVIDER_ID="${PROVIDER_ID:-f3r5-gh-provider}"
+PROVIDER_DISPLAY_NAME="F3 R5 GitHub Actions Provider"
+
+SA_NAME="${SA_NAME:-f3r5-ci-builder}"
+SA_DISPLAY_NAME="F3 R5 CI Image Builder"
+SA_DESCRIPTION="Pushes R5 runtime/reconciler/redirect-admin images to Artifact Registry"
+SA_EMAIL="${SA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com"
+
+AR_REPO="${AR_REPO:-f3-redirect-platform}"
+
+GITHUB_REPO="${GITHUB_REPO:-F3-Nation/f3-nation}"
+GITHUB_ISSUER_URI="https://token.actions.githubusercontent.com"
+
+# --- Helpers ----------------------------------------------------------------
+
+log()  { printf "[r5-wif-setup] %s\n" "$*"; }
+warn() { printf "[r5-wif-setup] WARN: %s\n" "$*" >&2; }
+die()  { printf "[r5-wif-setup] ERROR: %s\n" "$*" >&2; exit 1; }
+
+ensure_command() {
+  local cmd="$1"
+  command -v "$cmd" >/dev/null 2>&1 || die "required command not found: ${cmd}"
+}
+
+ensure_command gcloud
+
+# --- Preflight --------------------------------------------------------------
+
+log "Project : ${PROJECT_ID} (#${PROJECT_NUMBER})"
+log "Pool    : ${POOL_ID}"
+log "Provider: ${PROVIDER_ID}"
+log "SA      : ${SA_EMAIL}"
+log "AR repo : ${AR_REPO} in ${REGION}"
+log "GH repo : ${GITHUB_REPO}"
+
+gcloud config set project "${PROJECT_ID}" >/dev/null
+
+# --- 1. Workload Identity Pool ---------------------------------------------
+
+if gcloud iam workload-identity-pools describe "${POOL_ID}" \
+    --project="${PROJECT_ID}" \
+    --location="global" \
+    >/dev/null 2>&1; then
+  log "Pool ${POOL_ID} already exists — skipping create"
+else
+  log "Creating workload identity pool ${POOL_ID}"
+  gcloud iam workload-identity-pools create "${POOL_ID}" \
+    --project="${PROJECT_ID}" \
+    --location="global" \
+    --display-name="${POOL_DISPLAY_NAME}"
+fi
+
+POOL_FULL_NAME="projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/${POOL_ID}"
+
+# --- 2. OIDC Provider -------------------------------------------------------
+
+if gcloud iam workload-identity-pools providers describe "${PROVIDER_ID}" \
+    --project="${PROJECT_ID}" \
+    --location="global" \
+    --workload-identity-pool="${POOL_ID}" \
+    >/dev/null 2>&1; then
+  log "Provider ${PROVIDER_ID} already exists — skipping create"
+else
+  log "Creating OIDC provider ${PROVIDER_ID}"
+  gcloud iam workload-identity-pools providers create-oidc "${PROVIDER_ID}" \
+    --project="${PROJECT_ID}" \
+    --location="global" \
+    --workload-identity-pool="${POOL_ID}" \
+    --display-name="${PROVIDER_DISPLAY_NAME}" \
+    --issuer-uri="${GITHUB_ISSUER_URI}" \
+    --attribute-mapping="google.subject=assertion.sub,attribute.repository=assertion.repository,attribute.ref=assertion.ref" \
+    --attribute-condition="assertion.repository == '${GITHUB_REPO}'"
+fi
+
+PROVIDER_FULL_NAME="${POOL_FULL_NAME}/providers/${PROVIDER_ID}"
+
+# --- 3. CI Service Account --------------------------------------------------
+
+if gcloud iam service-accounts describe "${SA_EMAIL}" \
+    --project="${PROJECT_ID}" \
+    >/dev/null 2>&1; then
+  log "Service account ${SA_EMAIL} already exists — skipping create"
+else
+  log "Creating service account ${SA_EMAIL}"
+  gcloud iam service-accounts create "${SA_NAME}" \
+    --project="${PROJECT_ID}" \
+    --display-name="${SA_DISPLAY_NAME}" \
+    --description="${SA_DESCRIPTION}"
+fi
+
+# --- 4. Artifact Registry writer on the f3-redirect-platform repo ----------
+
+log "Granting roles/artifactregistry.writer on ${AR_REPO}"
+gcloud artifacts repositories add-iam-policy-binding "${AR_REPO}" \
+  --project="${PROJECT_ID}" \
+  --location="${REGION}" \
+  --member="serviceAccount:${SA_EMAIL}" \
+  --role="roles/artifactregistry.writer" \
+  --condition=None \
+  >/dev/null
+
+# --- 5. WIF impersonation binding ------------------------------------------
+
+PRINCIPAL_SET="principalSet://iam.googleapis.com/${POOL_FULL_NAME}/attribute.repository/${GITHUB_REPO}"
+
+log "Binding ${PRINCIPAL_SET} -> roles/iam.workloadIdentityUser"
+gcloud iam service-accounts add-iam-policy-binding "${SA_EMAIL}" \
+  --project="${PROJECT_ID}" \
+  --role="roles/iam.workloadIdentityUser" \
+  --member="${PRINCIPAL_SET}" \
+  --condition=None \
+  >/dev/null
+
+# The google-github-actions/auth@v2 action uses
+# iam.serviceAccounts.getAccessToken to mint short-lived access tokens.
+# roles/iam.workloadIdentityUser on the service account grants exactly
+# that permission for the federated principal; no additional SA-level
+# binding is needed.
+
+# --- Output -----------------------------------------------------------------
+
+cat <<EOF
+
+================================================================
+R5 Workload Identity Federation setup complete.
+
+Save these values as GitHub repo secrets on ${GITHUB_REPO}:
+
+  GCP_WIF_PROVIDER        = ${PROVIDER_FULL_NAME}
+  GCP_CI_SERVICE_ACCOUNT  = ${SA_EMAIL}
+
+Via gh CLI:
+
+  gh secret set GCP_WIF_PROVIDER --repo ${GITHUB_REPO} --body "${PROVIDER_FULL_NAME}"
+  gh secret set GCP_CI_SERVICE_ACCOUNT --repo ${GITHUB_REPO} --body "${SA_EMAIL}"
+
+================================================================
+EOF


### PR DESCRIPTION
## Summary

CI foundation for R5 image builds. Three new files, zero modifications to existing workflows.

- **`.github/workflows/r5-build-push-images.yml`** (307 lines) — matrix build for the three R5 apps (`runtime`, `reconciler`, `redirect-admin`) with Workload Identity Federation auth to GCP, pushing to `us-central1-docker.pkg.dev/f3-redirects/f3-redirect-platform/{app}:{sha|latest}`
- **`infra/scripts/r5-wif-setup.sh`** (175 lines, `chmod +x`, shellcheck clean, idempotent) — one-command setup for the WIF pool, OIDC provider, CI service account, and `roles/artifactregistry.writer` binding
- **`.github/workflows/r5-build-push-images-README.md`** (189 lines) — how to run the setup script, how to trigger manual builds, known limitations

## Workflow structure

Three jobs:

1. **`detect-changes`** — resolves `target_ref`, computes the app matrix from either `dorny/paths-filter@v3` output (push events) or the `app` dispatch input, emits shared SHA as job output so all jobs agree
2. **`build-push`** — matrix over apps, single `docker/build-push-action@v6` step with per-app GHA buildx cache scope (`type=gha,scope=r5-<app>`), `platforms: linux/amd64` only, pushes both `:sha` and `:latest` tags
3. **`notify-deploy-ready`** — aggregates matrix results, writes a deploy summary to `$GITHUB_STEP_SUMMARY`, PR-comments via `actions/github-script@v7` if an open PR exists for the ref

Triggers:
- **`workflow_dispatch`** with inputs `app` (runtime | reconciler | redirect-admin | all), `target_ref` (default current branch), `push` (default true)
- **`push`** with `paths:` filters scoped to `apps/runtime/**`, `apps/reconciler/**`, `apps/redirect-admin/**`, and `packages/redirect-platform-db/**`

## Secrets required

Documented in the README. Both come from the WIF setup script output:

- `GCP_WIF_PROVIDER` — full resource name, e.g. `projects/355149658273/locations/global/workloadIdentityPools/f3r5-gh-pool/providers/f3r5-gh-provider`
- `GCP_CI_SERVICE_ACCOUNT` — `f3r5-ci-builder@f3-redirects.iam.gserviceaccount.com`

## Existing GHA patterns adopted

Agent found `deploy-auth.yml` already using WIF via `google-github-actions/auth@v2` — but pointed at a different GCP project (`f3-authentication-staging`/`f3-authentication`). R5 gets its **own dedicated pool + provider + service account** in the `f3-redirects` project per isolation guidance. Documented the distinction in the README.

## Verification

- [x] `shellcheck infra/scripts/r5-wif-setup.sh` — clean
- [x] `yq eval` on the workflow — parses cleanly
- [x] Monorepo pre-commit hooks (prettier + eslint + typecheck via lefthook) — green on all 3 commits
- [x] No existing workflows modified
- [ ] First `workflow_dispatch` run against real secrets + real `feat/r5-*` branch
- [ ] `r5-wif-setup.sh` dry-run against `f3-redirects`

## Known limitations

1. **`push` triggers for `dev` won't fire until R5 feature branches merge into `dev`**. Until then, use `workflow_dispatch` with `target_ref=feat/r5-*` for manual builds
2. Single-arch `linux/amd64` only
3. No Trivy/Grype scan step (only whatever Artifact Registry auto-scans)
4. GHA-scoped buildx cache only; no registry cache mirror

## Stack

This PR is **independent** off `dev` — not part of the feature stack. Can be merged whenever, unblocks CI image builds for any branch that has R5 Dockerfiles (which is all feature branches).

🤖 Generated with [Claude Code](https://claude.com/claude-code)