### PR TITLE
fix(api): making start dates dynamic on api test files

### DIFF
--- a/packages/api/src/router/event.test.ts
+++ b/packages/api/src/router/event.test.ts
@@ -1344,6 +1344,10 @@ describe("Event Router", () => {
         const eventType = await createTestEventType();
         if (!eventType) return;
 
+        // Use dynamic dates so the series is always active relative to today
+        const seriesStartDate = nextFutureMonday(1);
+        const seriesEndDate = nextFutureMonday(12);
+
         // Create initial series on Mondays
         const [seriesEvent] = await db
           .insert(schema.events)
@@ -1354,8 +1358,8 @@ describe("Event Router", () => {
             dayOfWeek: "monday",
             startTime: "0530",
             endTime: "0615",
-            startDate: "2026-01-01",
-            endDate: "2026-03-31",
+            startDate: seriesStartDate,
+            endDate: seriesEndDate,
             recurrencePattern: "weekly",
             recurrenceInterval: 1,
             indexWithinInterval: null,
@@ -1402,8 +1406,8 @@ describe("Event Router", () => {
           dayOfWeek: "tuesday", // Changed from Monday (structural)
           startTime: "0530",
           endTime: "0615",
-          startDate: "2026-01-01",
-          endDate: "2026-03-31",
+          startDate: seriesStartDate,
+          endDate: seriesEndDate,
           recurrencePattern: "weekly",
           recurrenceInterval: 1,
           indexWithinInterval: null,

--- a/packages/api/src/router/event.test.ts
+++ b/packages/api/src/router/event.test.ts
@@ -30,6 +30,14 @@ import {
   uniqueId,
 } from "../__tests__/test-utils";
 
+/** Returns the YYYY-MM-DD date string for the nth upcoming Monday (UTC). n=1 is next Monday. */
+const nextFutureMonday = (n: number): string => {
+  const d = new Date();
+  const daysUntilNextMonday = (1 - d.getUTCDay() + 7) % 7 || 7;
+  d.setUTCDate(d.getUTCDate() + daysUntilNextMonday + (n - 1) * 7);
+  return d.toISOString().split("T")[0]!;
+};
+
 describe("Event Router", () => {
   // Track created entities for cleanup
   const createdEventIds: number[] = [];
@@ -1266,7 +1274,7 @@ describe("Event Router", () => {
             locationId: location.id,
             startTime: "0530",
             endTime: "0615",
-            startDate: "2026-04-07",
+            startDate: nextFutureMonday(2),
             isActive: true,
             highlight: false,
             seriesId: seriesEvent.id,
@@ -1368,7 +1376,7 @@ describe("Event Router", () => {
             locationId: location.id,
             startTime: "0530",
             endTime: "0615",
-            startDate: "2026-04-07",
+            startDate: nextFutureMonday(2),
             isActive: true,
             highlight: false,
             seriesId: seriesEvent.id,
@@ -1533,7 +1541,7 @@ describe("Event Router", () => {
             locationId: location.id,
             startTime: "0530",
             endTime: "0615",
-            startDate: "2026-04-07",
+            startDate: nextFutureMonday(2),
             isActive: true,
             highlight: false,
             seriesId: seriesEvent.id,

--- a/packages/api/src/router/org.test.ts
+++ b/packages/api/src/router/org.test.ts
@@ -29,7 +29,13 @@ import {
   mockAuthWithSession,
   uniqueId,
 } from "../__tests__/test-utils";
-
+/** Returns the YYYY-MM-DD date string for the nth upcoming Monday (UTC). n=1 is next Monday. */
+const nextFutureMonday = (n: number): string => {
+  const d = new Date();
+  const daysUntilNextMonday = (1 - d.getUTCDay() + 7) % 7 || 7;
+  d.setUTCDate(d.getUTCDate() + daysUntilNextMonday + (n - 1) * 7);
+  return d.toISOString().split("T")[0]!;
+};
 describe("Org Router", () => {
   // Track created orgs for cleanup
   const createdOrgIds: number[] = [];
@@ -466,7 +472,11 @@ describe("Org Router", () => {
 
       // Create future instances (should be soft-deleted)
       const futureInstanceIds: number[] = [];
-      for (const date of ["2026-04-06", "2026-04-13", "2026-04-20"]) {
+      for (const date of [
+        nextFutureMonday(2),
+        nextFutureMonday(3),
+        nextFutureMonday(4),
+      ]) {
         const [inst] = await db
           .insert(schema.eventInstances)
           .values({
@@ -510,7 +520,10 @@ describe("Org Router", () => {
         .where(
           and(
             eq(schema.eventInstances.orgId, ao.id),
-            gte(schema.eventInstances.startDate, "2026-03-25"),
+            gte(
+              schema.eventInstances.startDate,
+              new Date().toISOString().split("T")[0]!,
+            ),
           ),
         );
       expect(futureInstances.length).toBeGreaterThanOrEqual(3);


### PR DESCRIPTION
This pull request updates test files to use dynamically generated future dates instead of hardcoded ones, making the tests more robust and less likely to break as time passes. This was causing a test failure related to the cascade service, as that modifies future instances of a series. The main change is the introduction of a utility function to calculate the date of the next upcoming Monday (or subsequent Mondays), which is then used throughout the test cases.

**Test date handling improvements:**

* Added a `nextFutureMonday(n)` utility function in both `event.test.ts` and `org.test.ts` to generate the date string for the nth upcoming Monday in UTC. This replaces hardcoded future dates in tests. [[1]](diffhunk://#diff-210154fec7dd248bbdd863c80cc94936bfa142c5e2dee2fbeb3a8f74ed80a5a3R33-R40) [[2]](diffhunk://#diff-8ba43de9e6c0e3cb10a9cb0fff0274a36c75ee51c9c6a7a48c22a85b95126987L32-R38)
* Replaced hardcoded `startDate` values in multiple test cases within `event.test.ts` with calls to `nextFutureMonday(2)`. [[1]](diffhunk://#diff-210154fec7dd248bbdd863c80cc94936bfa142c5e2dee2fbeb3a8f74ed80a5a3L1269-R1277) [[2]](diffhunk://#diff-210154fec7dd248bbdd863c80cc94936bfa142c5e2dee2fbeb3a8f74ed80a5a3L1371-R1379) [[3]](diffhunk://#diff-210154fec7dd248bbdd863c80cc94936bfa142c5e2dee2fbeb3a8f74ed80a5a3L1536-R1544)
* Updated future instance creation in `org.test.ts` to use `nextFutureMonday(2)`, `nextFutureMonday(3)`, and `nextFutureMonday(4)` instead of hardcoded dates.
* Changed a test query in `org.test.ts` to use the current date (in ISO format) instead of a fixed date, ensuring the test always checks for future instances relative to the current day.