### PR TITLE
fix(map): make NEXT_PUBLIC_ADMIN_URL optional, derive from channel

### DIFF
--- a/apps/map/src/app/_components/modal/settings-modal.tsx
+++ b/apps/map/src/app/_components/modal/settings-modal.tsx
@@ -279,25 +279,35 @@ export default function SettingsModal() {
                     </p>
                   ))}
                 </div>
-                {isEditorOrAdmin && (
-                  <Link
-                    href={env.NEXT_PUBLIC_ADMIN_URL}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    <button
-                      className={cn(
-                        "flex w-full flex-row items-center justify-center gap-1 rounded-md bg-background p-2 text-foreground shadow-sm hover:bg-accent",
-                      )}
-                      onClick={() => {
-                        closeModal();
-                      }}
-                    >
-                      <Shield className="size-4" />
-                      <span className="text-xs">Admin Portal</span>
-                    </button>
-                  </Link>
-                )}
+                {isEditorOrAdmin &&
+                  (() => {
+                    const adminUrl =
+                      env.NEXT_PUBLIC_ADMIN_URL ??
+                      (env.NEXT_PUBLIC_CHANNEL === "prod"
+                        ? "https://admin.f3nation.com"
+                        : env.NEXT_PUBLIC_CHANNEL === "staging"
+                          ? "https://staging.admin.f3nation.com"
+                          : undefined);
+                    return adminUrl ? (
+                      <Link
+                        href={adminUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        <button
+                          className={cn(
+                            "flex w-full flex-row items-center justify-center gap-1 rounded-md bg-background p-2 text-foreground shadow-sm hover:bg-accent",
+                          )}
+                          onClick={() => {
+                            closeModal();
+                          }}
+                        >
+                          <Shield className="size-4" />
+                          <span className="text-xs">Admin Portal</span>
+                        </button>
+                      </Link>
+                    ) : null;
+                  })()}
                 <Link
                   href={"/api/auth/signout"}
                   onClick={() => {

--- a/apps/map/src/env.ts
+++ b/apps/map/src/env.ts
@@ -44,7 +44,7 @@ export const env = createEnv({
   client: {
     NEXT_PUBLIC_MAP_URL: z.string().min(1),
     NEXT_PUBLIC_API_URL: z.string().min(1),
-    NEXT_PUBLIC_ADMIN_URL: z.string().min(1),
+    NEXT_PUBLIC_ADMIN_URL: z.string().min(1).optional(),
     NEXT_PUBLIC_GOOGLE_API_KEY: z.string().min(1),
   },
   /**


### PR DESCRIPTION
This pull request updates the logic for displaying the Admin Portal link in the `SettingsModal` component, making the admin URL configuration more flexible and robust. The main improvements are around how the admin URL is determined and validated, especially when environment variables may be missing.

Environment configuration:

* Made the `NEXT_PUBLIC_ADMIN_URL` environment variable optional in `env.ts`, allowing the app to run even if this variable is not set.

Admin Portal link logic:

* Updated the `SettingsModal` component to dynamically determine the admin URL based on environment variables and the current deployment channel (`prod` or `staging`). If `NEXT_PUBLIC_ADMIN_URL` is not set, the component falls back to default URLs depending on the deployment channel, or hides the link if no URL is available. [[1]](diffhunk://#diff-fc27fca9e48f04308702dc33263ae2f328f9aed1ad4bfa8a884a4196771481a0L282-R293) [[2]](diffhunk://#diff-fc27fca9e48f04308702dc33263ae2f328f9aed1ad4bfa8a884a4196771481a0L300-R310)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated Admin Portal button to dynamically configure its destination URL from environment variables. The button now only appears when an admin URL is properly configured and opens in a new tab with security measures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/F3-Nation/f3-nation/pull/306?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->