### PR TITLE
fix(repo): switching from push to pull_request on ci trigger for incl…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
     branches: [dev]
   pull_request:
     branches: ["**"]
-    types: [opened, synchronize]
+    types: [opened, synchronize, reopened]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: CI
 
 on:
+  push:
+    branches: [dev]
   pull_request:
     branches: ["**"]
     types: [opened, synchronize]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,9 @@
 name: CI
 
 on:
-  push:
+  pull_request:
     branches: ["**"]
+    types: [opened, synchronize]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
This pull request updates the CI workflow trigger configuration to run on pull requests instead of direct pushes. This ensures that the CI pipeline is executed when a pull request is opened or updated, rather than on every push to a branch. This is an attempt to allow CI to run when the source branch is from a forked repo.

CI workflow trigger update:

* Modified `.github/workflows/ci.yml` to trigger the workflow on `pull_request` events (specifically when opened or synchronized), instead of on every `push`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow to run only on pull request events (when opened or synchronized) instead of triggering on every push, improving efficiency by focusing verification efforts on pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->