### PR TITLE
fix(typecheck): disable Turborepo daemon to stop pre-commit hang

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "reset-test-db": "turbo run reset-test-db",
     "test:coverage": "turbo test -- --coverage",
     "test": "turbo test",
-    "typecheck": "turbo typecheck --filter='!@acme/auth'",
+    "typecheck": "turbo typecheck --no-daemon --filter='!@acme/auth'",
     "with-env": "dotenv -e .env --"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

The Turborepo daemon's filesystem watcher can overflow and block `turbo typecheck` indefinitely, waiting on a watcher-cookie ACK that never arrives — which hangs the pre-commit hook (reported by Tackle in the #monorepo thread: "kill the terminal and re-run and it goes through quick").

This PR runs the canonical root `typecheck` script with **`--no-daemon`** so the typecheck invocation sidesteps the daemon entirely. One line:

```diff
- "typecheck": "turbo typecheck --filter='!@acme/auth'",
+ "typecheck": "turbo typecheck --no-daemon --filter='!@acme/auth'",
```

## Implementation notes

- Slimmed from the original PR per review (@taterhead247): the standalone RCA write-up and repro script were dropped as overkill for a fix this small — the root-cause explanation now lives in the commit message (discoverable via `git blame`). RCAs generally belong in the repo; this one just isn't worth the long-term weight for a one-line flag.
- The pre-commit hook is unchanged — it still delegates to `pnpm typecheck`, which now carries the flag, so there's no place for the flag to drift out of sync.

## Test plan

- [x] CI is green on this branch
- [x] Pre-commit `typecheck` completes without hanging (verified locally — this PR's own pre-commit hook ran `turbo typecheck --no-daemon` and passed)