### PR TITLE
feat(api): adding userId to org-chart API endpoints

### DIFF
--- a/packages/api/src/router/org-chart/index.ts
+++ b/packages/api/src/router/org-chart/index.ts
@@ -15,7 +15,17 @@ interface OrgRow {
 }
 
 interface PositionRow {
+  positionId: number;
   title: string;
+  userId: number;
+  f3Name: string | null;
+  avatarUrl: string | null;
+}
+
+interface RoleRow {
+  roleId: number;
+  title: string;
+  userId: number;
   f3Name: string | null;
   avatarUrl: string | null;
 }
@@ -279,7 +289,9 @@ export const orgChartRouter = {
         positions: z
           .array(
             z.object({
+              positionId: z.number().describe("Position ID"),
               title: z.string().describe("Position title"),
+              userId: z.number().describe("User ID"),
               f3Name: z.string().nullable().describe("User F3 name"),
               avatarUrl: z.string().nullable().describe("User avatar URL"),
             }),
@@ -288,7 +300,9 @@ export const orgChartRouter = {
         roles: z
           .array(
             z.object({
+              roleId: z.number().describe("Role ID"),
               title: z.string().describe("Role title"),
+              userId: z.number().describe("User ID"),
               f3Name: z.string().nullable().describe("User F3 name"),
               avatarUrl: z.string().nullable().describe("User avatar URL"),
             }),
@@ -319,7 +333,9 @@ export const orgChartRouter = {
 
       const orgPositions: PositionRow[] = await ctx.db
         .select({
+          positionId: schema.positions.id,
           title: schema.positions.name,
+          userId: schema.users.id,
           f3Name: schema.users.f3Name,
           avatarUrl: schema.users.avatarUrl,
         })
@@ -339,9 +355,11 @@ export const orgChartRouter = {
         .orderBy(asc(schema.positions.name), asc(schema.users.f3Name));
 
       // Get roles for this org, similar to positions
-      const orgRoles: PositionRow[] = await ctx.db
+      const orgRoles: RoleRow[] = await ctx.db
         .select({
+          roleId: schema.roles.id,
           title: schema.roles.name,
+          userId: schema.users.id,
           f3Name: schema.users.f3Name,
           avatarUrl: schema.users.avatarUrl,
         })
@@ -367,12 +385,16 @@ export const orgChartRouter = {
         facebook: org.facebook,
         instagram: org.instagram,
         positions: orgPositions.map((position) => ({
+          positionId: position.positionId,
           title: position.title,
+          userId: position.userId,
           f3Name: position.f3Name,
           avatarUrl: position.avatarUrl,
         })),
         roles: orgRoles.map((role) => ({
+          roleId: role.roleId,
           title: role.title,
+          userId: role.userId,
           f3Name: role.f3Name,
           avatarUrl: role.avatarUrl,
         })),


### PR DESCRIPTION
This pull request enhances the organization chart API response by including unique identifiers for both positions and roles, as well as associating each with a user ID. These changes improve the clarity and utility of the data returned, making it easier for consumers to reference and manipulate specific positions and roles.

**Schema and Type Improvements:**

* Updated the `PositionRow` and `RoleRow` interfaces to include `positionId`/`roleId` and `userId` fields, ensuring each position and role can be uniquely identified and directly associated with a user.

**API Response and Validation Enhancements:**

* Modified the Zod validation schemas for `positions` and `roles` to require `positionId`/`roleId` and `userId`, ensuring the API response includes these identifiers. [[1]](diffhunk://#diff-f86477e3517749afdd25cab6216480170fde2dc6b9c45ed488164134c03f354aR292-R294) [[2]](diffhunk://#diff-f86477e3517749afdd25cab6216480170fde2dc6b9c45ed488164134c03f354aR303-R305)
* Updated the database queries and API response construction to select and return `positionId`/`roleId` and `userId` for each position and role. [[1]](diffhunk://#diff-f86477e3517749afdd25cab6216480170fde2dc6b9c45ed488164134c03f354aR336-R338) [[2]](diffhunk://#diff-f86477e3517749afdd25cab6216480170fde2dc6b9c45ed488164134c03f354aL342-R362) [[3]](diffhunk://#diff-f86477e3517749afdd25cab6216480170fde2dc6b9c45ed488164134c03f354aR388-R397)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* The Org Chart endpoint now includes stable identifiers for organizational elements. Position ID and role ID are now returned with each leadership position and role entry, enabling more reliable references, integrations with organizational data, and improved data consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->