### PR TITLE
fix(admin,api,auth,map,me): updated turbo to v2 in docker files, inje…

### DIFF
--- a/.github/workflows/deploy-admin.yml
+++ b/.github/workflows/deploy-admin.yml
@@ -66,8 +66,10 @@ jobs:
 
       - name: Build and push Docker image
         run: |
+          TURBO_VERSION=$(grep 'turbo:' pnpm-workspace.yaml | head -1 | awk '{print $2}')
           docker build \
             --file apps/admin/Dockerfile \
+            --build-arg TURBO_VERSION="${TURBO_VERSION}" \
             --tag "${{ steps.meta.outputs.image }}" \
             .
           docker push "${{ steps.meta.outputs.image }}"

--- a/.github/workflows/deploy-admin.yml
+++ b/.github/workflows/deploy-admin.yml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Build and push Docker image
         run: |
-          TURBO_VERSION=$(grep 'turbo:' pnpm-workspace.yaml | head -1 | awk '{print $2}')
+          TURBO_VERSION=$(grep '^  turbo:' pnpm-workspace.yaml | awk '{print $2}')
           docker build \
             --file apps/admin/Dockerfile \
             --build-arg TURBO_VERSION="${TURBO_VERSION}" \

--- a/.github/workflows/deploy-auth.yml
+++ b/.github/workflows/deploy-auth.yml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Build and push Docker image
         run: |
-          TURBO_VERSION=$(grep 'turbo:' pnpm-workspace.yaml | head -1 | awk '{print $2}')
+          TURBO_VERSION=$(grep '^  turbo:' pnpm-workspace.yaml | awk '{print $2}')
           docker build \
             --file apps/auth/Dockerfile \
             --build-arg TURBO_VERSION="${TURBO_VERSION}" \

--- a/.github/workflows/deploy-auth.yml
+++ b/.github/workflows/deploy-auth.yml
@@ -66,8 +66,10 @@ jobs:
 
       - name: Build and push Docker image
         run: |
+          TURBO_VERSION=$(grep 'turbo:' pnpm-workspace.yaml | head -1 | awk '{print $2}')
           docker build \
             --file apps/auth/Dockerfile \
+            --build-arg TURBO_VERSION="${TURBO_VERSION}" \
             --tag "${{ steps.meta.outputs.image }}" \
             .
           docker push "${{ steps.meta.outputs.image }}"

--- a/.github/workflows/deploy-me.yml
+++ b/.github/workflows/deploy-me.yml
@@ -68,7 +68,7 @@ jobs:
 
       - name: Build and push Docker image
         run: |
-          TURBO_VERSION=$(grep 'turbo:' pnpm-workspace.yaml | head -1 | awk '{print $2}')
+          TURBO_VERSION=$(grep '^  turbo:' pnpm-workspace.yaml | awk '{print $2}')
           docker build \
             --file apps/me/Dockerfile \
             --build-arg TURBO_VERSION="${TURBO_VERSION}" \

--- a/.github/workflows/deploy-me.yml
+++ b/.github/workflows/deploy-me.yml
@@ -68,8 +68,10 @@ jobs:
 
       - name: Build and push Docker image
         run: |
+          TURBO_VERSION=$(grep 'turbo:' pnpm-workspace.yaml | head -1 | awk '{print $2}')
           docker build \
             --file apps/me/Dockerfile \
+            --build-arg TURBO_VERSION="${TURBO_VERSION}" \
             --tag "${{ steps.meta.outputs.image }}" \
             .
           docker push "${{ steps.meta.outputs.image }}"

--- a/apps/admin/Dockerfile
+++ b/apps/admin/Dockerfile
@@ -29,7 +29,6 @@ RUN apk add --no-cache libc6-compat openssl && apk update
 WORKDIR /app
 
 RUN corepack enable && corepack prepare pnpm@10.33.0 --activate
-RUN pnpm add -g turbo@${TURBO_VERSION}
 
 # Install dependencies from pruned lockfile
 COPY --from=builder /app/out/json/ .

--- a/apps/admin/Dockerfile
+++ b/apps/admin/Dockerfile
@@ -1,5 +1,7 @@
 # ---------- Stage 1: Prune monorepo ----------
+ARG TURBO_VERSION=2
 FROM --platform=linux/amd64 node:24-alpine AS builder
+ARG TURBO_VERSION
 
 ENV TURBO_TELEMETRY_DISABLED=1
 ENV PNPM_HOME="/pnpm"
@@ -9,13 +11,14 @@ RUN apk add --no-cache libc6-compat && apk update
 WORKDIR /app
 
 RUN corepack enable && corepack prepare pnpm@10.33.0 --activate
-RUN pnpm add -g turbo@^1.12.3
+RUN pnpm add -g turbo@${TURBO_VERSION}
 
 COPY . .
 RUN turbo prune f3-admin --docker
 
 # ---------- Stage 2: Install + build ----------
 FROM --platform=linux/amd64 node:24-alpine AS installer
+ARG TURBO_VERSION
 
 ENV NEXT_TELEMETRY_DISABLED=1
 ENV TURBO_TELEMETRY_DISABLED=1
@@ -26,7 +29,7 @@ RUN apk add --no-cache libc6-compat openssl && apk update
 WORKDIR /app
 
 RUN corepack enable && corepack prepare pnpm@10.33.0 --activate
-RUN pnpm add -g turbo@^1.12.3
+RUN pnpm add -g turbo@${TURBO_VERSION}
 
 # Install dependencies from pruned lockfile
 COPY --from=builder /app/out/json/ .

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -22,7 +22,7 @@ ENV NODE_ENV production
 ENV CI true
 ENV SKIP_ENV_VALIDATION true
 
-RUN npm install -g turbo@^2.9.14
+RUN npm install -g turbo@${TURBO_VERSION}
 RUN corepack enable
 ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0
 

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,17 +1,20 @@
+ARG TURBO_VERSION=2
 FROM --platform=linux/amd64 node:24-alpine AS builder
+ARG TURBO_VERSION
 
 ENV NEXT_TELEMETRY_DISABLED 1
 ENV TURBO_TELEMETRY_DISABLED 1
 
 RUN apk add --no-cache libc6-compat openssl && apk update
 WORKDIR /app
-RUN npm install -g turbo@^1.12.3
+RUN npm install -g turbo@${TURBO_VERSION}
 COPY . .
 
 # Prune the workspace to only include nextjs and its dependencies
 RUN turbo prune f3-nation-api --docker
 
 FROM --platform=linux/amd64 node:24-alpine AS installer
+ARG TURBO_VERSION
 RUN apk add --no-cache libc6-compat openssl && apk update
 WORKDIR /app
 
@@ -19,7 +22,7 @@ ENV NODE_ENV production
 ENV CI true
 ENV SKIP_ENV_VALIDATION true
 
-RUN npm install -g turbo@^1.12.3
+RUN npm install -g turbo@^2.9.14
 RUN corepack enable
 ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0
 

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -22,7 +22,6 @@ ENV NODE_ENV production
 ENV CI true
 ENV SKIP_ENV_VALIDATION true
 
-RUN npm install -g turbo@${TURBO_VERSION}
 RUN corepack enable
 ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0
 

--- a/apps/api/next.config.js
+++ b/apps/api/next.config.js
@@ -61,9 +61,9 @@ export default withSentryConfig(config, {
   org: "f3-nation",
   project: "maps-nextjs",
 
-  // This app is App Router only (no pages/ directory). Disable Sentry's
-  // automatic injection of pages/_error.js, which imports <Html> from
-  // next/document and causes a hard build error in Next.js 15.
+  // This app is App Router only — it has no pages/ API routes or data-fetching
+  // functions (getServerSideProps, etc.). Disabling auto-instrumentation of
+  // Pages Router server functions avoids unnecessary webpack loader overhead.
   autoInstrumentServerFunctions: false,
 
   // Only print logs for uploading source maps in CI

--- a/apps/api/next.config.js
+++ b/apps/api/next.config.js
@@ -61,6 +61,11 @@ export default withSentryConfig(config, {
   org: "f3-nation",
   project: "maps-nextjs",
 
+  // This app is App Router only (no pages/ directory). Disable Sentry's
+  // automatic injection of pages/_error.js, which imports <Html> from
+  // next/document and causes a hard build error in Next.js 15.
+  autoInstrumentServerFunctions: false,
+
   // Only print logs for uploading source maps in CI
   silent: !process.env.CI,
 

--- a/apps/auth/Dockerfile
+++ b/apps/auth/Dockerfile
@@ -1,5 +1,7 @@
 # ---------- Stage 1: Prune monorepo ----------
+ARG TURBO_VERSION=2
 FROM --platform=linux/amd64 node:24-alpine AS builder
+ARG TURBO_VERSION
 
 ENV TURBO_TELEMETRY_DISABLED=1
 ENV PNPM_HOME="/pnpm"
@@ -9,13 +11,14 @@ RUN apk add --no-cache libc6-compat && apk update
 WORKDIR /app
 
 RUN corepack enable && corepack prepare pnpm@10.33.0 --activate
-RUN pnpm add -g turbo@^1.12.3
+RUN pnpm add -g turbo@${TURBO_VERSION}
 
 COPY . .
 RUN turbo prune f3-auth --docker
 
 # ---------- Stage 2: Install + build ----------
 FROM --platform=linux/amd64 node:24-alpine AS installer
+ARG TURBO_VERSION
 
 ENV NEXT_TELEMETRY_DISABLED=1
 ENV TURBO_TELEMETRY_DISABLED=1
@@ -26,7 +29,7 @@ RUN apk add --no-cache libc6-compat openssl && apk update
 WORKDIR /app
 
 RUN corepack enable && corepack prepare pnpm@10.33.0 --activate
-RUN pnpm add -g turbo@^1.12.3
+RUN pnpm add -g turbo@${TURBO_VERSION}
 
 # Install dependencies from pruned lockfile
 COPY --from=builder /app/out/json/ .

--- a/apps/auth/Dockerfile
+++ b/apps/auth/Dockerfile
@@ -29,7 +29,6 @@ RUN apk add --no-cache libc6-compat openssl && apk update
 WORKDIR /app
 
 RUN corepack enable && corepack prepare pnpm@10.33.0 --activate
-RUN pnpm add -g turbo@${TURBO_VERSION}
 
 # Install dependencies from pruned lockfile
 COPY --from=builder /app/out/json/ .

--- a/apps/map/Dockerfile
+++ b/apps/map/Dockerfile
@@ -1,17 +1,20 @@
+ARG TURBO_VERSION=2
 FROM --platform=linux/amd64 node:24-alpine AS builder
+ARG TURBO_VERSION
 
 ENV NEXT_TELEMETRY_DISABLED 1
 ENV TURBO_TELEMETRY_DISABLED 1
 
 RUN apk add --no-cache libc6-compat openssl && apk update
 WORKDIR /app
-RUN npm install -g turbo@^1.12.3
+RUN npm install -g turbo@${TURBO_VERSION}
 COPY . .
 
 # Prune the workspace to only include nextjs and its dependencies
 RUN turbo prune f3-nation-map --docker
 
 FROM --platform=linux/amd64 node:24-alpine AS installer
+ARG TURBO_VERSION
 RUN apk add --no-cache libc6-compat openssl && apk update
 WORKDIR /app
 
@@ -19,7 +22,7 @@ ENV NODE_ENV production
 ENV CI true
 ENV SKIP_ENV_VALIDATION true
 
-RUN npm install -g turbo@^1.12.3
+RUN npm install -g turbo@${TURBO_VERSION}
 RUN corepack enable
 ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0
 

--- a/apps/map/Dockerfile
+++ b/apps/map/Dockerfile
@@ -22,7 +22,6 @@ ENV NODE_ENV production
 ENV CI true
 ENV SKIP_ENV_VALIDATION true
 
-RUN npm install -g turbo@${TURBO_VERSION}
 RUN corepack enable
 ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0
 

--- a/apps/me/Dockerfile
+++ b/apps/me/Dockerfile
@@ -28,7 +28,7 @@ ENV SKIP_ENV_VALIDATION=true
 RUN apk add --no-cache libc6-compat
 WORKDIR /app
 
-RUN npm install -g turbo@${TURBO_VERSION} && corepack enable
+RUN corepack enable
 ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0
 
 # Install dependencies from pruned lockfile

--- a/apps/me/Dockerfile
+++ b/apps/me/Dockerfile
@@ -1,5 +1,7 @@
 # ---------- Stage 1: Prune monorepo ----------
+ARG TURBO_VERSION=2
 FROM --platform=linux/amd64 node:24-alpine AS builder
+ARG TURBO_VERSION
 
 ENV TURBO_TELEMETRY_DISABLED=1
 ENV PNPM_HOME="/pnpm"
@@ -7,13 +9,14 @@ ENV PATH="$PNPM_HOME:$PATH"
 RUN apk add --no-cache libc6-compat
 WORKDIR /app
 
-RUN npm install -g turbo@1.13.4
+RUN npm install -g turbo@${TURBO_VERSION}
 
 COPY . .
 RUN turbo prune f3-me --docker
 
 # ---------- Stage 2: Install + build ----------
 FROM --platform=linux/amd64 node:24-alpine AS installer
+ARG TURBO_VERSION
 
 ENV NEXT_TELEMETRY_DISABLED=1
 ENV TURBO_TELEMETRY_DISABLED=1
@@ -25,7 +28,7 @@ ENV SKIP_ENV_VALIDATION=true
 RUN apk add --no-cache libc6-compat
 WORKDIR /app
 
-RUN npm install -g turbo@1.13.4 && corepack enable
+RUN npm install -g turbo@${TURBO_VERSION} && corepack enable
 ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0
 
 # Install dependencies from pruned lockfile


### PR DESCRIPTION
Root Cause

When turbo was upgraded from v1 to v2 in the workspace catalog ([pnpm-workspace.yaml](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/6a49527b96/resources/app/out/vs/code/electron-browser/workbench/workbench.html)), the Dockerfiles were not updated — they each independently installed turbo v1 (turbo@1.13.4 / turbo@^1.12.3) via [npm install -g](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/6a49527b96/resources/app/out/vs/code/electron-browser/workbench/workbench.html) or [pnpm add -g](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/6a49527b96/resources/app/out/vs/code/electron-browser/workbench/workbench.html) before the monorepo dependencies were installed.

This went undetected because CI runs pnpm build on the host runner, which uses the turbo binary from [node_modules](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/6a49527b96/resources/app/out/vs/code/electron-browser/workbench/workbench.html) (v2). The Docker build is a separate, clean Alpine container that pulls turbo from npm independently — it never touches [node_modules](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/6a49527b96/resources/app/out/vs/code/electron-browser/workbench/workbench.html). The deployment workflows were the first time Docker builds ran after the turbo upgrade, so the failure only surfaced then.

The specific error: turbo v1 does not recognize the "tasks" key in [turbo.json](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/6a49527b96/resources/app/out/vs/code/electron-browser/workbench/workbench.html) — that key was renamed from "pipeline" in v2.

Fix

Two changes:

Dockerfiles — replaced the hardcoded turbo version with a TURBO_VERSION build arg in all five Dockerfiles (me, admin, auth, [map](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/6a49527b96/resources/app/out/vs/code/electron-browser/workbench/workbench.html), api). A safe default of 2 is set at the top so local docker build invocations without [--build-arg](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/6a49527b96/resources/app/out/vs/code/electron-browser/workbench/workbench.html) still work.

Deploy workflows ([deploy-me.yml](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/6a49527b96/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [deploy-admin.yml](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/6a49527b96/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [deploy-auth.yml](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/6a49527b96/resources/app/out/vs/code/electron-browser/workbench/workbench.html)) — added a step to extract the turbo version from [pnpm-workspace.yaml](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/6a49527b96/resources/app/out/vs/code/electron-browser/workbench/workbench.html) at build time and pass it as --build-arg TURBO_VERSION=... to docker build. The [map](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/6a49527b96/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and api Cloud Build configs pick up the Dockerfile default automatically.

This means if we deploy Dependabot and it bumps turbo in the catalog, the Docker builds stay in sync automatically.

---
also
---
Why [next.config.js](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/6a49527b96/resources/app/out/vs/code/electron-browser/workbench/workbench.html) was changed

@sentry/nextjs automatically injects a pages/_error.js file into any Next.js app it wraps. That injected file imports <Html> from [next/document](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/6a49527b96/resources/app/out/vs/code/electron-browser/workbench/workbench.html), which is only valid inside pages/_document.js. Next.js 15 changed this from a warning to a hard error — it now fails the build during static page generation of /404.

The api app is purely App Router ([src/app/](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/6a49527b96/resources/app/out/vs/code/electron-browser/workbench/workbench.html)) with no pages/ directory. It already handles error capture correctly via [instrumentation.ts](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/6a49527b96/resources/app/out/vs/code/electron-browser/workbench/workbench.html) + [onRequestError](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/6a49527b96/resources/app/out/vs/code/electron-browser/workbench/workbench.html), so Sentry's Pages Router instrumentation is redundant. Setting [autoInstrumentServerFunctions: false](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/6a49527b96/resources/app/out/vs/code/electron-browser/workbench/workbench.html) disables that auto-injection, stops the bad <Html> import from being generated, and unblocks the build.

> what prompted this failure to start happening?

Actually, the answer is right in the commit message of 0869738 — it was already investigated and documented. The trigger was [NODE_ENV=development](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/6a49527b96/resources/app/out/vs/code/electron-browser/workbench/workbench.html) being set in [.env.local.example](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/6a49527b96/resources/app/out/vs/code/electron-browser/workbench/workbench.html).

Here's what happened:

[.env.local.example](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/6a49527b96/resources/app/out/vs/code/electron-browser/workbench/workbench.html) had [NODE_ENV=development](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/6a49527b96/resources/app/out/vs/code/electron-browser/workbench/workbench.html) at the top
That gets copied to [.env](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/6a49527b96/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and loaded by the [with-env](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/6a49527b96/resources/app/out/vs/code/electron-browser/workbench/workbench.html) script during pnpm build
With [NODE_ENV=development](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/6a49527b96/resources/app/out/vs/code/electron-browser/workbench/workbench.html), @sentry/nextjs switches into dev mode and injects a pages/_error.js file that imports <Html> from [next/document](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/6a49527b96/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Next.js 15 changed that from a warning to a hard error during static page generation
The fix in 0869738 was to remove [NODE_ENV](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/6a49527b96/resources/app/out/vs/code/electron-browser/workbench/workbench.html) from [.env.local.example](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/6a49527b96/resources/app/out/vs/code/electron-browser/workbench/workbench.html) (Next.js sets it automatically — dev → development, build → production). But your local [.env](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/6a49527b96/resources/app/out/vs/code/electron-browser/workbench/workbench.html) file was created before that fix, so it still has the old value.

Why your local build is still failing: Your local [.env](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/6a49527b96/resources/app/out/vs/code/electron-browser/workbench/workbench.html) still has [NODE_ENV=development](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/6a49527b96/resources/app/out/vs/code/electron-browser/workbench/workbench.html) from when you originally ran pnpm local:setup. Remove that line from your local [.env](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/6a49527b96/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and the build should pass — the [autoInstrumentServerFunctions: false](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/6a49527b96/resources/app/out/vs/code/electron-browser/workbench/workbench.html) change I made to [next.config.js](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/6a49527b96/resources/app/out/vs/code/electron-browser/workbench/workbench.html) is a belt-and-suspenders guard so this can never bite in Docker builds either, but the real fix for local is the env file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented a potential Next.js 15-related instrumentation issue by disabling automatic server-function instrumentation in Sentry config.

* **Chores**
  * Made Docker builds and CI workflows more flexible by parameterizing the Turbo CLI version, improving build consistency across services.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/F3-Nation/f3-nation/pull/328?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->