### PR TITLE
docs(repo): adding 2nd key to google api docs

### DIFF
--- a/docs/LOCAL_DEV_DOCKER.md
+++ b/docs/LOCAL_DEV_DOCKER.md
@@ -185,7 +185,7 @@ You should see output ending with:
 The app will start without this, but the map tiles won't render. To get one:
 
 1. Go to [console.cloud.google.com/google/maps-apis](https://console.cloud.google.com/google/maps-apis/)
-2. Create a project and enable **Maps JavaScript API**
+2. Create a project and enable **Maps JavaScript API** and **Places API (New)**
 3. Create an API key
 4. Set the key in both `apps/map/.env` and `apps/api/.env`:
    `NEXT_PUBLIC_GOOGLE_API_KEY=your-key-here`


### PR DESCRIPTION
This pull request makes a small update to the local development documentation. It clarifies that both the **Maps JavaScript API** and the **Places API (New)** need to be enabled when setting up a Google Cloud project for map development.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated local development Docker setup instructions for Google Maps API configuration to require enabling both Maps JavaScript API and Places API (New) in Google Cloud.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->