### PR TITLE
feat(homepage): grouping apps by role

### DIFF
--- a/apps/homepage/README.md
+++ b/apps/homepage/README.md
@@ -83,17 +83,27 @@ The DNS CNAME record for `apps.f3nation.com` must point to `f3-nation.github.io`
 
 ### Adding a new app to the landing page
 
-Edit the `APPS` array in `src/app/page.tsx`:
+Edit the `APP_GROUPS` array in `src/app/page.tsx`. Each group has:
 
 ```ts
 {
-  name: "New App Name",
-  description: "What it does.",
-  href: "https://newapp.f3nation.com",
-  // optional: override the default "Open" link label
-  linkLabel: "Learn More",
+  title: "Group Name",        // rendered as an <h2> section heading
+  description: "Who it's for.",
+  apps: [
+    {
+      name: "New App Name",
+      description: "What it does.",
+      href: "https://newapp.f3nation.com",
+      // optional: only shown in local dev (NEXT_PUBLIC_LOCAL_DEV=true)
+      localHref: "http://localhost:3000",
+      // optional: override the default "Open" link label
+      linkLabel: "Learn More",
+    },
+  ],
 }
 ```
+
+Apps belong to one of three groups: **Everyday Use**, **Region Admins**, or **Developers**.
 
 ### Adding a new route
 

--- a/apps/homepage/src/app/page.tsx
+++ b/apps/homepage/src/app/page.tsx
@@ -8,86 +8,111 @@ interface App {
   linkLabel?: string;
 }
 
+interface AppGroup {
+  title: string;
+  description: string;
+  apps: App[];
+}
+
 const isLocal = process.env.NEXT_PUBLIC_LOCAL_DEV === "true";
 
-const APPS: App[] = [
+const APP_GROUPS: AppGroup[] = [
   {
-    name: "F3 Map",
+    title: "Everyday Use",
     description:
-      "Find F3 workouts near you. Browse every workout group across the nation on an interactive map.",
-    href: "https://map.f3nation.com",
-    localHref: "http://localhost:3000",
+      "Apps built for every PAX — find workouts, manage your profile, and explore the F3 ecosystem.",
+    apps: [
+      {
+        name: "F3 Map",
+        description:
+          "Find F3 workouts near you. Browse every workout group across the nation on an interactive map.",
+        href: "https://map.f3nation.com",
+        localHref: "http://localhost:3000",
+      },
+      {
+        name: "F3 Near Me",
+        description:
+          "Lightweight, fast map for discovering F3 workout locations near you — no account needed.",
+        href: "https://f3near.me",
+      },
+      {
+        name: "F3 Me",
+        description:
+          "Your personal F3 profile. Update your avatar, manage emergency contacts, and control your info.",
+        href: "https://me.f3nation.com",
+        localHref: "http://localhost:3003",
+      },
+      {
+        name: "PAX Vault",
+        description:
+          "Analytics and reporting for F3 regions. Participation, leadership load, attendance trends — data over vibes.",
+        href: "https://pax-vault.f3nation.com",
+      },
+      {
+        name: "The Codex",
+        description:
+          "The F3 Exicon and Lexicon — a living, searchable repository of exercises and F3 terminology built by the community.",
+        href: "https://codex.f3nation.com",
+      },
+      {
+        name: "Org Chart",
+        description:
+          "Geographic digital directory visualizing F3's organizational structure — Sectors, Areas, and Regions on a map.",
+        href: "https://org.f3nation.com",
+      },
+    ],
   },
   {
-    name: "F3 Near Me",
+    title: "Region Admins",
     description:
-      "Lightweight, fast map for discovering F3 workout locations near you — no account needed.",
-    href: "https://f3near.me",
+      "Tools for ITQs, region leaders, and anyone responsible for keeping a local F3 community running.",
+    apps: [
+      {
+        name: "Admin",
+        description:
+          "Administrative portal for region and group leadership. Manage locations, events, and organization settings.",
+        href: "https://admin.f3nation.com",
+        localHref: "http://localhost:3002",
+      },
+      {
+        name: "Region Pages",
+        description:
+          "Dedicated pages for F3 regions — workout calendars, member directories, event info, and contact details for each local community.",
+        href: "https://regions.f3nation.com",
+      },
+      {
+        name: "Slack Bot",
+        description:
+          "The primary way most PAX interact with F3 tech. Scheduling, attendance tracking, and region management — installed on 300+ workspaces.",
+        href: "https://docs.google.com/document/d/1e7tmuY3irKDt9oy1URQVcxPwxyet1ZY_bVZhGvhESEw",
+        linkLabel: "Learn More",
+      },
+      {
+        name: "Status",
+        description:
+          "Real-time health and status for all F3 Nation services. Check if something's down before filing a bug report.",
+        href: "https://status.f3nation.com",
+      },
+    ],
   },
   {
-    name: "F3 Me",
+    title: "Developers",
     description:
-      "Your personal F3 profile. Update your avatar, manage emergency contacts, and control your info.",
-    href: "https://me.f3nation.com",
-    localHref: "http://localhost:3003",
-  },
-  {
-    name: "Admin",
-    description:
-      "Administrative portal for region and group leadership. Manage locations, events, and organization settings.",
-    href: "https://admin.f3nation.com",
-    localHref: "http://localhost:3002",
-    linkLabel: "Open (region admins only)",
-  },
-  {
-    name: "PAX Vault",
-    description:
-      "Analytics and reporting for F3 regions. Participation, leadership load, attendance trends — data over vibes.",
-    href: "https://pax-vault.f3nation.com",
-  },
-  {
-    name: "The Codex",
-    description:
-      "The F3 Exicon and Lexicon — a living, searchable repository of exercises and F3 terminology built by the community.",
-    href: "https://codex.f3nation.com",
-  },
-  {
-    name: "Slack Bot",
-    description:
-      "The primary way most PAX interact with F3 tech. Scheduling, attendance tracking, and region management — installed on 300+ workspaces.",
-    href: "https://docs.google.com/document/d/1e7tmuY3irKDt9oy1URQVcxPwxyet1ZY_bVZhGvhESEw",
-    linkLabel: "Learn More",
-  },
-  {
-    name: "Region Pages",
-    description:
-      "Dedicated pages for F3 regions — workout calendars, member directories, event info, and contact details for each local community.",
-    href: "https://regions.f3nation.com",
-  },
-  {
-    name: "Org Chart",
-    description:
-      "Geographic digital directory visualizing F3's organizational structure — Sectors, Areas, and Regions on a map.",
-    href: "https://org.f3nation.com",
-  },
-  {
-    name: "Auth",
-    description:
-      "Shared SSO authentication powering F3 Nation apps. Secure, centralized sign-in for PAX across the ecosystem.",
-    localHref: "http://localhost:3004",
-  },
-  {
-    name: "API",
-    description:
-      "The F3 Nation data API. Unified backend powering the map, admin, and other apps — the single source of truth for F3 data.",
-    href: "https://api.f3nation.com",
-    localHref: "http://localhost:3001",
-  },
-  {
-    name: "Status",
-    description:
-      "Real-time health and status for all F3 Nation services. Check if something's down before filing a bug report.",
-    href: "https://status.f3nation.com",
+      "Infrastructure and APIs for contributors building on or integrating with the F3 Nation platform.",
+    apps: [
+      {
+        name: "Auth",
+        description:
+          "Shared SSO authentication powering F3 Nation apps. Secure, centralized sign-in for PAX across the ecosystem.",
+      },
+      {
+        name: "API",
+        description:
+          "The F3 Nation data API. Unified backend powering the map, admin, and other apps — the single source of truth for F3 data.",
+        href: "https://api.f3nation.com",
+        localHref: "http://localhost:3001",
+      },
+    ],
   },
 ];
 
@@ -180,9 +205,23 @@ export default function HomePage() {
           </p>
         </div>
 
-        <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
-          {APPS.map((app) => (
-            <AppCard key={app.name} app={app} />
+        <div className="space-y-16">
+          {APP_GROUPS.map((group) => (
+            <section key={group.title}>
+              <div className="mb-6">
+                <h2 className="text-2xl font-bold tracking-tight text-foreground">
+                  {group.title}
+                </h2>
+                <p className="mt-1 text-muted-foreground">
+                  {group.description}
+                </p>
+              </div>
+              <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+                {group.apps.map((app) => (
+                  <AppCard key={app.name} app={app} />
+                ))}
+              </div>
+            </section>
           ))}
         </div>
       </div>

--- a/apps/homepage/src/app/page.tsx
+++ b/apps/homepage/src/app/page.tsx
@@ -1,17 +1,31 @@
 import Image from "next/image";
 
-interface App {
+/** App with a production URL — renders as a clickable card. */
+interface NavigableApp {
   name: string;
   description: string;
-  href?: string;
+  href: string;
+  /** Local dev URL override; falls back to `href` when absent. */
   localHref?: string;
+  /** Link button label. Defaults to "Open". */
   linkLabel?: string;
 }
+
+/** App with no link — renders as a non-clickable informational card in both dev and prod. */
+interface InformationalApp {
+  name: string;
+  description: string;
+  href?: never;
+  linkLabel?: never;
+}
+
+type App = NavigableApp | InformationalApp;
 
 interface AppGroup {
   title: string;
   description: string;
-  apps: App[];
+  /** At least one app is required — an empty group renders a heading with no cards. */
+  apps: [App, ...App[]];
 }
 
 const isLocal = process.env.NEXT_PUBLIC_LOCAL_DEV === "true";
@@ -116,6 +130,19 @@ const APP_GROUPS: AppGroup[] = [
   },
 ];
 
+if (process.env.NODE_ENV === "development") {
+  const titles = APP_GROUPS.map((g) => g.title);
+  if (new Set(titles).size !== titles.length)
+    throw new Error("Duplicate AppGroup title — titles are used as React keys");
+  for (const group of APP_GROUPS) {
+    const names = group.apps.map((a) => a.name);
+    if (new Set(names).size !== names.length)
+      throw new Error(
+        `Duplicate app name in group "${group.title}" — names are used as React keys`,
+      );
+  }
+}
+
 function ArrowIcon() {
   return (
     <svg
@@ -138,7 +165,11 @@ function ArrowIcon() {
 
 function AppCard({ app }: { app: App }) {
   const label = app.linkLabel ?? "Open";
-  const resolvedHref = isLocal ? (app.localHref ?? app.href) : app.href;
+  const resolvedHref = app.href
+    ? isLocal
+      ? (app.localHref ?? app.href)
+      : app.href
+    : undefined;
   const inner = (
     <>
       <h3 className="mb-2 text-lg font-semibold text-foreground">{app.name}</h3>

--- a/apps/homepage/src/app/page.tsx
+++ b/apps/homepage/src/app/page.tsx
@@ -141,7 +141,7 @@ function AppCard({ app }: { app: App }) {
   const resolvedHref = isLocal ? (app.localHref ?? app.href) : app.href;
   const inner = (
     <>
-      <h2 className="mb-2 text-lg font-semibold text-foreground">{app.name}</h2>
+      <h3 className="mb-2 text-lg font-semibold text-foreground">{app.name}</h3>
       <p className="mb-4 flex-1 text-sm text-muted-foreground">
         {app.description}
       </p>


### PR DESCRIPTION
This pull request restructures how apps are displayed on the homepage by grouping them into themed categories for improved organization and clarity. Instead of a single flat list, apps are now organized into groups such as "Everyday Use," "Region Admins," and "Developers," each with its own title and description. The rendering logic is updated to display these groups and their respective apps.

**Homepage App Organization:**

* Introduced a new `AppGroup` interface and replaced the flat `APPS` array with a grouped `APP_GROUPS` array, categorizing apps into themed sections.
* Updated the homepage rendering logic to iterate over `APP_GROUPS`, displaying each group with its title, description, and the corresponding apps in a grid layout.

**App Reassignment and Grouping:**

* Moved the "Admin" app from the general list to the new "Region Admins" group, and similarly reassigned the "Org Chart," "Slack Bot," and "Status" apps to their appropriate groups [[1]](diffhunk://#diff-9206c3d0a0f02b7b87da2e3e1b2ef26635c6be8142605888c8e5975f27f984eeL34-L41) [[2]](diffhunk://#diff-9206c3d0a0f02b7b87da2e3e1b2ef26635c6be8142605888c8e5975f27f984eeL55-R75) [[3]](diffhunk://#diff-9206c3d0a0f02b7b87da2e3e1b2ef26635c6be8142605888c8e5975f27f984eeL68-L77) [[4]](diffhunk://#diff-9206c3d0a0f02b7b87da2e3e1b2ef26635c6be8142605888c8e5975f27f984eeL86-R115).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Homepage apps reorganized into grouped sections with a title, description, and a grid of app cards per group for improved navigation and discoverability.
  * App card headings reduced in prominence for a clearer visual hierarchy.
* **Documentation**
  * README updated with instructions for adding apps using the new grouped structure and field guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->