### PR TITLE
Changing regions

### DIFF
--- a/.claude/skills/logs/SKILL.md
+++ b/.claude/skills/logs/SKILL.md
@@ -14,8 +14,8 @@ See `apps.conf` for the full registry. Currently:
 
 | App    | Staging Project             | Prod Project        | Region        |
 | ------ | --------------------------- | ------------------- | ------------- |
-| `auth` | `f3-authentication-staging` | `f3-authentication` | `us-east1`    |
-| `api`  | `f3-api-app-staging`        | `f3-api-app`        | `us-east1`    |
+| `auth` | `f3-authentication-staging` | `f3-authentication` | `us-central1` |
+| `api`  | `f3-api-app-staging`        | `f3-api-app`        | `us-central1` |
 | `map`  | `pin-mastery`               | `pin-mastery`       | `us-central1` |
 
 ## Instructions
@@ -82,7 +82,7 @@ The following app + environment combinations have been verified working:
 | App    | Staging | Prod | Notes                                                                   |
 | ------ | ------- | ---- | ----------------------------------------------------------------------- |
 | `auth` | ✅      | ✅   | Primary use case — originally built for this app                        |
-| `api`  | ✅      | ✅   | GCP projects `f3-api-app-staging` / `f3-api-app`, region `us-east1`     |
+| `api`  | ✅      | ✅   | GCP projects `f3-api-app-staging` / `f3-api-app`, region `us-central1`  |
 | `map`  | ✅      | ✅   | GCP project `pin-mastery`, Cloud Run service is `f3-2` / `f3-2-staging` |
 
 ## Adding a New App

--- a/.claude/skills/logs/apps.conf
+++ b/.claude/skills/logs/apps.conf
@@ -4,9 +4,9 @@
 # To add a new app, append a line pair (staging + prod).
 # The app name must match a directory under apps/.
 
-auth:staging:f3-authentication-staging:f3-auth:us-east1
-auth:prod:f3-authentication:f3-auth:us-east1
-api:staging:f3-api-app-staging:f3-api:us-east1
-api:prod:f3-api-app:f3-api:us-east1
+auth:staging:f3-authentication-staging:f3-auth:us-central1
+auth:prod:f3-authentication:f3-auth:us-central1
+api:staging:f3-api-app-staging:f3-api:us-central1
+api:prod:f3-api-app:f3-api:us-central1
 map:staging:pin-mastery:f3-2-staging:us-central1
 map:prod:pin-mastery:f3-2:us-central1

--- a/.github/workflows/_deploy-cloudrun.yml
+++ b/.github/workflows/_deploy-cloudrun.yml
@@ -52,7 +52,7 @@ on:
         description: "GCP region"
         required: false
         type: string
-        default: us-east1
+        default: us-central1
       ar_repo:
         description: "Artifact Registry repository"
         required: false

--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -30,5 +30,5 @@ jobs:
       staging_environment: api-staging
       prod_environment: api-production
       # TODO: Update these URLs to the URLs of the staging and production services when domains are set up
-      staging_url: https://f3-api-150221595414.us-east1.run.app
-      prod_url: https://f3-api-120003472394.us-east1.run.app
+      staging_url: https://staging.api.f3nation.com
+      prod_url: https://api.f3nation.com

--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -29,6 +29,5 @@ jobs:
       dockerfile: apps/api/Dockerfile
       staging_environment: api-staging
       prod_environment: api-production
-      # TODO: Update these URLs to the URLs of the staging and production services when domains are set up
       staging_url: https://staging.api.f3nation.com
       prod_url: https://api.f3nation.com

--- a/.github/workflows/deploy-map.yml
+++ b/.github/workflows/deploy-map.yml
@@ -30,5 +30,5 @@ jobs:
       staging_environment: map-staging
       prod_environment: map-production
       # TODO: Update these URLs to the URLs of the staging and production services when domains are set up
-      staging_url: https://f3-map-1054072148233.us-east1.run.app
-      prod_url: https://f3-map-836482382930.us-east1.run.app
+      staging_url: https://staging.map.f3nation.com
+      prod_url: https://map.f3nation.com

--- a/.github/workflows/deploy-map.yml
+++ b/.github/workflows/deploy-map.yml
@@ -29,6 +29,5 @@ jobs:
       dockerfile: apps/map/Dockerfile
       staging_environment: map-staging
       prod_environment: map-production
-      # TODO: Update these URLs to the URLs of the staging and production services when domains are set up
       staging_url: https://staging.map.f3nation.com
       prod_url: https://map.f3nation.com

--- a/apps/admin/scripts/cloud-run-env.sh
+++ b/apps/admin/scripts/cloud-run-env.sh
@@ -29,7 +29,7 @@ declare -A PROJECT_MAP=(
 )
 
 SERVICE_NAME="f3-admin"
-REGION="us-east1"
+REGION="us-central1"
 
 # Env vars that map to GCP secrets (var name -> secret ID).
 # Only genuinely sensitive values go here.

--- a/apps/api/scripts/cloud-run-env.sh
+++ b/apps/api/scripts/cloud-run-env.sh
@@ -29,7 +29,7 @@ declare -A PROJECT_MAP=(
 )
 
 SERVICE_NAME="f3-api"
-REGION="us-east1"
+REGION="us-central1"
 
 # Env vars that map to GCP secrets (var name -> secret ID).
 # Only genuinely sensitive values go here.

--- a/apps/auth/README.md
+++ b/apps/auth/README.md
@@ -553,13 +553,13 @@ Each project gets its own Artifact Registry. The build pushes to staging; the de
 # Staging
 gcloud artifacts repositories create cloud-run-builds \
   --repository-format=docker \
-  --location=us-east1 \
+  --location=us-central1 \
   --project=f3-authentication-staging
 
 # Production
 gcloud artifacts repositories create cloud-run-builds \
   --repository-format=docker \
-  --location=us-east1 \
+  --location=us-central1 \
   --project=f3-authentication
 ```
 
@@ -571,7 +571,7 @@ gcloud artifacts repositories create cloud-run-builds \
 # Staging
 gcloud run deploy f3-auth \
   --image=us-docker.pkg.dev/cloudrun/container/hello \
-  --region=us-east1 \
+  --region=us-central1 \
   --project=f3-authentication-staging \
   --add-cloudsql-instances=f3data:us-central1:f3data-nonprod \
   --allow-unauthenticated
@@ -579,7 +579,7 @@ gcloud run deploy f3-auth \
 # Production
 gcloud run deploy f3-auth \
   --image=us-docker.pkg.dev/cloudrun/container/hello \
-  --region=us-east1 \
+  --region=us-central1 \
   --project=f3-authentication \
   --add-cloudsql-instances=f3data:us-central1:f3data \
   --allow-unauthenticated
@@ -703,13 +703,13 @@ bash apps/auth/scripts/cloud-run-env.sh --env prod
 gcloud run domain-mappings create \
   --service=f3-auth \
   --domain=staging.auth.f3nation.com \
-  --region=us-east1 \
+  --region=us-central1 \
   --project=f3-authentication-staging
 
 gcloud run domain-mappings create \
   --service=f3-auth \
   --domain=auth.f3nation.com \
-  --region=us-east1 \
+  --region=us-central1 \
   --project=f3-authentication
 ```
 
@@ -723,12 +723,12 @@ Get the service accounts Cloud Run is using. You will need to use the output to 
 
 ```bash
 gcloud run services describe f3-auth \
-  --region=us-east1 \
+  --region=us-central1 \
   --project=f3-authentication-staging \
   --format="value(spec.template.spec.serviceAccountName)"
 
 gcloud run services describe f3-auth \
-  --region=us-east1 \
+  --region=us-central1 \
   --project=f3-authentication \
   --format="value(spec.template.spec.serviceAccountName)"
 ```
@@ -779,7 +779,7 @@ Triggered by tags matching `auth@*` (e.g. `auth@1.0.0`).
 - GCP Workload Identity Federation for keyless auth (shared `WIF_PROVIDER`, per-app `WIF_SA_AUTH_*` variables)
 - GCP project IDs hardcoded in workflow `env:` block (no GitHub variables needed)
 - Artifact Registry for container images
-- Cloud Run (us-east1) for compute
+- Cloud Run (us-central1) for compute
 - GCP Secret Manager for secrets (see `scripts/cloud-run-env.sh`)
 
 ### GCP Secret Management

--- a/apps/auth/scripts/cloud-run-env.sh
+++ b/apps/auth/scripts/cloud-run-env.sh
@@ -29,7 +29,7 @@ declare -A PROJECT_MAP=(
 )
 
 SERVICE_NAME="f3-auth"
-REGION="us-east1"
+REGION="us-central1"
 
 # Env vars that map to GCP secrets (var name → secret ID).
 # Only genuinely sensitive values go here.

--- a/apps/map/scripts/cloud-run-env.sh
+++ b/apps/map/scripts/cloud-run-env.sh
@@ -29,7 +29,7 @@ declare -A PROJECT_MAP=(
 )
 
 SERVICE_NAME="f3-map"
-REGION="us-east1"
+REGION="us-central1"
 
 # Env vars that map to GCP secrets (var name -> secret ID).
 # Only genuinely sensitive values go here.

--- a/apps/me/README.md
+++ b/apps/me/README.md
@@ -248,7 +248,7 @@ See [docs/GCP_APP_SETUP.md](../../docs/GCP_APP_SETUP.md) for the full generalize
 ```bash
 APP_NAME="me"
 CLOUDRUN_SERVICE="f3-me"
-GCP_REGION="us-east1"
+GCP_REGION="us-central1"
 GCP_STAGING_PROJECT="f3-me-app-staging"
 GCP_PROD_PROJECT="f3-me-app"
 STAGING_DOMAIN="staging.me.f3nation.com"

--- a/apps/me/scripts/cloud-run-env.sh
+++ b/apps/me/scripts/cloud-run-env.sh
@@ -27,7 +27,7 @@ declare -A PROJECT_MAP=(
 )
 
 SERVICE_NAME="f3-me"
-REGION="us-east1"
+REGION="us-central1"
 
 # Env vars that map to GCP secrets (var name → secret ID)
 # Only genuinely sensitive values go here.

--- a/docs/GCP_APP_SETUP.md
+++ b/docs/GCP_APP_SETUP.md
@@ -14,7 +14,7 @@ Fill these in and paste the whole block into your terminal. Every subsequent com
 # ── App identity ─────────────────────────────────────────────────────────────
 APP_NAME="me"                            # short identifier: me | map | api | auth | admin
 CLOUDRUN_SERVICE="f3-me"                 # Cloud Run service name (usually f3-$APP_NAME)
-GCP_REGION="us-east1"                   # GCP region for Cloud Run and Artifact Registry
+GCP_REGION="us-central1"                   # GCP region for Cloud Run and Artifact Registry
 
 # ── GCP projects ─────────────────────────────────────────────────────────────
 GCP_STAGING_PROJECT="f3-me-app-staging"  # staging GCP project ID

--- a/docs/GCP_APP_SETUP.md
+++ b/docs/GCP_APP_SETUP.md
@@ -14,7 +14,7 @@ Fill these in and paste the whole block into your terminal. Every subsequent com
 # ── App identity ─────────────────────────────────────────────────────────────
 APP_NAME="me"                            # short identifier: me | map | api | auth | admin
 CLOUDRUN_SERVICE="f3-me"                 # Cloud Run service name (usually f3-$APP_NAME)
-GCP_REGION="us-central1"                   # GCP region for Cloud Run and Artifact Registry
+GCP_REGION="us-central1"                 # GCP region for Cloud Run and Artifact Registry
 
 # ── GCP projects ─────────────────────────────────────────────────────────────
 GCP_STAGING_PROJECT="f3-me-app-staging"  # staging GCP project ID


### PR DESCRIPTION
I accidentally created most infrastructure in us-east1 region. The database is in us-central1. This generates Network cost and latency (which therefore drives up compute). This is to correct references in the code to the errant region. We still have to migrate auth, me, api, and maps. By that I mean delete and recreate.