### PR TITLE
chore(repo): enable coverage by default in all test scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,4 +110,4 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup-node-pnpm
-      - run: pnpm test:coverage
+      - run: pnpm test

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -11,7 +11,7 @@
     "lint": "dotenv -v SKIP_ENV_VALIDATION=1 eslint .",
     "start": "pnpm with-env next start",
     "typecheck": "tsc --noEmit",
-    "test": "pnpm with-env vitest --run",
+    "test": "pnpm with-env vitest --run --coverage",
     "test:watch": "pnpm with-env vitest -w",
     "test:e2e": "pnpm with-env playwright test",
     "test:e2e:staging": "pnpm with-env playwright test --config=playwright.staging.config.ts",

--- a/apps/auth/package.json
+++ b/apps/auth/package.json
@@ -10,7 +10,7 @@
     "format": "prettier --check . --ignore-path ../../.gitignore --ignore-path ../../.prettierignore",
     "lint": "eslint .",
     "start": "next start",
-    "test": "pnpm with-env vitest --run",
+    "test": "pnpm with-env vitest --run --coverage",
     "typecheck": "tsc --noEmit",
     "add-client": "tsx scripts/add-client.ts",
     "with-env": "dotenv -e .env --"

--- a/apps/map/package.json
+++ b/apps/map/package.json
@@ -11,7 +11,7 @@
     "lint": "dotenv -v SKIP_ENV_VALIDATION=1 eslint .",
     "start": "pnpm with-env next start",
     "typecheck": "tsc --noEmit",
-    "test": "SKIP_ENV_VALIDATION=1 pnpm with-env vitest --run \"$@\"",
+    "test": "SKIP_ENV_VALIDATION=1 pnpm with-env vitest --run --coverage \"$@\"",
     "test:watch": "SKIP_ENV_VALIDATION=1 pnpm with-env vitest -w \"$@\"",
     "test:e2e": "pnpm with-env playwright test",
     "test:e2e:staging": "pnpm with-env playwright test --config=playwright.staging.config.ts",

--- a/apps/me/README.md
+++ b/apps/me/README.md
@@ -129,14 +129,11 @@ Open [https://localhost:3003](https://localhost:3003). Accept the self-signed ce
 ## Testing
 
 ```bash
-# Run all tests
+# Run all tests (coverage always collected)
 pnpm test
 
-# Run tests in watch mode
+# Run tests in watch mode (no coverage)
 pnpm test:watch
-
-# Run tests with coverage
-pnpm test
 ```
 
 Tests are located in `__tests__/` and cover:

--- a/apps/me/README.md
+++ b/apps/me/README.md
@@ -136,7 +136,7 @@ pnpm test
 pnpm test:watch
 
 # Run tests with coverage
-pnpm test:coverage
+pnpm test
 ```
 
 Tests are located in `__tests__/` and cover:

--- a/apps/me/package.json
+++ b/apps/me/package.json
@@ -10,9 +10,8 @@
     "lint": "eslint . --max-warnings 0",
     "format:check": "prettier --check .",
     "format": "prettier --write .",
-    "test": "vitest --run",
+    "test": "vitest --run --coverage",
     "test:watch": "vitest -w",
-    "test:coverage": "vitest --run --coverage",
     "typecheck": "tsc --noEmit",
     "deploy:variables-secrets:staging": "/usr/bin/env bash scripts/cloud-run-env.sh --env staging",
     "deploy:variables-secrets:prod": "/usr/bin/env bash scripts/cloud-run-env.sh --env prod"

--- a/package.json
+++ b/package.json
@@ -6,10 +6,10 @@
   "engines": {
     "node": ">=24.14.1 <25"
   },
-  "packageManager": "pnpm@11.5.0+sha512.dbfcc4f81cf48597afd4bc391ffdf12c11f1a9fb83a395bfa6b0a2d9cc2fd8ffebafdb1ccbd529632153f793904c2615b7f09fe1a345473fd1c35845172a8eb1",
+  "packageManager": "pnpm@11.5.1+sha512.93f7b57422ea7068257235b4c16eb60762eb68e1dc23723199cc739043ea9be2c4143274a399d8c6defa2b1176226d9ca1c4b63482d6200c1a8fbaa78c1d1485",
   "scripts": {
     "build": "turbo build",
-    "ci:local": "pnpm format && pnpm lint && pnpm typecheck && pnpm build --filter='!@acme/auth' && pnpm test:coverage",
+    "ci:local": "pnpm format && pnpm lint && pnpm typecheck && pnpm build --filter='!@acme/auth' && pnpm test",
     "clean:workspaces": "turbo clean && pnpm clean",
     "clean": "rm -rf .turbo node_modules",
     "commit": "cz",
@@ -44,7 +44,6 @@
     "local:setup": "bash scripts/local-setup.sh",
     "release": "pnpm -F release-it release",
     "reset-test-db": "turbo run reset-test-db",
-    "test:coverage": "turbo test -- --coverage",
     "test": "turbo test",
     "typecheck": "turbo typecheck --filter='!@acme/auth'",
     "with-env": "dotenv -e .env --"

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -12,7 +12,7 @@
     "clean": "rm -rf .turbo node_modules",
     "format": "prettier --check . --ignore-path ../../.gitignore --ignore-path ../../.prettierignore",
     "lint": "eslint .",
-    "test": "pnpm with-env vitest --run",
+    "test": "pnpm with-env vitest --run --coverage",
     "test:org-hierarchy": "pnpm with-env tsx src/scripts/test-org-hierarchy.ts",
     "test:watch": "pnpm with-env vitest -w",
     "typecheck": "tsc --noEmit",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -45,9 +45,11 @@
     "@acme/eslint-config": "workspace:^0.2.0",
     "@acme/prettier-config": "workspace:^0.1.0",
     "@acme/tsconfig": "workspace:^0.1.0",
+    "@vitest/coverage-v8": "catalog:",
     "eslint": "catalog:",
     "prettier": "catalog:",
-    "typescript": "catalog:"
+    "typescript": "catalog:",
+    "vitest": "catalog:"
   },
   "prettier": "@acme/prettier-config"
 }

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -24,6 +24,7 @@
     "@acme/prettier-config": "workspace:^0.1.0",
     "@acme/tsconfig": "workspace:^0.1.0",
     "@types/node": "catalog:",
+    "@vitest/coverage-v8": "catalog:",
     "eslint": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:"

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -11,7 +11,7 @@
     "clean": "rm -rf .turbo node_modules",
     "format": "prettier --check . --ignore-path ../../.gitignore --ignore-path ../../.prettierignore",
     "lint": "eslint .",
-    "test": "vitest --run",
+    "test": "vitest --run --coverage",
     "test:watch": "vitest -w",
     "typecheck": "tsc --noEmit"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1385,6 +1385,9 @@ importers:
       '@acme/tsconfig':
         specifier: workspace:^0.1.0
         version: link:../../tooling/typescript
+      '@vitest/coverage-v8':
+        specifier: 'catalog:'
+        version: 3.2.4(vitest@3.2.4(@types/node@25.9.1)(jsdom@29.1.1)(terser@5.48.0))
       eslint:
         specifier: 'catalog:'
         version: 10.4.0(jiti@2.7.0)
@@ -1394,6 +1397,9 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 3.2.4(@types/node@25.9.1)(jsdom@29.1.1)(terser@5.48.0)
 
   packages/auth:
     dependencies:
@@ -1639,6 +1645,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.12.4
+      '@vitest/coverage-v8':
+        specifier: 'catalog:'
+        version: 3.2.4(vitest@3.2.4(@types/node@24.12.4)(jsdom@29.1.1)(terser@5.48.0))
       eslint:
         specifier: 'catalog:'
         version: 10.4.0(jiti@2.7.0)
@@ -13317,6 +13326,25 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@types/node@25.9.1)(jsdom@29.1.1)(terser@5.48.0))':
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@bcoe/v8-coverage': 1.0.2
+      ast-v8-to-istanbul: 0.3.12
+      debug: 4.4.3
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-lib-source-maps: 5.0.6
+      istanbul-reports: 3.2.0
+      magic-string: 0.30.21
+      magicast: 0.3.5
+      std-env: 3.10.0
+      test-exclude: 7.0.2
+      tinyrainbow: 2.0.0
+      vitest: 3.2.4(@types/node@25.9.1)(jsdom@29.1.1)(terser@5.48.0)
+    transitivePeerDependencies:
+      - supports-color
+
   '@vitest/expect@3.2.4':
     dependencies:
       '@types/chai': 5.2.3
@@ -13332,6 +13360,14 @@ snapshots:
       magic-string: 0.30.21
     optionalDependencies:
       vite: 5.4.21(@types/node@24.12.4)(terser@5.48.0)
+
+  '@vitest/mocker@3.2.4(vite@5.4.21(@types/node@25.9.1)(terser@5.48.0))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 5.4.21(@types/node@25.9.1)(terser@5.48.0)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -17668,6 +17704,24 @@ snapshots:
       - supports-color
       - terser
 
+  vite-node@3.2.4(@types/node@25.9.1)(terser@5.48.0):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 5.4.21(@types/node@25.9.1)(terser@5.48.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
   vite-tsconfig-paths@6.1.1(typescript@6.0.3)(vite@5.4.21(@types/node@24.12.4)(terser@5.48.0)):
     dependencies:
       debug: 4.4.3
@@ -17685,6 +17739,16 @@ snapshots:
       rollup: 4.60.1
     optionalDependencies:
       '@types/node': 24.12.4
+      fsevents: 2.3.3
+      terser: 5.48.0
+
+  vite@5.4.21(@types/node@25.9.1)(terser@5.48.0):
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.5.15
+      rollup: 4.60.1
+    optionalDependencies:
+      '@types/node': 25.9.1
       fsevents: 2.3.3
       terser: 5.48.0
 
@@ -17721,6 +17785,45 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.12.4
+      jsdom: 29.1.1
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  vitest@3.2.4(@types/node@25.9.1)(jsdom@29.1.1)(terser@5.48.0):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(vite@5.4.21(@types/node@25.9.1)(terser@5.48.0))
+      '@vitest/pretty-format': 3.2.4
+      '@vitest/runner': 3.2.4
+      '@vitest/snapshot': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 5.4.21(@types/node@25.9.1)(terser@5.48.0)
+      vite-node: 3.2.4(@types/node@25.9.1)(terser@5.48.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 25.9.1
       jsdom: 29.1.1
     transitivePeerDependencies:
       - less


### PR DESCRIPTION
## Summary

- Moves `--coverage` from the root-level `turbo test -- --coverage` passthrough into each individual package's `test` script, so coverage is always collected regardless of how tests are invoked (root `pnpm test`, per-package `pnpm test`, or CI)
- Removes the now-redundant `test:coverage` scripts from `apps/me` and the repo root
- Updates all callers (`ci:local` in root `package.json`, the `test-coverage` CI job in `ci.yml`) to call `pnpm test` instead of `pnpm test:coverage`
- Explicitly declares `@vitest/coverage-v8` as a devDependency in `packages/api` and `packages/storage`, which previously relied on hoisting

## Test plan

- [ ] CI passes on this branch (prettier, typecheck, test-coverage job)
- [ ] Coverage reports are generated in each app's `./coverage/` directory when running `pnpm test` locally
- [ ] No remaining `test:coverage` references in scripts or workflows: `grep -r "test:coverage" . --include="*.json" --include="*.yml"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Consolidated test coverage reporting into the default test command across all packages.
  * Removed separate test coverage scripts; coverage is now automatically collected when running tests.
  * Updated test infrastructure configuration to streamline the testing workflow.
  * Updated package manager to version 11.5.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->