### PR TITLE
chore(deps): restore pnpm minimumReleaseAge to 7 days

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -163,4 +163,4 @@ allowBuilds:
   lefthook: true
   sharp: true
   unrs-resolver: true
-minimumReleaseAge: 4320
+minimumReleaseAge: 10080


### PR DESCRIPTION
## Summary

- Restores `minimumReleaseAge` in `pnpm-workspace.yaml` from 4320 min (3 days) to 10080 min (7 days)
- All 11 packages that triggered the temporary reduction have now cleared the 7-day window — the youngest was `nodemailer@8.0.10` (published 2026-05-29), which cleared on 2026-06-05
- Closes #390

## Test plan

- [x] `pnpm install` runs successfully — "Lockfile passes supply-chain policies (1597 entries)" ✓
- [x] Pre-commit hook (lefthook typecheck + commitlint) passes ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #390 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workspace release timing configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->