### PR TITLE
Fix admin redirect and update email links to new URL

### DIFF
--- a/apps/map/next.config.js
+++ b/apps/map/next.config.js
@@ -43,11 +43,24 @@ const config = {
   eslint: { ignoreDuringBuilds: true },
   typescript: { ignoreBuildErrors: true },
   redirects: async () => {
+    const adminUrl = (
+      process.env.NEXT_PUBLIC_ADMIN_URL ?? "https://admin.f3nation.com"
+    ).replace(/\/$/, "");
     return [
       {
         source: "/map",
         destination: "/",
         permanent: true,
+      },
+      {
+        source: "/admin",
+        destination: adminUrl,
+        permanent: false,
+      },
+      {
+        source: "/admin/:path*",
+        destination: `${adminUrl}/:path*`,
+        permanent: false,
       },
     ];
   },

--- a/packages/api/src/services/map-request-notification.ts
+++ b/packages/api/src/services/map-request-notification.ts
@@ -216,10 +216,7 @@ export const notifyMapChangeRequest = async ({
   }
 
   // Prepare email parameters
-  const adminBaseUrl = env.NEXT_PUBLIC_ADMIN_URL?.endsWith("/")
-    ? env.NEXT_PUBLIC_ADMIN_URL.slice(0, -1)
-    : env.NEXT_PUBLIC_ADMIN_URL ?? "";
-
+  const adminBaseUrl = (env.NEXT_PUBLIC_ADMIN_URL ?? "").replace(/\/$/, "");
   const requestsUrl = `${adminBaseUrl}/requests`;
   const title = requestTypeToTitle(request.requestType);
 

--- a/tooling/scripts/src/notify-outstanding-requests.ts
+++ b/tooling/scripts/src/notify-outstanding-requests.ts
@@ -158,10 +158,8 @@ async function main() {
   console.log("\n" + "─".repeat(80));
   console.log("\n📬 Email Summary:\n");
 
-  const mapBaseUrl = env.NEXT_PUBLIC_MAP_URL?.endsWith("/")
-    ? env.NEXT_PUBLIC_MAP_URL.slice(0, -1)
-    : env.NEXT_PUBLIC_MAP_URL ?? "";
-  const requestsUrl = `${mapBaseUrl}/admin/requests`;
+  const adminBaseUrl = (env.NEXT_PUBLIC_ADMIN_URL ?? "").replace(/\/$/, "");
+  const requestsUrl = `${adminBaseUrl}/requests`;
 
   // Display and optionally send emails
   let emailsSent = 0;


### PR DESCRIPTION
This pull request standardizes how the `NEXT_PUBLIC_ADMIN_URL` environment variable is handled across multiple parts of the codebase, ensuring consistent URL formatting and usage. Additionally, it introduces new redirect rules in the Next.js configuration to route `/admin` paths to the appropriate admin interface.

**Redirect and URL handling improvements:**

* Added new redirect rules in `next.config.js` to forward `/admin` and `/admin/:path*` requests to the admin interface, using the `NEXT_PUBLIC_ADMIN_URL` environment variable and ensuring no trailing slash is present.
* Updated the logic for constructing the admin base URL in both `map-request-notification.ts` and `notify-outstanding-requests.ts` to consistently remove trailing slashes using `.replace(/\/$/, "")`, preventing double slashes in URLs. [[1]](diffhunk://#diff-33f93271130e0183e85d345c5105780198375ac4201bb5de2dae65f50df1041dL219-R219) [[2]](diffhunk://#diff-c96a9dddccce3c67749b88f7ad0bbe842e5422a92234be0a5ad184becf4d195fL161-R162)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The map application now includes configurable admin route redirection, enabling seamless navigation to a dedicated admin base URL

* **Bug Fixes**
  * Corrected email notifications for map change requests to reference the proper admin interface location

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/F3-Nation/f3-nation/pull/307?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->