### PR TITLE
fix(me,api): removed pii from api

### DIFF
--- a/apps/api/src/app/docs/openapi.json/route.ts
+++ b/apps/api/src/app/docs/openapi.json/route.ts
@@ -138,7 +138,6 @@ As of February 1, 2026, regional admins can only create read-only API keys. If y
           "event-tag",
           "attendance",
           "location",
-          "me",
           "org",
           "ping",
           "position",
@@ -181,7 +180,8 @@ As of February 1, 2026, regional admins can only create read-only API keys. If y
       },
       {
         name: "Me",
-        description: "Used by the F3 Me app",
+        description:
+          "Used by the F3 Me app to allow authenticated users to manage their profile",
       },
       {
         name: "org",

--- a/apps/me/__tests__/api/users.test.ts
+++ b/apps/me/__tests__/api/users.test.ts
@@ -31,8 +31,6 @@ describe("Users API route", () => {
         {
           id: 1,
           f3Name: "Dredd",
-          firstName: "Joe",
-          lastName: "Smith",
           homeRegionId: 1,
           homeRegionName: "Charlotte",
           status: "active",
@@ -40,8 +38,6 @@ describe("Users API route", () => {
         {
           id: 2,
           f3Name: "Maverick",
-          firstName: "Pete",
-          lastName: "Mitchell",
           homeRegionId: 2,
           homeRegionName: "Raleigh",
           status: "active",
@@ -66,8 +62,6 @@ describe("Users API route", () => {
         {
           id: 1,
           f3Name: "Dredd",
-          firstName: "Joe",
-          lastName: "Smith",
           homeRegionId: 5,
           homeRegionName: "Charlotte",
           status: "active",

--- a/apps/me/src/hooks/__tests__/useUserSearch.test.ts
+++ b/apps/me/src/hooks/__tests__/useUserSearch.test.ts
@@ -34,20 +34,6 @@ describe("displayName", () => {
     expect(displayName(user)).toBe("Dredd");
   });
 
-  it("shows only region when no f3Name", () => {
-    const user = makeUser({
-      f3Name: null,
-    });
-    expect(displayName(user)).toBe("\u2014 Muletown");
-  });
-
-  it("shows only region when only region exists", () => {
-    const user = makeUser({
-      f3Name: null,
-    });
-    expect(displayName(user)).toBe("\u2014 Muletown");
-  });
-
   it("falls back to User #id when everything is null", () => {
     const user = makeUser({
       id: 42,

--- a/apps/me/src/hooks/__tests__/useUserSearch.test.ts
+++ b/apps/me/src/hooks/__tests__/useUserSearch.test.ts
@@ -10,8 +10,6 @@ function makeUser(overrides: Partial<UserListItem> = {}): UserListItem {
   return {
     id: 1,
     f3Name: "Dredd",
-    firstName: "Patrick",
-    lastName: "Smith",
     homeRegionId: 10,
     homeRegionName: "Muletown",
     status: "active",
@@ -24,33 +22,28 @@ function makeUser(overrides: Partial<UserListItem> = {}): UserListItem {
 // ---------------------------------------------------------------------------
 
 describe("displayName", () => {
-  it("shows f3Name, real name, and region", () => {
+  it("shows f3Name and region", () => {
     const user = makeUser();
-    expect(displayName(user)).toBe("Dredd (Patrick Smith) \u2014 Muletown");
+    expect(displayName(user)).toBe("Dredd \u2014 Muletown");
   });
 
-  it("shows only f3Name when no real name or region", () => {
+  it("shows only f3Name when no region", () => {
     const user = makeUser({
-      firstName: null,
-      lastName: null,
       homeRegionName: null,
     });
     expect(displayName(user)).toBe("Dredd");
   });
 
-  it("shows only real name when no f3Name", () => {
+  it("shows only region when no f3Name", () => {
     const user = makeUser({
       f3Name: null,
-      homeRegionName: null,
     });
-    expect(displayName(user)).toBe("(Patrick Smith)");
+    expect(displayName(user)).toBe("\u2014 Muletown");
   });
 
-  it("shows only region when no names", () => {
+  it("shows only region when only region exists", () => {
     const user = makeUser({
       f3Name: null,
-      firstName: null,
-      lastName: null,
     });
     expect(displayName(user)).toBe("\u2014 Muletown");
   });
@@ -59,27 +52,9 @@ describe("displayName", () => {
     const user = makeUser({
       id: 42,
       f3Name: null,
-      firstName: null,
-      lastName: null,
       homeRegionName: null,
     });
     expect(displayName(user)).toBe("User #42");
-  });
-
-  it("handles first name only (no last name)", () => {
-    const user = makeUser({
-      lastName: null,
-      homeRegionName: null,
-    });
-    expect(displayName(user)).toBe("Dredd (Patrick)");
-  });
-
-  it("handles last name only (no first name)", () => {
-    const user = makeUser({
-      firstName: null,
-      homeRegionName: null,
-    });
-    expect(displayName(user)).toBe("Dredd (Smith)");
   });
 });
 
@@ -94,14 +69,6 @@ describe("matchesSearch", () => {
     expect(matchesSearch(user, "DREDD")).toBe(true);
   });
 
-  it("matches by firstName", () => {
-    expect(matchesSearch(makeUser(), "pat")).toBe(true);
-  });
-
-  it("matches by lastName", () => {
-    expect(matchesSearch(makeUser(), "smith")).toBe(true);
-  });
-
   it("matches by region name", () => {
     expect(matchesSearch(makeUser(), "mule")).toBe(true);
   });
@@ -113,8 +80,6 @@ describe("matchesSearch", () => {
   it("returns false when all name fields are null", () => {
     const user = makeUser({
       f3Name: null,
-      firstName: null,
-      lastName: null,
       homeRegionName: null,
     });
     expect(matchesSearch(user, "anything")).toBe(false);

--- a/apps/me/src/hooks/useUserSearch.ts
+++ b/apps/me/src/hooks/useUserSearch.ts
@@ -28,10 +28,10 @@ export interface UseUserSearchReturn {
 
 /** Build a display string for a user in the dropdown. */
 export function displayName(u: UserListItem): string {
-  const parts: string[] = [];
-  if (u.f3Name) parts.push(u.f3Name);
-  if (u.homeRegionName) parts.push(`\u2014 ${u.homeRegionName}`);
-  return parts.join(" ") || `User #${u.id}`;
+  if (u.f3Name && u.homeRegionName)
+    return `${u.f3Name} \u2014 ${u.homeRegionName}`;
+  if (u.f3Name) return u.f3Name;
+  return `User #${u.id}`;
 }
 
 /** Check whether a user matches a search term (case-insensitive). */
@@ -139,8 +139,9 @@ export function useUserSearch({
   }, []);
 
   const filteredUsers = useMemo(() => {
-    if (!search) return users;
-    return users.filter((u) => matchesSearch(u, search));
+    const withName = users.filter((u) => !!u.f3Name);
+    if (!search) return withName;
+    return withName.filter((u) => matchesSearch(u, search));
   }, [users, search]);
 
   const isRegionScoped = !showAllRegions && !!homeRegionId;

--- a/apps/me/src/hooks/useUserSearch.ts
+++ b/apps/me/src/hooks/useUserSearch.ts
@@ -30,8 +30,6 @@ export interface UseUserSearchReturn {
 export function displayName(u: UserListItem): string {
   const parts: string[] = [];
   if (u.f3Name) parts.push(u.f3Name);
-  const real = [u.firstName, u.lastName].filter(Boolean).join(" ");
-  if (real) parts.push(`(${real})`);
   if (u.homeRegionName) parts.push(`\u2014 ${u.homeRegionName}`);
   return parts.join(" ") || `User #${u.id}`;
 }
@@ -41,8 +39,6 @@ export function matchesSearch(u: UserListItem, term: string): boolean {
   const lower = term.toLowerCase();
   return (
     (u.f3Name?.toLowerCase().includes(lower) ?? false) ||
-    (u.firstName?.toLowerCase().includes(lower) ?? false) ||
-    (u.lastName?.toLowerCase().includes(lower) ?? false) ||
     (u.homeRegionName?.toLowerCase().includes(lower) ?? false)
   );
 }

--- a/apps/me/src/lib/types.ts
+++ b/apps/me/src/lib/types.ts
@@ -54,8 +54,6 @@ export interface Region {
 export interface UserListItem {
   id: number;
   f3Name: string | null;
-  firstName: string | null;
-  lastName: string | null;
   homeRegionId: number | null;
   homeRegionName: string | null;
   status: "active" | "inactive";

--- a/packages/api/src/router/me/index.ts
+++ b/packages/api/src/router/me/index.ts
@@ -80,6 +80,49 @@ const profileUpdateSchema = z
   .strict()
   .describe("Whitelisted profile fields the user can update.");
 
+const meRoleSchema = z.object({
+  roleId: z.number().int().min(1),
+  orgId: z.number().int().min(1),
+  orgName: z.string(),
+  roleName: z.enum(["user", "editor", "admin"]),
+});
+
+const mePositionSchema = z.object({
+  positionId: z.number().int().min(1),
+  orgId: z.number().int().min(1),
+  positionName: z.string(),
+  orgName: z.string(),
+});
+
+const meProfileSchema = z.object({
+  id: z.number().int().min(1),
+  f3Name: z.string().nullable(),
+  firstName: z.string().nullable(),
+  lastName: z.string().nullable(),
+  email: z.string(),
+  emailVerified: z.string().nullable(),
+  phone: z.string().nullable(),
+  homeRegionId: z.number().int().min(1).nullable(),
+  avatarUrl: z.string().nullable(),
+  meta: z.union([z.record(z.unknown()), z.string()]).nullable(),
+  emergencyContact: z.string().nullable(),
+  emergencyPhone: z.string().nullable(),
+  emergencyNotes: z.string().nullable(),
+  status: z.enum(["active", "inactive"]),
+  created: z.string(),
+  updated: z.string(),
+  roles: z.array(meRoleSchema),
+  positions: z.array(mePositionSchema),
+});
+
+const meUsersListItemSchema = z.object({
+  id: z.number().int().min(1),
+  f3Name: z.string().nullable(),
+  homeRegionId: z.number().int().min(1).nullable(),
+  homeRegionName: z.string().nullable(),
+  status: z.enum(["active", "inactive"]),
+});
+
 /** Fetch the full profile (user + roles + positions) for the given userId. */
 async function fetchFullProfile(db: AppDb, userId: number) {
   const [user] = await db
@@ -159,6 +202,11 @@ export const meRouter = {
       description:
         "Return the authenticated user's full profile including PII, roles, and position assignments in a single call.",
     })
+    .output(
+      z.object({
+        user: meProfileSchema,
+      }),
+    )
     .handler(async ({ context: ctx }) => {
       const user = await fetchFullProfile(ctx.db, ctx.session!.id);
       return { user };
@@ -178,6 +226,11 @@ export const meRouter = {
       description:
         "Update the authenticated user's profile fields. Only whitelisted fields are accepted. Returns the full updated profile.",
     })
+    .output(
+      z.object({
+        user: meProfileSchema,
+      }),
+    )
     .handler(async ({ context: ctx, input }) => {
       const userId = ctx.session!.id;
 
@@ -230,6 +283,17 @@ export const meRouter = {
       description:
         "Return all regions (active and inactive) for the region dropdown. Each region includes an isActive flag so the UI can restrict new selections to active ones.",
     })
+    .output(
+      z.object({
+        orgs: z.array(
+          z.object({
+            id: z.number().int().min(1),
+            name: z.string(),
+            isActive: z.boolean(),
+          }),
+        ),
+      }),
+    )
     .handler(async ({ context: ctx }) => {
       const regions = await ctx.db
         .select({
@@ -272,6 +336,12 @@ export const meRouter = {
       description:
         "Remove the authenticated user from a specific position at a specific org.",
     })
+    .output(
+      z.object({
+        success: z.boolean(),
+        found: z.boolean(),
+      }),
+    )
     .handler(async ({ context: ctx, input }) => {
       const userId = ctx.session!.id;
 
@@ -319,6 +389,12 @@ export const meRouter = {
       description:
         "Remove the authenticated user from a specific role at a specific org.",
     })
+    .output(
+      z.object({
+        success: z.boolean(),
+        found: z.boolean(),
+      }),
+    )
     .handler(async ({ context: ctx, input }) => {
       const userId = ctx.session!.id;
 
@@ -364,6 +440,11 @@ export const meRouter = {
         "Return a lightweight user list for the 'Who Brought You?' dropdown. " +
         "Optionally filter by homeRegionId to limit results to the same region.",
     })
+    .output(
+      z.object({
+        users: z.array(meUsersListItemSchema),
+      }),
+    )
     .handler(async ({ context: ctx, input }) => {
       const homeRegionId = input?.homeRegionId;
 
@@ -376,8 +457,6 @@ export const meRouter = {
         .select({
           id: schema.users.id,
           f3Name: schema.users.f3Name,
-          firstName: schema.users.firstName,
-          lastName: schema.users.lastName,
           homeRegionId: schema.users.homeRegionId,
           homeRegionName: sql<string | null>`${schema.orgs.name}`,
           status: schema.users.status,
@@ -385,7 +464,7 @@ export const meRouter = {
         .from(schema.users)
         .leftJoin(schema.orgs, eq(schema.orgs.id, schema.users.homeRegionId))
         .where(conditions.length > 0 ? and(...conditions) : undefined)
-        .orderBy(asc(schema.users.f3Name), asc(schema.users.lastName));
+        .orderBy(asc(schema.users.f3Name), asc(schema.users.id));
 
       return { users: rows };
     }),

--- a/packages/api/src/router/me/me.test.ts
+++ b/packages/api/src/router/me/me.test.ts
@@ -536,6 +536,8 @@ describe("Me Router", () => {
       expect(first).toHaveProperty("f3Name");
       expect(first).toHaveProperty("homeRegionId");
       expect(first).toHaveProperty("status");
+      expect(first).not.toHaveProperty("firstName");
+      expect(first).not.toHaveProperty("lastName");
     });
 
     it("should filter by homeRegionId", async () => {


### PR DESCRIPTION
Removing real name fields and updating related logic, tests, and API schemas. It also improves API response schemas for better type safety and clarity. This only affects the GET /me/users API endpoint and the who brought me field in Me.

**User Name Handling and Display Simplification**
- Removed `firstName` and `lastName` fields from the `UserListItem` type, user search, and display logic, so user lists now only show `f3Name` and region, not real names. Tests and UI expectations were updated to match this change. [[1]](diffhunk://#diff-cbd596ad38c95f41bbfebc224a3fcc5c11437109e11861b5953738a9fb324f01L57-L58) [[2]](diffhunk://#diff-4f457f7684a8b98be4a2f187b9de35339198adf81808106781c9ed1480cd7c29L33-L34) [[3]](diffhunk://#diff-aeb8c01618335048b0db6db3a9f817714d18afa86c348a5c4bea57145ed55104L13-L14) [[4]](diffhunk://#diff-aeb8c01618335048b0db6db3a9f817714d18afa86c348a5c4bea57145ed55104L27-L53) [[5]](diffhunk://#diff-aeb8c01618335048b0db6db3a9f817714d18afa86c348a5c4bea57145ed55104L62-L83) [[6]](diffhunk://#diff-aeb8c01618335048b0db6db3a9f817714d18afa86c348a5c4bea57145ed55104L97-L104) [[7]](diffhunk://#diff-aeb8c01618335048b0db6db3a9f817714d18afa86c348a5c4bea57145ed55104L116-L117) [[8]](diffhunk://#diff-02918431eb27016d7330e149305b1e8aae14107a7a914782674827729057a11eL34-L44) [[9]](diffhunk://#diff-02918431eb27016d7330e149305b1e8aae14107a7a914782674827729057a11eL69-L70)
- Updated user search functionality to match only on `f3Name` and region name, no longer supporting search by real names.
- Adjusted API user list queries and ordering to remove real name fields and sort by `f3Name` and `id` instead of last name.

**API Schema and Response Improvements**
- Added detailed Zod schemas for user profile, roles, positions, and user list items, and specified these as output types for relevant API endpoints to improve type safety and documentation. [[1]](diffhunk://#diff-5fef05d5e1a9a6c4bbbe6f454d353967eb7d01dc14f4c129d25629eb281045cdR83-R125) [[2]](diffhunk://#diff-5fef05d5e1a9a6c4bbbe6f454d353967eb7d01dc14f4c129d25629eb281045cdR205-R209) [[3]](diffhunk://#diff-5fef05d5e1a9a6c4bbbe6f454d353967eb7d01dc14f4c129d25629eb281045cdR229-R233) [[4]](diffhunk://#diff-5fef05d5e1a9a6c4bbbe6f454d353967eb7d01dc14f4c129d25629eb281045cdR286-R296) [[5]](diffhunk://#diff-5fef05d5e1a9a6c4bbbe6f454d353967eb7d01dc14f4c129d25629eb281045cdR339-R344) [[6]](diffhunk://#diff-5fef05d5e1a9a6c4bbbe6f454d353967eb7d01dc14f4c129d25629eb281045cdR392-R397) [[7]](diffhunk://#diff-5fef05d5e1a9a6c4bbbe6f454d353967eb7d01dc14f4c129d25629eb281045cdR443-R447)
- Updated API tests to assert that real name fields are no longer present in user list responses.

**Documentation Updates**
- Clarified the description for the "Me" API tag to better explain its purpose for authenticated user profile management.
- Removed the "me" tag from the OpenAPI route tag list, likely reflecting internal API documentation changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Profiles and dropdowns now prioritize F3 name + home region, falling back to F3 name or "User #<id>"
  * User lists include home region ID, region name, and status; ordering adjusted to sort by F3 name then ID
  * Search now matches only F3 name and home region (first/last name no longer searched)

* **Documentation**
  * "Me" API tag description expanded for clearer usage context

* **Tests**
  * Tests updated to reflect new response shape, displayName rules, and search behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->