### PR TITLE
chore(deps): add root eslint devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "@turbo/gen": "catalog:",
     "commitizen": "catalog:",
     "dotenv-cli": "catalog:",
+    "eslint": "catalog:",
     "inquirer": "catalog:",
     "knip": "catalog:",
     "lefthook": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -424,16 +424,19 @@ importers:
         version: 21.0.2
       '@commitlint/cz-commitlint':
         specifier: 'catalog:'
-        version: 21.0.2(@types/node@25.9.1)(commitizen@4.3.1(@types/node@25.9.1)(typescript@6.0.3))(inquirer@12.11.1(@types/node@25.9.1))(typescript@6.0.3)
+        version: 21.0.2(@types/node@25.9.2)(commitizen@4.3.1(@types/node@25.9.2)(typescript@6.0.3))(inquirer@12.11.1(@types/node@25.9.1))(typescript@6.0.3)
       '@turbo/gen':
         specifier: 'catalog:'
-        version: 1.13.4(@types/node@25.9.1)(typescript@6.0.3)
+        version: 1.13.4(@types/node@25.9.2)(typescript@6.0.3)
       commitizen:
         specifier: 'catalog:'
-        version: 4.3.1(@types/node@25.9.1)(typescript@6.0.3)
+        version: 4.3.1(@types/node@25.9.2)(typescript@6.0.3)
       dotenv-cli:
         specifier: 'catalog:'
         version: 7.4.4
+      eslint:
+        specifier: 'catalog:'
+        version: 10.4.0(jiti@2.7.0)
       inquirer:
         specifier: 'catalog:'
         version: 12.11.1(@types/node@25.9.1)
@@ -9630,12 +9633,12 @@ snapshots:
       '@commitlint/types': 21.0.1
       ajv: 8.20.0
 
-  '@commitlint/cz-commitlint@21.0.2(@types/node@25.9.1)(commitizen@4.3.1(@types/node@25.9.1)(typescript@6.0.3))(inquirer@12.11.1(@types/node@25.9.1))(typescript@6.0.3)':
+  '@commitlint/cz-commitlint@21.0.2(@types/node@25.9.2)(commitizen@4.3.1(@types/node@25.9.2)(typescript@6.0.3))(inquirer@12.11.1(@types/node@25.9.1))(typescript@6.0.3)':
     dependencies:
       '@commitlint/ensure': 21.0.1
-      '@commitlint/load': 21.0.2(@types/node@25.9.1)(typescript@6.0.3)
+      '@commitlint/load': 21.0.2(@types/node@25.9.2)(typescript@6.0.3)
       '@commitlint/types': 21.0.1
-      commitizen: 4.3.1(@types/node@25.9.1)(typescript@6.0.3)
+      commitizen: 4.3.1(@types/node@25.9.2)(typescript@6.0.3)
       inquirer: 12.11.1(@types/node@25.9.1)
       is-plain-obj: 4.1.0
       picocolors: 1.1.1
@@ -9668,14 +9671,14 @@ snapshots:
       '@commitlint/rules': 21.0.2
       '@commitlint/types': 21.0.1
 
-  '@commitlint/load@21.0.1(@types/node@25.9.1)(typescript@6.0.3)':
+  '@commitlint/load@21.0.1(@types/node@25.9.2)(typescript@6.0.3)':
     dependencies:
       '@commitlint/config-validator': 21.0.1
       '@commitlint/execute-rule': 21.0.1
       '@commitlint/resolve-extends': 21.0.1
       '@commitlint/types': 21.0.1
       cosmiconfig: 9.0.1(typescript@6.0.3)
-      cosmiconfig-typescript-loader: 6.3.0(@types/node@25.9.1)(cosmiconfig@9.0.1(typescript@6.0.3))(typescript@6.0.3)
+      cosmiconfig-typescript-loader: 6.3.0(@types/node@25.9.2)(cosmiconfig@9.0.1(typescript@6.0.3))(typescript@6.0.3)
       es-toolkit: 1.47.0
       is-plain-obj: 4.1.0
       picocolors: 1.1.1
@@ -9692,6 +9695,21 @@ snapshots:
       '@commitlint/types': 21.0.1
       cosmiconfig: 9.0.1(typescript@6.0.3)
       cosmiconfig-typescript-loader: 6.3.0(@types/node@25.9.1)(cosmiconfig@9.0.1(typescript@6.0.3))(typescript@6.0.3)
+      es-toolkit: 1.47.0
+      is-plain-obj: 4.1.0
+      picocolors: 1.1.1
+    transitivePeerDependencies:
+      - '@types/node'
+      - typescript
+
+  '@commitlint/load@21.0.2(@types/node@25.9.2)(typescript@6.0.3)':
+    dependencies:
+      '@commitlint/config-validator': 21.0.1
+      '@commitlint/execute-rule': 21.0.1
+      '@commitlint/resolve-extends': 21.0.1
+      '@commitlint/types': 21.0.1
+      cosmiconfig: 9.0.1(typescript@6.0.3)
+      cosmiconfig-typescript-loader: 6.3.0(@types/node@25.9.2)(cosmiconfig@9.0.1(typescript@6.0.3))(typescript@6.0.3)
       es-toolkit: 1.47.0
       is-plain-obj: 4.1.0
       picocolors: 1.1.1
@@ -10367,6 +10385,13 @@ snapshots:
       iconv-lite: 0.7.2
     optionalDependencies:
       '@types/node': 25.9.1
+
+  '@inquirer/external-editor@1.0.3(@types/node@25.9.2)':
+    dependencies:
+      chardet: 2.1.1
+      iconv-lite: 0.7.2
+    optionalDependencies:
+      '@types/node': 25.9.2
 
   '@inquirer/figures@1.0.15': {}
 
@@ -12046,7 +12071,7 @@ snapshots:
 
   '@rollup/pluginutils@5.3.0(rollup@4.60.1)':
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       estree-walker: 2.0.2
       picomatch: 4.0.4
     optionalDependencies:
@@ -12455,9 +12480,9 @@ snapshots:
   '@turbo/darwin-arm64@2.9.16':
     optional: true
 
-  '@turbo/gen@1.13.4(@types/node@25.9.1)(typescript@6.0.3)':
+  '@turbo/gen@1.13.4(@types/node@25.9.2)(typescript@6.0.3)':
     dependencies:
-      '@turbo/workspaces': 1.13.4(@types/node@25.9.1)
+      '@turbo/workspaces': 1.13.4(@types/node@25.9.2)
       chalk: 2.4.2
       commander: 10.0.1
       fs-extra: 10.1.0
@@ -12487,7 +12512,7 @@ snapshots:
   '@turbo/windows-arm64@2.9.16':
     optional: true
 
-  '@turbo/workspaces@1.13.4(@types/node@25.9.1)':
+  '@turbo/workspaces@1.13.4(@types/node@25.9.2)':
     dependencies:
       chalk: 2.4.2
       commander: 10.0.1
@@ -12495,7 +12520,7 @@ snapshots:
       fast-glob: 3.3.3
       fs-extra: 10.1.0
       gradient-string: 2.0.2
-      inquirer: 8.2.7(@types/node@25.9.1)
+      inquirer: 8.2.7(@types/node@25.9.2)
       js-yaml: 4.1.1
       ora: 4.1.1
       rimraf: 3.0.2
@@ -13438,10 +13463,10 @@ snapshots:
 
   comment-parser@1.4.6: {}
 
-  commitizen@4.3.1(@types/node@25.9.1)(typescript@6.0.3):
+  commitizen@4.3.1(@types/node@25.9.2)(typescript@6.0.3):
     dependencies:
       cachedir: 2.3.0
-      cz-conventional-changelog: 3.3.0(@types/node@25.9.1)(typescript@6.0.3)
+      cz-conventional-changelog: 3.3.0(@types/node@25.9.2)(typescript@6.0.3)
       dedent: 0.7.0
       detect-indent: 6.1.0
       find-node-modules: 2.1.3
@@ -13506,6 +13531,13 @@ snapshots:
       jiti: 2.6.1
       typescript: 6.0.3
 
+  cosmiconfig-typescript-loader@6.3.0(@types/node@25.9.2)(cosmiconfig@9.0.1(typescript@6.0.3))(typescript@6.0.3):
+    dependencies:
+      '@types/node': 25.9.2
+      cosmiconfig: 9.0.1(typescript@6.0.3)
+      jiti: 2.6.1
+      typescript: 6.0.3
+
   cosmiconfig@9.0.1(typescript@6.0.3):
     dependencies:
       env-paths: 2.2.1
@@ -13540,16 +13572,16 @@ snapshots:
 
   csstype@3.2.3: {}
 
-  cz-conventional-changelog@3.3.0(@types/node@25.9.1)(typescript@6.0.3):
+  cz-conventional-changelog@3.3.0(@types/node@25.9.2)(typescript@6.0.3):
     dependencies:
       chalk: 2.4.2
-      commitizen: 4.3.1(@types/node@25.9.1)(typescript@6.0.3)
+      commitizen: 4.3.1(@types/node@25.9.2)(typescript@6.0.3)
       conventional-commit-types: 3.0.0
       lodash.map: 4.6.0
       longest: 2.0.1
       word-wrap: 1.2.5
     optionalDependencies:
-      '@commitlint/load': 21.0.1(@types/node@25.9.1)(typescript@6.0.3)
+      '@commitlint/load': 21.0.1(@types/node@25.9.2)(typescript@6.0.3)
     transitivePeerDependencies:
       - '@types/node'
       - typescript
@@ -14086,7 +14118,7 @@ snapshots:
   eslint-scope@9.1.2:
     dependencies:
       '@types/esrecurse': 4.3.1
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       esrecurse: 4.3.0
       estraverse: 5.3.0
 
@@ -14105,7 +14137,7 @@ snapshots:
       '@humanfs/node': 0.16.8
       '@humanwhocodes/module-importer': 1.0.1
       '@humanwhocodes/retry': 0.4.3
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       ajv: 6.14.0
       cross-spawn: 7.0.6
       debug: 4.4.3
@@ -14155,7 +14187,7 @@ snapshots:
 
   estree-walker@3.0.3:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
 
   esutils@2.0.3: {}
 
@@ -14775,6 +14807,26 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
+  inquirer@8.2.7(@types/node@25.9.2):
+    dependencies:
+      '@inquirer/external-editor': 1.0.3(@types/node@25.9.2)
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      cli-cursor: 3.1.0
+      cli-width: 3.0.0
+      figures: 3.2.0
+      lodash: 4.18.1
+      mute-stream: 0.0.8
+      ora: 5.4.1
+      run-async: 2.4.1
+      rxjs: 7.8.2
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      through: 2.3.8
+      wrap-ansi: 6.2.0
+    transitivePeerDependencies:
+      - '@types/node'
+
   internal-slot@1.1.0:
     dependencies:
       es-errors: 1.3.0
@@ -14878,7 +14930,7 @@ snapshots:
 
   is-reference@1.2.1:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
 
   is-regex@1.2.1:
     dependencies:


### PR DESCRIPTION
## Summary

Adds `eslint` (version `catalog:`) to the **root** `devDependencies` in `package.json`, with the corresponding `pnpm-lock.yaml` update.

## Why

Follow-up to #432 ("restore pnpm isolated linker + enforce catalog"). Under pnpm's isolated linker, transitive dependencies are not hoisted, so root-level tooling (the lefthook `eslint`/lint hooks) needs `eslint` declared explicitly at the workspace root to resolve. Using the `catalog:` specifier keeps the version pinned to the central catalog, consistent with the repo's enforced single-source-of-truth.

## Lockfile churn

Most of the `pnpm-lock.yaml` diff is mechanical re-resolution from the install:
- New `eslint` snapshot entry.
- Incidental `@types/node` `25.9.1` → `25.9.2` bumps.
- Incidental `@types/estree` `1.0.8` → `1.0.9` bumps.

## Verification

- Local `pre-commit` (turbo `typecheck`) and `commit-msg` (commitlint) hooks pass.
- CI checks (`format-check`, `lint`, `typecheck`, `build`, `test-coverage`) should run green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)