### PR TITLE
fix(api): add check to destination parent

### DIFF
--- a/packages/api/src/router/event.ts
+++ b/packages/api/src/router/event.ts
@@ -746,13 +746,15 @@ export const eventRouter = {
       }
 
       const { eventTypeIds, meta, ...eventData } = input;
+      const mapSeed =
+        typeof meta?.mapSeed === "boolean" ? meta.mapSeed : undefined;
       const eventToUpdate: typeof schema.events.$inferInsert = {
         ...eventData,
         orgId: input.aoId,
         meta: meta
           ? {
               ...meta,
-              mapSeed: meta.mapSeed,
+              mapSeed,
               eventTypeId: undefined, // Remove eventTypeId from meta since we handle it in join table
             }
           : null,

--- a/packages/api/src/router/org.test.ts
+++ b/packages/api/src/router/org.test.ts
@@ -330,6 +330,234 @@ describe("Org Router", () => {
         }),
       ).rejects.toThrow();
     });
+
+    it("should require editor permission on the destination region when moving an AO", async () => {
+      const f3Nation = await getOrCreateF3NationOrg();
+
+      const [sourceRegion] = await db
+        .insert(schema.orgs)
+        .values({
+          name: `Source Region ${uniqueId()}`,
+          orgType: "region",
+          parentId: f3Nation.id,
+          isActive: true,
+        })
+        .returning();
+
+      const [destinationRegion] = await db
+        .insert(schema.orgs)
+        .values({
+          name: `Destination Region ${uniqueId()}`,
+          orgType: "region",
+          parentId: f3Nation.id,
+          isActive: true,
+        })
+        .returning();
+
+      if (!sourceRegion || !destinationRegion) {
+        throw new Error("Failed to create test regions");
+      }
+
+      createdOrgIds.push(sourceRegion.id, destinationRegion.id);
+
+      const [ao] = await db
+        .insert(schema.orgs)
+        .values({
+          name: `AO Move Permission ${uniqueId()}`,
+          orgType: "ao",
+          parentId: sourceRegion.id,
+          isActive: true,
+        })
+        .returning();
+
+      if (!ao) {
+        throw new Error("Failed to create test AO");
+      }
+
+      createdOrgIds.push(ao.id);
+
+      const session = createEditorSession({
+        orgId: sourceRegion.id,
+        orgName: sourceRegion.name,
+      });
+      await mockAuthWithSession(session);
+
+      const client = createTestClient();
+
+      await expect(
+        client.org.crupdate({
+          id: ao.id,
+          name: ao.name,
+          orgType: "ao",
+          parentId: destinationRegion.id,
+          isActive: true,
+          email: null,
+          description: null,
+          website: null,
+          twitter: null,
+          facebook: null,
+          instagram: null,
+        }),
+      ).rejects.toThrow("destination parent");
+    });
+
+    it("should require editor permission on the destination parent when moving a region", async () => {
+      const f3Nation = await getOrCreateF3NationOrg();
+
+      const [sourceSector] = await db
+        .insert(schema.orgs)
+        .values({
+          name: `Source Sector ${uniqueId()}`,
+          orgType: "sector",
+          parentId: f3Nation.id,
+          isActive: true,
+        })
+        .returning();
+
+      const [destinationSector] = await db
+        .insert(schema.orgs)
+        .values({
+          name: `Destination Sector ${uniqueId()}`,
+          orgType: "sector",
+          parentId: f3Nation.id,
+          isActive: true,
+        })
+        .returning();
+
+      if (!sourceSector || !destinationSector) {
+        throw new Error("Failed to create test sectors");
+      }
+
+      createdOrgIds.push(sourceSector.id, destinationSector.id);
+
+      const [region] = await db
+        .insert(schema.orgs)
+        .values({
+          name: `Region Move Permission ${uniqueId()}`,
+          orgType: "region",
+          parentId: sourceSector.id,
+          isActive: true,
+        })
+        .returning();
+
+      if (!region) {
+        throw new Error("Failed to create test region");
+      }
+
+      createdOrgIds.push(region.id);
+
+      const session = createEditorSession({
+        orgId: sourceSector.id,
+        orgName: sourceSector.name,
+      });
+      await mockAuthWithSession(session);
+
+      const client = createTestClient();
+
+      await expect(
+        client.org.crupdate({
+          id: region.id,
+          name: region.name,
+          orgType: "region",
+          parentId: destinationSector.id,
+          isActive: true,
+          email: null,
+          description: null,
+          website: null,
+          twitter: null,
+          facebook: null,
+          instagram: null,
+        }),
+      ).rejects.toThrow("destination parent");
+    });
+
+    it("should not bypass destination permission checks for parentId zero", async () => {
+      const f3Nation = await getOrCreateF3NationOrg();
+
+      const [sourceRegion] = await db
+        .insert(schema.orgs)
+        .values({
+          name: `Zero Source Region ${uniqueId()}`,
+          orgType: "region",
+          parentId: f3Nation.id,
+          isActive: true,
+        })
+        .returning();
+
+      if (!sourceRegion) {
+        throw new Error("Failed to create source region");
+      }
+
+      createdOrgIds.push(sourceRegion.id);
+
+      const [existingZeroRegion] = await db
+        .select()
+        .from(schema.orgs)
+        .where(eq(schema.orgs.id, 0));
+
+      const zeroRegion =
+        existingZeroRegion ??
+        (
+          await db
+            .insert(schema.orgs)
+            .values({
+              id: 0,
+              name: `Zero Region ${uniqueId()}`,
+              orgType: "region",
+              parentId: f3Nation.id,
+              isActive: true,
+            })
+            .returning()
+        )[0];
+
+      if (!zeroRegion) {
+        throw new Error("Failed to create zero region");
+      }
+
+      if (!existingZeroRegion) {
+        createdOrgIds.push(zeroRegion.id);
+      }
+
+      const [ao] = await db
+        .insert(schema.orgs)
+        .values({
+          name: `AO Zero Move ${uniqueId()}`,
+          orgType: "ao",
+          parentId: sourceRegion.id,
+          isActive: true,
+        })
+        .returning();
+
+      if (!ao) {
+        throw new Error("Failed to create test AO");
+      }
+
+      createdOrgIds.push(ao.id);
+
+      const session = createEditorSession({
+        orgId: sourceRegion.id,
+        orgName: sourceRegion.name,
+      });
+      await mockAuthWithSession(session);
+
+      const client = createTestClient();
+
+      await expect(
+        client.org.crupdate({
+          id: ao.id,
+          name: ao.name,
+          orgType: "ao",
+          parentId: zeroRegion.id,
+          isActive: true,
+          email: null,
+          description: null,
+          website: null,
+          twitter: null,
+          facebook: null,
+          instagram: null,
+        }),
+      ).rejects.toThrow("destination parent");
+    });
   });
 
   describe("mine", () => {

--- a/packages/api/src/router/org.ts
+++ b/packages/api/src/router/org.ts
@@ -840,16 +840,45 @@ export const orgRouter = {
         });
       }
 
+      const isChangingParent =
+        input.parentId !== undefined && input.parentId !== existingOrg.parentId;
+
+      let destinationParentOrgId: number | null = null;
+
+      if (isChangingParent) {
+        if (input.parentId == null) {
+          throw new ORPCError("BAD_REQUEST", {
+            message: "Parent ID is required to move this org",
+          });
+        }
+
+        destinationParentOrgId = input.parentId;
+
+        const destinationRoleCheckResult = await checkHasRoleOnOrg({
+          orgId: destinationParentOrgId,
+          session: ctx.session,
+          db: ctx.db,
+          roleName: "editor",
+        });
+
+        if (!destinationRoleCheckResult.success) {
+          throw new ORPCError("UNAUTHORIZED", {
+            message:
+              "You are not authorized to move this org to the destination parent organization",
+          });
+        }
+      }
+
       // If the parentId is changing and this is an AO, we need to move the locations for the org
       if (
-        input.parentId &&
-        existingOrg.parentId &&
-        input.parentId !== existingOrg.parentId &&
-        input.orgType === "ao"
+        isChangingParent &&
+        input.orgType === "ao" &&
+        destinationParentOrgId !== null &&
+        existingOrg.parentId !== null
       ) {
         await moveAOLocsToNewRegion(ctx, {
           oldRegionId: existingOrg.parentId,
-          newRegionId: input.parentId,
+          newRegionId: destinationParentOrgId,
           aoId: existingOrg.id,
         });
       }


### PR DESCRIPTION
This pull request strengthens permission checks when moving organizations (orgs) within the hierarchy, ensuring that users must have editor rights on the destination parent before an org can be moved. It also adds comprehensive tests to verify these behaviors and clarifies the handling of `mapSeed` in event metadata.

**Permission enforcement for org moves:**

- Added a check in `orgRouter` to ensure users have editor permissions on the destination parent org when moving an org (i.e., changing its `parentId`). If the user lacks permission, an explicit error is thrown.

**Test coverage for org move permissions:**

- Added tests to `org.test.ts` to verify that:
  - Moving an AO requires editor permission on the destination region.
  - Moving a region requires editor permission on the destination sector.
  - Permission checks are not bypassed when moving to a parent with ID zero.

**Event metadata handling:**

- Updated `eventRouter` to only set the `mapSeed` property in event metadata if it is explicitly a boolean, preventing unintended values from being stored.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved permission enforcement when moving organizations in the hierarchy.
  * Enhanced reliability of event handling through more robust validation.

* **Tests**
  * Expanded test coverage for organization hierarchy operations and permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->