### PR TITLE
fix(api): event cascade issue

### DIFF
--- a/packages/api/src/router/event.test.ts
+++ b/packages/api/src/router/event.test.ts
@@ -1500,6 +1500,121 @@ describe("Event Router", () => {
         }
       });
 
+      it("should update instances in place (not duplicate) when updating a series with null recurrencePattern", async () => {
+        // Regression test: a series with dayOfWeek set but recurrencePattern = null was
+        // incorrectly treated as a non-series event on update, causing createEventInstancesForSeries
+        // to run again and duplicate all existing instances.
+        const session = await createAdminSession();
+        await mockAuthWithSession(session);
+
+        const region = await createTestRegion();
+        if (!region) return;
+
+        const ao = await createTestAO(region.id);
+        if (!ao) return;
+
+        const location = await createTestLocation(region.id);
+        if (!location) return;
+
+        const eventType = await createTestEventType();
+        if (!eventType) return;
+
+        const editorSession = createEditorSession({
+          orgId: ao.id,
+          orgName: ao.name,
+        });
+        await mockAuthWithSession(editorSession);
+
+        const client = createTestClient();
+
+        // Step 1: Create a series with dayOfWeek set and recurrencePattern: null (defaults to weekly)
+        const createResult = await client.event.crupdate({
+          name: `Null Recurrence Regression ${uniqueId()}`,
+          aoId: ao.id,
+          regionId: region.id,
+          locationId: location.id,
+          dayOfWeek: "thursday",
+          startTime: "0530",
+          endTime: "0615",
+          startDate: "2027-01-01",
+          endDate: "2027-03-31",
+          recurrencePattern: null,
+          recurrenceInterval: null,
+          indexWithinInterval: null,
+          highlight: false,
+          isActive: true,
+          eventTypeIds: [eventType.id],
+          email: null,
+        });
+
+        expect(createResult.event).not.toBeNull();
+        const seriesId = createResult.event!.id;
+        createdEventIds.push(seriesId);
+
+        // Step 2: Record the unique instance dates after creation
+        const instancesAfterCreate = await db
+          .select({
+            id: schema.eventInstances.id,
+            startDate: schema.eventInstances.startDate,
+          })
+          .from(schema.eventInstances)
+          .where(eq(schema.eventInstances.seriesId, seriesId));
+
+        expect(instancesAfterCreate.length).toBeGreaterThan(0);
+        const datesAfterCreate = instancesAfterCreate
+          .map((i) => i.startDate)
+          .sort();
+
+        // Step 3: Update a non-structural field (name) — recurrencePattern stays null
+        const updatedName = `Null Recurrence Regression Updated ${uniqueId()}`;
+        const updateResult = await client.event.crupdate({
+          id: seriesId,
+          name: updatedName,
+          aoId: ao.id,
+          regionId: region.id,
+          locationId: location.id,
+          dayOfWeek: "thursday",
+          startTime: "0530",
+          endTime: "0615",
+          startDate: "2027-01-01",
+          endDate: "2027-03-31",
+          recurrencePattern: null,
+          recurrenceInterval: null,
+          indexWithinInterval: null,
+          highlight: false,
+          isActive: true,
+          eventTypeIds: [eventType.id],
+          email: null,
+        });
+
+        expect(updateResult.event?.name).toBe(updatedName);
+
+        // Step 4: Assert no duplicate instances were created
+        const instancesAfterUpdate = await db
+          .select({
+            id: schema.eventInstances.id,
+            startDate: schema.eventInstances.startDate,
+            name: schema.eventInstances.name,
+          })
+          .from(schema.eventInstances)
+          .where(eq(schema.eventInstances.seriesId, seriesId));
+
+        const datesAfterUpdate = instancesAfterUpdate
+          .map((i) => i.startDate)
+          .sort();
+
+        // Instance count must not increase
+        expect(instancesAfterUpdate.length).toBe(instancesAfterCreate.length);
+
+        // Dates must be identical (no duplicates, no new entries)
+        expect(datesAfterUpdate).toEqual(datesAfterCreate);
+
+        // Instances should reflect the updated name
+        expect(instancesAfterUpdate.every((i) => i.name === updatedName)).toBe(
+          true,
+        );
+      });
+
       it("should cascade soft-delete to instances when deleting a series", async () => {
         const session = await createAdminSession();
         await mockAuthWithSession(session);

--- a/packages/api/src/router/event.ts
+++ b/packages/api/src/router/event.ts
@@ -839,7 +839,7 @@ export const eventRouter = {
             (err: unknown) =>
               console.error("maybeNotifyFirstEventForRegion failed", { err }),
           );
-        } else if (existingEvent.recurrencePattern) {
+        } else if (existingEvent.dayOfWeek) {
           // Existing series: check for structural changes
           const existingSeriesData = {
             dayOfWeek: existingEvent.dayOfWeek,


### PR DESCRIPTION
This very small PR fixes an issue where when an `event` (series) was edited through the API, the cascade logic was leading to duplication for some events.

The problem: a series can have recurrencePattern = null (it defaults to "weekly" inside createEventInstancesForSeries). So editing a null-recurrence-pattern series (like changing its name) fell into the else branch and calls createEventInstancesForSeries again — duplicating all instances.

The fix was to check existingEvent.dayOfWeek instead — that's what actually determines whether the event was already a recurring series (really, all `events` _should_ be recurring at this point, but they technically wouldn't have to)

This is a high priority deployment from my perspective, as it's messy and manual to have to clean up duplicate instances.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed recurring event series updates that incorrectly duplicated or recreated existing event instances.
  * Ensured series updates (including name changes) apply correctly while preserving existing event instances.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->