### PR TITLE
feat(deps): add Renovate for automated dependency updates

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -163,4 +163,5 @@ allowBuilds:
   lefthook: true
   sharp: true
   unrs-resolver: true
-minimumReleaseAge: 10080
+minimumReleaseAge: 4320
+

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -163,4 +163,4 @@ allowBuilds:
   lefthook: true
   sharp: true
   unrs-resolver: true
-
+minimumReleaseAge: 10080

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,120 @@
+{
+  "$schema": "https://json.schemastore.org/renovate.json",
+  "extends": ["config:recommended"],
+  "enabledManagers": ["github-actions", "npm"],
+  "timezone": "America/New_York",
+  "schedule": ["before 9am on Monday"],
+  "dependencyDashboard": true,
+  "dependencyDashboardAutoclose": true,
+  "labels": ["dependencies"],
+  "rangeStrategy": "bump",
+  "prConcurrentLimit": 10,
+  "packageRules": [
+    {
+      "description": "Group all GitHub Actions updates together; auto-merge minor and patch",
+      "groupName": "GitHub Actions",
+      "matchDatasources": ["github-actions"],
+      "automerge": true,
+      "matchUpdateTypes": ["minor", "patch"]
+    },
+    {
+      "description": "Disable noisy peerDependency update PRs",
+      "matchDepTypes": ["peerDependencies"],
+      "enabled": false
+    },
+    {
+      "description": "Group Next.js ecosystem packages",
+      "groupName": "Next.js",
+      "matchDepTypes": ["pnpm.catalog.default"],
+      "matchPackageNames": [
+        "next",
+        "next-auth",
+        "next-plausible",
+        "next-themes",
+        "@sentry/nextjs",
+        "@scalar/nextjs-api-reference",
+        "@t3-oss/env-nextjs"
+      ]
+    },
+    {
+      "description": "Group React core packages",
+      "groupName": "React",
+      "matchDepTypes": ["pnpm.catalog.default"],
+      "matchPackageNames": ["react", "react-dom", "@types/react", "@types/react-dom"]
+    },
+    {
+      "description": "Group all @radix-ui/* packages",
+      "groupName": "Radix UI",
+      "matchDepTypes": ["pnpm.catalog.default"],
+      "matchPackageNames": ["@radix-ui/*"]
+    },
+    {
+      "description": "Group TanStack packages",
+      "groupName": "TanStack",
+      "matchDepTypes": ["pnpm.catalog.default"],
+      "matchPackageNames": ["@tanstack/*"]
+    },
+    {
+      "description": "Group oRPC packages",
+      "groupName": "oRPC",
+      "matchDepTypes": ["pnpm.catalog.default"],
+      "matchPackageNames": ["@orpc/*"]
+    },
+    {
+      "description": "Group Drizzle ORM packages",
+      "groupName": "Drizzle ORM",
+      "matchDepTypes": ["pnpm.catalog.default"],
+      "matchPackageNames": ["drizzle-orm", "drizzle-kit", "drizzle-zod"]
+    },
+    {
+      "description": "Group testing packages",
+      "groupName": "Testing",
+      "matchDepTypes": ["pnpm.catalog.default"],
+      "matchPackageNames": [
+        "vitest",
+        "@vitest/*",
+        "@testing-library/*",
+        "@playwright/test",
+        "jsdom",
+        "vitest-canvas-mock"
+      ]
+    },
+    {
+      "description": "Group ESLint packages",
+      "groupName": "ESLint",
+      "matchDepTypes": ["pnpm.catalog.default"],
+      "matchPackageNames": [
+        "eslint",
+        "typescript-eslint",
+        "eslint-config-turbo",
+        "eslint-plugin-import-x",
+        "eslint-plugin-jsx-a11y",
+        "eslint-plugin-react",
+        "eslint-plugin-react-hooks",
+        "@next/eslint-plugin-next"
+      ]
+    },
+    {
+      "description": "Group Prettier and formatting packages",
+      "groupName": "Prettier",
+      "matchDepTypes": ["pnpm.catalog.default"],
+      "matchPackageNames": [
+        "prettier",
+        "prettier-plugin-tailwindcss",
+        "@ianvs/prettier-plugin-sort-imports"
+      ]
+    },
+    {
+      "description": "Group Tailwind CSS packages",
+      "groupName": "Tailwind CSS",
+      "matchDepTypes": ["pnpm.catalog.default"],
+      "matchPackageNames": [
+        "tailwindcss",
+        "tailwind-merge",
+        "tailwindcss-animate",
+        "autoprefixer",
+        "postcss"
+      ]
+    }
+  ]
+}

--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,7 @@
   "schedule": ["before 9am on Monday"],
   "dependencyDashboard": true,
   "dependencyDashboardAutoclose": true,
-  "minimumReleaseAge": "3 days",
+  "minimumReleaseAge": "7 days",
   "labels": ["dependencies"],
   "rangeStrategy": "bump",
   "prConcurrentLimit": 10,

--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,7 @@
   "schedule": ["before 9am on Monday"],
   "dependencyDashboard": true,
   "dependencyDashboardAutoclose": true,
+  "minimumReleaseAge": "7 days",
   "labels": ["dependencies"],
   "rangeStrategy": "bump",
   "prConcurrentLimit": 10,

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/renovate.json",
-  "extends": ["config:recommended", "helpers:pinGitHubActionDigests"],
+  "extends": ["config:recommended"],
   "enabledManagers": ["github-actions", "npm"],
   "timezone": "America/New_York",
   "schedule": ["before 9am on Monday"],

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/renovate.json",
-  "extends": ["config:recommended"],
+  "extends": ["config:recommended", "helpers:pinGitHubActionDigests"],
   "enabledManagers": ["github-actions", "npm"],
   "timezone": "America/New_York",
   "schedule": ["before 9am on Monday"],
@@ -11,11 +11,18 @@
   "prConcurrentLimit": 10,
   "packageRules": [
     {
-      "description": "Group all GitHub Actions updates together; auto-merge minor and patch",
-      "groupName": "GitHub Actions",
+      "description": "Group first-party GitHub Actions (actions/*); auto-merge minor and patch — low supply-chain risk",
+      "groupName": "GitHub Actions (first-party)",
       "matchDatasources": ["github-actions"],
+      "matchPackageNames": ["actions/*"],
       "automerge": true,
       "matchUpdateTypes": ["minor", "patch"]
+    },
+    {
+      "description": "Group third-party GitHub Actions; require manual review — these run with deploy secrets",
+      "groupName": "GitHub Actions (third-party)",
+      "matchDatasources": ["github-actions"],
+      "matchPackageNames": ["!actions/*"]
     },
     {
       "description": "Disable noisy peerDependency update PRs",

--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,7 @@
   "schedule": ["before 9am on Monday"],
   "dependencyDashboard": true,
   "dependencyDashboardAutoclose": true,
-  "minimumReleaseAge": "7 days",
+  "minimumReleaseAge": "3 days",
   "labels": ["dependencies"],
   "rangeStrategy": "bump",
   "prConcurrentLimit": 10,


### PR DESCRIPTION
## Summary

- Adds `renovate.json` to enable automated dependency update PRs via [Mend Renovate](https://github.com/apps/renovate)
- Targets the pnpm catalog in `pnpm-workspace.yaml` directly (not individual `package.json` files) — compatible with this repo's centralized version pinning strategy
- Covers both npm packages **and** GitHub Actions version pins in one config
- Updates are grouped by ecosystem (Next.js, React, Radix UI, TanStack, oRPC, Drizzle, Testing, ESLint, Prettier, Tailwind CSS) to keep the PR queue manageable
- Runs on a weekly Monday morning schedule; GitHub Actions minor/patch updates auto-merge, npm updates require manual review
- Creates a "Dependency Dashboard" issue in this repo listing all pending updates for full team visibility

> **Why Renovate instead of Dependabot?** Dependabot doesn't understand the pnpm catalog format. All deps in this repo are pinned as `"next": "catalog:"` in individual `package.json` files — Dependabot would try to update those and find nothing. Renovate's `npm` manager natively reads the `catalog:` block in `pnpm-workspace.yaml` and updates versions there. See comment on #349 for full context.

---

## Action required before this PR can do anything: @taterhead247

Hey @taterhead247 — this PR adds the config file, but the automation won't actually run until someone with admin access to the F3-Nation GitHub organization installs a free app called **Mend Renovate**. That's you!

Here's exactly what to do — it takes about 2 minutes:

1. **Click this link:** https://github.com/apps/renovate
2. Click the green **"Install"** (or **"Configure"**) button on that page
3. When it asks which organization, choose **F3-Nation**
4. When it asks which repositories, choose **"Only select repositories"** and pick **f3-nation**
5. Click **"Install"**

That's it. Once installed, Renovate will automatically open a short "onboarding" pull request in this repo that shows you a preview of exactly what it plans to update before it ever changes anything. You can review and approve or tweak settings from there.

---

## Test plan

- [ ] @taterhead247 installs the Mend Renovate GitHub App on F3-Nation/f3-nation (steps above)
- [ ] Renovate opens an onboarding PR — review it to confirm `pnpm-workspace.yaml` catalog entries are detected (not `package.json` files)
- [ ] Confirm a Dependency Dashboard issue appears in the repo's Issues tab
- [ ] Merge this PR into `dev`

Closes #349

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Configured automated dependency management to regularly scan and group updates for GitHub Actions, npm packages, and framework/ecosystem-specific sets.
  * Enabled weekly scheduling, a dependency dashboard with auto-close, and limits on concurrent PRs.
  * Auto-merge enabled for selected minor/patch updates; peer dependency update PRs disabled.
  * Added a minimum release age setting for workspace package handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->