### PR TITLE
chore(prettier): re-enable prettier-plugin-tailwindcss

### DIFF
--- a/apps/admin/src/app/_components/modal/admin-aos-modal.tsx
+++ b/apps/admin/src/app/_components/modal/admin-aos-modal.tsx
@@ -134,7 +134,7 @@ export default function AdminAOsModal({
       <DialogContent
         style={{ zIndex: Z_INDEX.HOW_TO_JOIN_MODAL }}
         className={cn(
-          `max-w-[95%] rounded-lg sm:max-w-[90%] lg:max-w-[600px] max-h-[90vh] overflow-y-auto`,
+          `max-h-[90vh] max-w-[95%] overflow-y-auto rounded-lg sm:max-w-[90%] lg:max-w-[600px]`,
         )}
       >
         <DialogHeader>

--- a/apps/admin/src/app/_components/modal/admin-areas-modal.tsx
+++ b/apps/admin/src/app/_components/modal/admin-areas-modal.tsx
@@ -138,7 +138,7 @@ export default function AdminAreasModal({
       <DialogContent
         style={{ zIndex: Z_INDEX.HOW_TO_JOIN_MODAL }}
         className={cn(
-          `max-w-[95%] rounded-lg sm:max-w-[90%] lg:max-w-[600px] max-h-[90vh] overflow-y-auto`,
+          `max-h-[90vh] max-w-[95%] overflow-y-auto rounded-lg sm:max-w-[90%] lg:max-w-[600px]`,
         )}
       >
         <DialogHeader>

--- a/apps/admin/src/app/_components/modal/admin-event-types-modal.tsx
+++ b/apps/admin/src/app/_components/modal/admin-event-types-modal.tsx
@@ -139,7 +139,7 @@ export default function AdminEventTypesModal({
       <DialogContent
         style={{ zIndex: Z_INDEX.HOW_TO_JOIN_MODAL }}
         className={cn(
-          `max-w-[95%] rounded-lg sm:max-w-[90%] lg:max-w-[600px] max-h-[90vh] overflow-y-auto`,
+          `max-h-[90vh] max-w-[95%] overflow-y-auto rounded-lg sm:max-w-[90%] lg:max-w-[600px]`,
         )}
       >
         <DialogHeader>

--- a/apps/admin/src/app/_components/modal/admin-locations-modal.tsx
+++ b/apps/admin/src/app/_components/modal/admin-locations-modal.tsx
@@ -151,7 +151,7 @@ export default function AdminLocationsModal({
       <DialogContent
         style={{ zIndex: Z_INDEX.HOW_TO_JOIN_MODAL }}
         className={cn(
-          `max-w-[95%] rounded-lg sm:max-w-[90%] lg:max-w-[1024px] max-h-[90vh] overflow-y-auto`,
+          `max-h-[90vh] max-w-[95%] overflow-y-auto rounded-lg sm:max-w-[90%] lg:max-w-[1024px]`,
         )}
       >
         <DialogHeader>

--- a/apps/admin/src/app/_components/modal/admin-manage-access-modal.tsx
+++ b/apps/admin/src/app/_components/modal/admin-manage-access-modal.tsx
@@ -531,7 +531,7 @@ export default function AdminManageAccessModal({
                                       {selectedUser.email}
                                     </p>
                                   ) : (
-                                    <p className="truncate text-sm text-muted-foreground italic">
+                                    <p className="truncate text-sm italic text-muted-foreground">
                                       Email not available
                                     </p>
                                   )}

--- a/apps/admin/src/app/_components/modal/admin-regions-modal.tsx
+++ b/apps/admin/src/app/_components/modal/admin-regions-modal.tsx
@@ -138,7 +138,7 @@ export default function AdminRegionsModal({
       <DialogContent
         style={{ zIndex: Z_INDEX.HOW_TO_JOIN_MODAL }}
         className={cn(
-          `max-w-[95%] rounded-lg sm:max-w-[90%] lg:max-w-[600px] max-h-[90vh] overflow-y-auto`,
+          `max-h-[90vh] max-w-[95%] overflow-y-auto rounded-lg sm:max-w-[90%] lg:max-w-[600px]`,
         )}
       >
         <DialogHeader>

--- a/apps/admin/src/app/_components/modal/admin-sectors-modal.tsx
+++ b/apps/admin/src/app/_components/modal/admin-sectors-modal.tsx
@@ -137,7 +137,7 @@ export default function AdminSectorsModal({
       <DialogContent
         style={{ zIndex: Z_INDEX.HOW_TO_JOIN_MODAL }}
         className={cn(
-          `max-w-[95%] rounded-lg sm:max-w-[90%] lg:max-w-[600px] max-h-[90vh] overflow-y-auto`,
+          `max-h-[90vh] max-w-[95%] overflow-y-auto rounded-lg sm:max-w-[90%] lg:max-w-[600px]`,
         )}
       >
         <DialogHeader>

--- a/apps/admin/src/app/_components/modal/admin-users-modal.tsx
+++ b/apps/admin/src/app/_components/modal/admin-users-modal.tsx
@@ -518,7 +518,7 @@ export default function UserModal({
                         <UserPlus className="mr-2 h-4 w-4" />
                         Manage Access
                       </Button>
-                      <p className="text-xs text-muted-foreground text-center">
+                      <p className="text-center text-xs text-muted-foreground">
                         Progress here will be lost
                       </p>
                     </div>

--- a/apps/admin/src/app/auth/sign-in/already-signed-in.tsx
+++ b/apps/admin/src/app/auth/sign-in/already-signed-in.tsx
@@ -9,7 +9,7 @@ import { AuthWrapper } from "../components/auth-components";
 export const AlreadySignedIn = ({ session }: { session: AdminSession }) => {
   const router = useRouter();
   return (
-    <AuthWrapper className="max-w-md mx-auto">
+    <AuthWrapper className="mx-auto max-w-md">
       <h2 className="mt-2 text-2xl font-semibold">
         {`You're already signed in as ${session.email}`}
       </h2>

--- a/apps/admin/src/app/auth/sign-in/sign-in.tsx
+++ b/apps/admin/src/app/auth/sign-in/sign-in.tsx
@@ -11,7 +11,7 @@ export const SignIn = ({ channel }: { channel: string }) => {
     searchParams.get("callbackUrl") ?? searchParams.get("returnTo") ?? "/";
 
   return (
-    <div className="flex max-w-md flex-col gap-4 mx-auto">
+    <div className="mx-auto flex max-w-md flex-col gap-4">
       <div className="flex flex-col items-center">
         <h2 className="mt-2 text-center text-3xl font-semibold">
           Sign in to F3 Nation Admin

--- a/apps/auth/src/app/components/PhoneField.tsx
+++ b/apps/auth/src/app/components/PhoneField.tsx
@@ -46,7 +46,7 @@ export function PhoneField({
 
   return (
     <div>
-      <label htmlFor={id} className="block text-base font-medium mb-2">
+      <label htmlFor={id} className="mb-2 block text-base font-medium">
         {label}
       </label>
       <div className="grid grid-cols-[max-content_minmax(0,1fr)] gap-3">

--- a/apps/auth/src/app/components/SignOutButton.tsx
+++ b/apps/auth/src/app/components/SignOutButton.tsx
@@ -22,13 +22,13 @@ export default function SignOutButton() {
         <div className="flex gap-3">
           <button
             onClick={handleLogout}
-            className="flex-1 rounded-md bg-primary px-4 py-3 text-base font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
+            className="flex-1 rounded-md bg-primary px-4 py-3 text-base font-medium text-primary-foreground transition-colors hover:bg-primary/90"
           >
             Log Out
           </button>
           <button
             onClick={() => setConfirming(false)}
-            className="flex-1 rounded-md border px-4 py-3 text-base font-medium hover:bg-accent transition-colors"
+            className="flex-1 rounded-md border px-4 py-3 text-base font-medium transition-colors hover:bg-accent"
           >
             Cancel
           </button>
@@ -40,7 +40,7 @@ export default function SignOutButton() {
   return (
     <button
       onClick={() => setConfirming(true)}
-      className="w-full rounded-md bg-primary px-4 py-3 text-base font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
+      className="w-full rounded-md bg-primary px-4 py-3 text-base font-medium text-primary-foreground transition-colors hover:bg-primary/90"
     >
       Log Out
     </button>

--- a/apps/auth/src/app/login/email/page.tsx
+++ b/apps/auth/src/app/login/email/page.tsx
@@ -80,7 +80,7 @@ function EmailLoginForm() {
 
         <form onSubmit={handleSubmit} noValidate className="space-y-5">
           <div>
-            <label htmlFor="email" className="block text-base font-medium mb-2">
+            <label htmlFor="email" className="mb-2 block text-base font-medium">
               Email address
             </label>
             <input
@@ -99,7 +99,7 @@ function EmailLoginForm() {
           <button
             type="submit"
             disabled={loading}
-            className="w-full rounded-md bg-primary px-4 py-3 text-base font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50 transition-colors"
+            className="w-full rounded-md bg-primary px-4 py-3 text-base font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:opacity-50"
           >
             {loading ? "Sending..." : "Send Code"}
           </button>

--- a/apps/auth/src/app/login/email/verify/page.tsx
+++ b/apps/auth/src/app/login/email/verify/page.tsx
@@ -111,7 +111,7 @@ function VerifyEmailForm() {
 
         <form onSubmit={handleSubmit} className="space-y-5">
           <div>
-            <label htmlFor="code" className="block text-base font-medium mb-2">
+            <label htmlFor="code" className="mb-2 block text-base font-medium">
               Verification code
             </label>
             <input
@@ -124,7 +124,7 @@ function VerifyEmailForm() {
               value={code}
               onChange={(e) => setCode(e.target.value.replace(/\D/g, ""))}
               placeholder="000000"
-              className="w-full rounded-md border bg-background px-3 py-2 text-center text-2xl font-mono tracking-[0.5em] outline-none focus:ring-2 focus:ring-ring"
+              className="w-full rounded-md border bg-background px-3 py-2 text-center font-mono text-2xl tracking-[0.5em] outline-none focus:ring-2 focus:ring-ring"
             />
           </div>
 
@@ -133,7 +133,7 @@ function VerifyEmailForm() {
           <button
             type="submit"
             disabled={loading || code.length !== 6}
-            className="w-full rounded-md bg-primary px-4 py-3 text-base font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50 transition-colors"
+            className="w-full rounded-md bg-primary px-4 py-3 text-base font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:opacity-50"
           >
             {loading ? "Verifying..." : "Verify"}
           </button>

--- a/apps/auth/src/app/login/page.tsx
+++ b/apps/auth/src/app/login/page.tsx
@@ -14,13 +14,13 @@ export default function LoginPage() {
             priority
           />
           <h1 className="text-3xl font-bold">F3 Nation Auth Provider</h1>
-          <p className="text-base text-muted-foreground text-center">
+          <p className="text-center text-base text-muted-foreground">
             Central authentication service for F3 Nation applications
           </p>
         </div>
         <Link
           href="/login/email"
-          className="flex w-full items-center justify-center rounded-md bg-primary px-4 py-3 text-base font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
+          className="flex w-full items-center justify-center rounded-md bg-primary px-4 py-3 text-base font-medium text-primary-foreground transition-colors hover:bg-primary/90"
         >
           Sign in with Email
         </Link>

--- a/apps/auth/src/app/onboarding/page.tsx
+++ b/apps/auth/src/app/onboarding/page.tsx
@@ -115,7 +115,7 @@ function OnboardingForm() {
           <div>
             <label
               htmlFor="f3Name"
-              className="block text-base font-medium mb-2"
+              className="mb-2 block text-base font-medium"
             >
               F3 Name
             </label>
@@ -133,7 +133,7 @@ function OnboardingForm() {
           <div>
             <label
               htmlFor="firstName"
-              className="block text-base font-medium mb-2"
+              className="mb-2 block text-base font-medium"
             >
               First Name
             </label>
@@ -151,7 +151,7 @@ function OnboardingForm() {
           <div>
             <label
               htmlFor="lastName"
-              className="block text-base font-medium mb-2"
+              className="mb-2 block text-base font-medium"
             >
               Last Name
             </label>
@@ -171,7 +171,7 @@ function OnboardingForm() {
           <button
             type="submit"
             disabled={loading}
-            className="w-full rounded-md bg-primary px-4 py-3 text-base font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50 transition-colors"
+            className="w-full rounded-md bg-primary px-4 py-3 text-base font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:opacity-50"
           >
             {loading ? "Saving..." : "Continue"}
           </button>

--- a/apps/auth/src/app/register/page.tsx
+++ b/apps/auth/src/app/register/page.tsx
@@ -175,7 +175,7 @@ function RegisterForm() {
               priority
             />
             <h1 className="text-3xl font-bold">Create Your Account</h1>
-            <p className="text-base text-muted-foreground text-center">
+            <p className="text-center text-base text-muted-foreground">
               Welcome to F3 Nation! Fill in your details to get started.
             </p>
             <p className="text-base font-medium">{email}</p>
@@ -186,7 +186,7 @@ function RegisterForm() {
               <div>
                 <label
                   htmlFor="firstName"
-                  className="block text-base font-medium mb-2"
+                  className="mb-2 block text-base font-medium"
                 >
                   First Name <span className="text-destructive">*</span>
                 </label>
@@ -203,7 +203,7 @@ function RegisterForm() {
               <div>
                 <label
                   htmlFor="lastName"
-                  className="block text-base font-medium mb-2"
+                  className="mb-2 block text-base font-medium"
                 >
                   Last Name <span className="text-destructive">*</span>
                 </label>
@@ -222,7 +222,7 @@ function RegisterForm() {
             <div>
               <label
                 htmlFor="f3Name"
-                className="block text-base font-medium mb-2"
+                className="mb-2 block text-base font-medium"
               >
                 F3 Name
               </label>
@@ -239,7 +239,7 @@ function RegisterForm() {
             <div ref={regionRef} className="relative">
               <label
                 htmlFor="homeRegion"
-                className="block text-base font-medium mb-2"
+                className="mb-2 block text-base font-medium"
               >
                 Home Region
               </label>
@@ -290,7 +290,7 @@ function RegisterForm() {
                           setRegionSearch(r.name);
                           setRegionDropdownOpen(false);
                         }}
-                        className="w-full px-4 py-2 text-left text-base hover:bg-accent transition-colors"
+                        className="w-full px-4 py-2 text-left text-base transition-colors hover:bg-accent"
                       >
                         {r.name}
                       </button>
@@ -327,7 +327,7 @@ function RegisterForm() {
               <button
                 type="button"
                 onClick={() => setShowEmergency(!showEmergency)}
-                className="text-base text-muted-foreground hover:text-foreground transition-colors"
+                className="text-base text-muted-foreground transition-colors hover:text-foreground"
               >
                 {showEmergency ? "▾" : "▸"} Emergency Contact Info
               </button>
@@ -338,7 +338,7 @@ function RegisterForm() {
                 <div>
                   <label
                     htmlFor="emergencyContact"
-                    className="block text-base font-medium mb-2"
+                    className="mb-2 block text-base font-medium"
                   >
                     Emergency Contact Name
                   </label>
@@ -363,7 +363,7 @@ function RegisterForm() {
                 <div>
                   <label
                     htmlFor="emergencyNotes"
-                    className="block text-base font-medium mb-2"
+                    className="mb-2 block text-base font-medium"
                   >
                     Notes
                   </label>
@@ -384,7 +384,7 @@ function RegisterForm() {
             <button
               type="submit"
               disabled={loading}
-              className="w-full rounded-md bg-primary px-4 py-3 text-base font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50 transition-colors"
+              className="w-full rounded-md bg-primary px-4 py-3 text-base font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:opacity-50"
             >
               {loading ? "Creating Account..." : "Create Account"}
             </button>

--- a/apps/map/src/app/_components/contact-links.tsx
+++ b/apps/map/src/app/_components/contact-links.tsx
@@ -47,7 +47,7 @@ export const ContactLinks = ({
 
   const iconClass = iconSizes[iconSize];
   const buttonClass = cn(
-    "rounded-full bg-muted hover:bg-muted-foreground/20 transition-colors",
+    "rounded-full bg-muted transition-colors hover:bg-muted-foreground/20",
     buttonSizes[iconSize],
   );
 

--- a/apps/map/src/app/_components/map-page-wrapper.tsx
+++ b/apps/map/src/app/_components/map-page-wrapper.tsx
@@ -58,7 +58,7 @@ export const MapPageWrapper = (props: { children: React.ReactNode }) => {
       <DesktopSidebarContainer>
         <Sidebar />
       </DesktopSidebarContainer>
-      <div className={cn(`lg:pl-360 pl-0`)}>{props.children}</div>
+      <div className={cn(`pl-0 lg:pl-360`)}>{props.children}</div>
     </>
   );
 };

--- a/apps/map/src/app/auth/components/auth-components.tsx
+++ b/apps/map/src/app/auth/components/auth-components.tsx
@@ -51,7 +51,7 @@ export const AuthWrapper = ({
     <div
       className={cn(
         "flex h-full w-full flex-1 flex-col items-center bg-background p-8 pb-16 text-center",
-        "xs:w-min xs:min-w-[400px] xs:shadow-md xs:rounded-xl xs:pb-8 xs:flex-grow-0 xs:h-auto",
+        "xs:h-auto xs:w-min xs:min-w-[400px] xs:flex-grow-0 xs:rounded-xl xs:pb-8 xs:shadow-md",
         className,
       )}
     >

--- a/apps/map/src/app/auth/layout.tsx
+++ b/apps/map/src/app/auth/layout.tsx
@@ -18,7 +18,7 @@ export default function AuthLayout(props: { children: ReactNode }) {
       <div
         className={cn(
           "overflow-y-auto",
-          "xs:p-8 xs:flex xs:flex-row xs:justify-center xs:items-start",
+          "xs:flex xs:flex-row xs:items-start xs:justify-center xs:p-8",
         )}
         style={{ height: `calc(100dvh - ${HEADER_HEIGHT}px)` }}
       >

--- a/apps/me/src/app/layout.tsx
+++ b/apps/me/src/app/layout.tsx
@@ -26,7 +26,7 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <body
-        className={`${inter.className} min-h-screen overflow-x-hidden overscroll-y-none bg-background text-foreground antialiased`}
+        className={`${inter.className} bg-background text-foreground min-h-screen overflow-x-hidden overscroll-y-none antialiased`}
       >
         <GoogleAnalytics />
         <ToastProvider>

--- a/apps/me/src/components/auth-card.tsx
+++ b/apps/me/src/components/auth-card.tsx
@@ -45,13 +45,13 @@ export function AuthCard({ error }: AuthCardProps) {
       </CardHeader>
       <CardContent className="flex flex-col gap-4">
         {error && (
-          <div className="rounded-md border border-destructive/50 bg-destructive/10 p-3 text-sm text-destructive">
+          <div className="border-destructive/50 bg-destructive/10 text-destructive rounded-md border p-3 text-sm">
             {ERROR_MESSAGES[error] ?? `An error occurred: ${error}`}
           </div>
         )}
         <a
           href="/api/auth/login?returnTo=/profile"
-          className="inline-flex h-11 w-full items-center justify-center whitespace-nowrap rounded-md bg-primary px-8 text-sm font-medium text-primary-foreground ring-offset-background transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+          className="bg-primary text-primary-foreground ring-offset-background hover:bg-primary/90 focus-visible:ring-ring inline-flex h-11 w-full items-center justify-center whitespace-nowrap rounded-md px-8 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
         >
           Sign in with F3 Nation
         </a>

--- a/apps/me/src/components/avatar-upload.tsx
+++ b/apps/me/src/components/avatar-upload.tsx
@@ -37,7 +37,7 @@ export function AvatarUpload({
         type="button"
         className={cn(
           "relative cursor-pointer rounded-full",
-          dragOver && "ring-2 ring-primary ring-offset-2",
+          dragOver && "ring-primary ring-2 ring-offset-2",
         )}
         onClick={openFilePicker}
         onDragOver={(e) => {
@@ -68,7 +68,7 @@ export function AvatarUpload({
         >
           {uploading ? "Uploading..." : "Change avatar"}
         </Button>
-        <p className="text-xs text-muted-foreground">
+        <p className="text-muted-foreground text-xs">
           JPEG, PNG, or WebP. Max 5MB. Will be converted to JPEG.
         </p>
       </div>

--- a/apps/me/src/components/navbar.tsx
+++ b/apps/me/src/components/navbar.tsx
@@ -53,7 +53,7 @@ export function Navbar() {
               variant="ghost"
               size="sm"
               onClick={signOut}
-              className="text-[#f8f4ea]/70 hover:text-[#f8f4ea] hover:bg-white/10"
+              className="text-[#f8f4ea]/70 hover:bg-white/10 hover:text-[#f8f4ea]"
             >
               Sign out
             </Button>

--- a/apps/me/src/components/position-list.tsx
+++ b/apps/me/src/components/position-list.tsx
@@ -39,7 +39,7 @@ export function PositionList({
 
   if (positions.length === 0) {
     return (
-      <p className="text-sm text-muted-foreground">No positions assigned.</p>
+      <p className="text-muted-foreground text-sm">No positions assigned.</p>
     );
   }
 
@@ -59,7 +59,7 @@ export function PositionList({
               </span>
               <button
                 type="button"
-                className="ml-1 rounded-full p-0.5 hover:bg-foreground/10 disabled:opacity-50"
+                className="hover:bg-foreground/10 ml-1 rounded-full p-0.5 disabled:opacity-50"
                 disabled={removing !== null}
                 onClick={() => setPositionToConfirm(pos)}
                 aria-label={`Remove ${pos.positionName} position from ${pos.orgName}`}
@@ -81,7 +81,7 @@ export function PositionList({
           );
         })}
       </div>
-      <p className="text-xs text-muted-foreground">
+      <p className="text-muted-foreground text-xs">
         To add a new position, contact your region admins. Check{" "}
         <a
           href="https://org.f3nation.com"

--- a/apps/me/src/components/profile-form.tsx
+++ b/apps/me/src/components/profile-form.tsx
@@ -72,7 +72,7 @@ export function ProfileForm({ user, regions }: ProfileFormProps) {
               href="https://apps.f3nation.com"
               target="_blank"
               rel="noopener noreferrer"
-              className="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+              className="bg-primary text-primary-foreground hover:bg-primary/90 focus-visible:outline-hidden focus-visible:ring-ring inline-flex items-center gap-2 rounded-md px-4 py-2 text-sm font-medium transition-colors focus-visible:ring-2 focus-visible:ring-offset-2"
             >
               Go to apps.f3nation.com &rarr;
             </a>
@@ -88,18 +88,18 @@ export function ProfileForm({ user, regions }: ProfileFormProps) {
             <CardTitle className="text-lg">Personal Information</CardTitle>
           </CardHeader>
           <CardContent className="space-y-4">
-            <div className="space-y-2 pl-2 border-l-[3px] border-l-transparent">
+            <div className="space-y-2 border-l-[3px] border-l-transparent pl-2">
               <Label>Email</Label>
               <Input
                 value={user.email}
                 disabled
                 className="disabled:opacity-70"
               />
-              <p className="text-xs text-muted-foreground">
+              <p className="text-muted-foreground text-xs">
                 Email{" "}
                 <a
                   href="mailto:it@f3nation.com?subject=Need%20to%20change%20F3%20email%20address"
-                  className="text-primary underline hover:text-primary/80"
+                  className="text-primary hover:text-primary/80 underline"
                 >
                   it@f3nation.com
                 </a>{" "}
@@ -209,7 +209,7 @@ export function ProfileForm({ user, regions }: ProfileFormProps) {
                 </Label>
                 <p
                   id="user-emergency-info-dr-sharing-help"
-                  className="text-sm text-muted-foreground"
+                  className="text-muted-foreground text-sm"
                 >
                   If enabled, users can search for your emergency info from
                   other Slack workspaces.

--- a/apps/me/src/components/region-select.tsx
+++ b/apps/me/src/components/region-select.tsx
@@ -56,7 +56,7 @@ export function RegionSelect({ regions, value, onChange }: RegionSelectProps) {
       {open && (
         <div
           id="region-list"
-          className="absolute z-50 mt-1 w-full rounded-md border bg-popover shadow-md"
+          className="bg-popover absolute z-50 mt-1 w-full rounded-md border shadow-md"
         >
           <div className="p-2">
             <Input
@@ -73,7 +73,7 @@ export function RegionSelect({ regions, value, onChange }: RegionSelectProps) {
             {value !== null && (
               <button
                 type="button"
-                className="relative flex w-full cursor-pointer select-none items-center rounded-sm px-2 py-1.5 text-sm text-muted-foreground outline-none hover:bg-accent"
+                className="text-muted-foreground hover:bg-accent relative flex w-full cursor-pointer select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none"
                 onClick={() => {
                   onChange(null);
                   selectAndClose();
@@ -83,7 +83,7 @@ export function RegionSelect({ regions, value, onChange }: RegionSelectProps) {
               </button>
             )}
             {filteredRegions.length === 0 ? (
-              <p className="px-2 py-4 text-center text-sm text-muted-foreground">
+              <p className="text-muted-foreground px-2 py-4 text-center text-sm">
                 No regions found.
               </p>
             ) : (
@@ -92,7 +92,7 @@ export function RegionSelect({ regions, value, onChange }: RegionSelectProps) {
                   key={region.id}
                   type="button"
                   disabled={!region.isActive && region.id !== value}
-                  className={`relative flex w-full cursor-pointer select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none hover:bg-accent ${
+                  className={`hover:bg-accent relative flex w-full cursor-pointer select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none ${
                     region.id === value ? "bg-accent font-medium" : ""
                   }${!region.isActive ? " opacity-50" : ""}`}
                   onClick={() => {
@@ -102,7 +102,7 @@ export function RegionSelect({ regions, value, onChange }: RegionSelectProps) {
                 >
                   {region.name}
                   {!region.isActive && (
-                    <span className="ml-auto text-xs text-muted-foreground">
+                    <span className="text-muted-foreground ml-auto text-xs">
                       Inactive
                     </span>
                   )}

--- a/apps/me/src/components/role-list.tsx
+++ b/apps/me/src/components/role-list.tsx
@@ -35,7 +35,7 @@ export function RoleList({ roles: initialRoles }: RoleListProps) {
   });
 
   if (roles.length === 0) {
-    return <p className="text-sm text-muted-foreground">No roles assigned.</p>;
+    return <p className="text-muted-foreground text-sm">No roles assigned.</p>;
   }
 
   return (
@@ -54,7 +54,7 @@ export function RoleList({ roles: initialRoles }: RoleListProps) {
               </span>
               <button
                 type="button"
-                className="ml-1 rounded-full p-0.5 hover:bg-foreground/10 disabled:opacity-50"
+                className="hover:bg-foreground/10 ml-1 rounded-full p-0.5 disabled:opacity-50"
                 disabled={removing !== null}
                 onClick={() => setRoleToConfirm(role)}
                 aria-label={`Remove ${role.roleName} role from ${role.orgName ?? `Org ${role.orgId}`}`}
@@ -76,7 +76,7 @@ export function RoleList({ roles: initialRoles }: RoleListProps) {
           );
         })}
       </div>
-      <p className="text-xs text-muted-foreground">
+      <p className="text-muted-foreground text-xs">
         To add a new role, contact your region admins. Check{" "}
         <a
           href="https://org.f3nation.com"

--- a/apps/me/src/components/ui/button.tsx
+++ b/apps/me/src/components/ui/button.tsx
@@ -35,7 +35,7 @@ const Button = React.forwardRef<
   return (
     <button
       className={cn(
-        "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
+        "ring-offset-background focus-visible:ring-ring inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
         variants[variant],
         sizes[size],
         className,

--- a/apps/me/src/components/user-select.tsx
+++ b/apps/me/src/components/user-select.tsx
@@ -128,7 +128,7 @@ export function UserSelect({ value, onChange }: UserSelectProps) {
           aria-activedescendant={
             focusedIndex >= 0 ? `user-option-${focusedIndex}` : undefined
           }
-          className="absolute z-50 mt-1 w-full rounded-md border bg-popover shadow-md"
+          className="bg-popover absolute z-50 mt-1 w-full rounded-md border shadow-md"
           onKeyDown={handleListKeyDown}
         >
           <div className="p-2">
@@ -144,7 +144,7 @@ export function UserSelect({ value, onChange }: UserSelectProps) {
           </div>
           <div className="max-h-60 overflow-y-auto p-1">
             {loading ? (
-              <p className="px-2 py-4 text-center text-sm text-muted-foreground">
+              <p className="text-muted-foreground px-2 py-4 text-center text-sm">
                 Loading...
               </p>
             ) : (
@@ -158,7 +158,7 @@ export function UserSelect({ value, onChange }: UserSelectProps) {
                       itemRefs.current[0] = el;
                     }}
                     type="button"
-                    className="relative flex w-full cursor-pointer select-none items-center rounded-sm px-2 py-1.5 text-sm text-muted-foreground outline-none hover:bg-accent"
+                    className="text-muted-foreground hover:bg-accent relative flex w-full cursor-pointer select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none"
                     onClick={() => {
                       onChange(null);
                       setSelectedUser(null);
@@ -169,11 +169,11 @@ export function UserSelect({ value, onChange }: UserSelectProps) {
                   </button>
                 )}
                 {showPrompt ? (
-                  <p className="px-2 py-4 text-center text-sm text-muted-foreground">
+                  <p className="text-muted-foreground px-2 py-4 text-center text-sm">
                     Type at least 2 characters to search.
                   </p>
                 ) : results.length === 0 ? (
-                  <p className="px-2 py-4 text-center text-sm text-muted-foreground">
+                  <p className="text-muted-foreground px-2 py-4 text-center text-sm">
                     No users found.
                   </p>
                 ) : null}
@@ -187,7 +187,7 @@ export function UserSelect({ value, onChange }: UserSelectProps) {
                       itemRefs.current[clearOffset + idx] = el;
                     }}
                     type="button"
-                    className={`relative flex w-full cursor-pointer select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none hover:bg-accent ${
+                    className={`hover:bg-accent relative flex w-full cursor-pointer select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none ${
                       user.id === value ? "bg-accent font-medium" : ""
                     }${user.status !== "active" ? " opacity-50" : ""}`}
                     onClick={() => {
@@ -199,7 +199,7 @@ export function UserSelect({ value, onChange }: UserSelectProps) {
                     <span className="truncate">
                       {displayName(user)}
                       {user.status !== "active" && (
-                        <span className="ml-1 text-xs text-muted-foreground">
+                        <span className="text-muted-foreground ml-1 text-xs">
                           (Inactive)
                         </span>
                       )}

--- a/packages/ui/src/alert-dialog.tsx
+++ b/packages/ui/src/alert-dialog.tsx
@@ -24,7 +24,7 @@ const AlertDialogOverlay = React.forwardRef<
   <AlertDialogPrimitive.Overlay
     style={{ zIndex: Z_INDEX.ALERT_DIALOG_OVERLAY }}
     className={cn(
-      "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 bg-white/80 backdrop-blur-sm dark:bg-zinc-950/80",
+      "fixed inset-0 bg-white/80 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 dark:bg-zinc-950/80",
       className,
     )}
     {...props}
@@ -43,7 +43,7 @@ const AlertDialogContent = React.forwardRef<
       ref={ref}
       style={{ zIndex: Z_INDEX.ALERT_DIALOG }}
       className={cn(
-        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] fixed left-[50%] top-[50%] grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border border-zinc-200 bg-white p-6 shadow-lg duration-200 dark:border-zinc-800 dark:bg-zinc-950 sm:rounded-lg md:w-full",
+        "fixed left-[50%] top-[50%] grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border border-zinc-200 bg-white p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] dark:border-zinc-800 dark:bg-zinc-950 sm:rounded-lg md:w-full",
         className,
       )}
       {...props}

--- a/packages/ui/src/context-menu.tsx
+++ b/packages/ui/src/context-menu.tsx
@@ -51,7 +51,7 @@ const ContextMenuSubContent = React.forwardRef<
     ref={ref}
     style={{ zIndex: Z_INDEX.CONTEXT_MENU_SUBCONTENT }}
     className={cn(
-      "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 min-w-[8rem] overflow-hidden rounded-md border border-zinc-200 bg-white p-1 text-zinc-950 shadow-lg dark:border-zinc-800 dark:bg-zinc-950 dark:text-zinc-50",
+      "min-w-[8rem] overflow-hidden rounded-md border border-zinc-200 bg-white p-1 text-zinc-950 shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 dark:border-zinc-800 dark:bg-zinc-950 dark:text-zinc-50",
       className,
     )}
     {...props}
@@ -68,7 +68,7 @@ const ContextMenuContent = React.forwardRef<
       ref={ref}
       style={{ zIndex: Z_INDEX.CONTEXT_MENU_CONTENT }}
       className={cn(
-        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 min-w-[8rem] overflow-hidden rounded-md border border-zinc-200 bg-white p-1 text-zinc-950 shadow-md dark:border-zinc-800 dark:bg-zinc-950 dark:text-zinc-50",
+        "min-w-[8rem] overflow-hidden rounded-md border border-zinc-200 bg-white p-1 text-zinc-950 shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 dark:border-zinc-800 dark:bg-zinc-950 dark:text-zinc-50",
         className,
       )}
       {...props}

--- a/packages/ui/src/dialog.tsx
+++ b/packages/ui/src/dialog.tsx
@@ -50,7 +50,7 @@ const DialogContent = React.forwardRef<
         className={cn(
           "my-6",
           "relative grid w-full max-w-[calc(min(90%,768px))] gap-4 bg-muted p-6 shadow-lg sm:rounded-lg md:w-full",
-          "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 duration-200",
+          "duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
           className,
         )}
         {...props}

--- a/packages/ui/src/dropdown-menu.tsx
+++ b/packages/ui/src/dropdown-menu.tsx
@@ -49,7 +49,7 @@ const DropdownMenuSubContent = React.forwardRef<
     ref={ref}
     style={{ zIndex: Z_INDEX.DROPDOWN_MENU_SUBCONTENT }}
     className={cn(
-      "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg",
+      "min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
       className,
     )}
     {...props}

--- a/packages/ui/src/hover-card.tsx
+++ b/packages/ui/src/hover-card.tsx
@@ -19,7 +19,7 @@ const HoverCardContent = React.forwardRef<
     sideOffset={sideOffset}
     style={{ zIndex: Z_INDEX.HOVER_CARD_CONTENT }}
     className={cn(
-      "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 w-64 rounded-md border border-zinc-200 bg-white p-4 text-zinc-950 shadow-md outline-none dark:border-zinc-800 dark:bg-zinc-950 dark:text-zinc-50",
+      "w-64 rounded-md border border-zinc-200 bg-white p-4 text-zinc-950 shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 dark:border-zinc-800 dark:bg-zinc-950 dark:text-zinc-50",
       className,
     )}
     {...props}

--- a/packages/ui/src/md-table.tsx
+++ b/packages/ui/src/md-table.tsx
@@ -350,7 +350,7 @@ export const MDTable = <T,>(params: MDTableProps<T>) => {
           </TableBody>
         </Table>
         {pagination ? (
-          <div className="flex flex-wrap items-center justify-between lg:px-3 gap-3 py-4">
+          <div className="flex flex-wrap items-center justify-between gap-3 py-4 lg:px-3">
             <div className="flex flex-row items-center gap-1 sm:gap-2">
               <Button
                 variant="ghost"

--- a/packages/ui/src/navigation-menu.tsx
+++ b/packages/ui/src/navigation-menu.tsx
@@ -73,7 +73,7 @@ const NavigationMenuContent = React.forwardRef<
   <NavigationMenuPrimitive.Content
     ref={ref}
     className={cn(
-      "data-[motion^=from-]:animate-in data-[motion^=to-]:animate-out data-[motion^=from-]:fade-in data-[motion^=to-]:fade-out data-[motion=from-end]:slide-in-from-right-52 data-[motion=from-start]:slide-in-from-left-52 data-[motion=to-end]:slide-out-to-right-52 data-[motion=to-start]:slide-out-to-left-52 left-0 top-0 w-full md:absolute md:w-auto",
+      "left-0 top-0 w-full data-[motion^=from-]:animate-in data-[motion^=to-]:animate-out data-[motion^=from-]:fade-in data-[motion^=to-]:fade-out data-[motion=from-end]:slide-in-from-right-52 data-[motion=from-start]:slide-in-from-left-52 data-[motion=to-end]:slide-out-to-right-52 data-[motion=to-start]:slide-out-to-left-52 md:absolute md:w-auto",
       className,
     )}
     {...props}
@@ -90,7 +90,7 @@ const NavigationMenuViewport = React.forwardRef<
   <div className={cn("absolute left-0 top-full flex justify-center")}>
     <NavigationMenuPrimitive.Viewport
       className={cn(
-        "origin-top-center data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-90 relative mt-1.5 h-[var(--radix-navigation-menu-viewport-height)] w-full overflow-hidden rounded-md border border-slate-200 bg-white text-slate-950 shadow-lg dark:border-slate-800 dark:bg-slate-950 dark:text-slate-50 md:w-[var(--radix-navigation-menu-viewport-width)]",
+        "origin-top-center relative mt-1.5 h-[var(--radix-navigation-menu-viewport-height)] w-full overflow-hidden rounded-md border border-slate-200 bg-white text-slate-950 shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-90 dark:border-slate-800 dark:bg-slate-950 dark:text-slate-50 md:w-[var(--radix-navigation-menu-viewport-width)]",
         className,
       )}
       ref={ref}
@@ -109,7 +109,7 @@ const NavigationMenuIndicator = React.forwardRef<
     ref={ref}
     style={{ zIndex: Z_INDEX.NAVIGATION_MENU }}
     className={cn(
-      "data-[state=visible]:animate-in data-[state=hidden]:animate-out data-[state=hidden]:fade-out data-[state=visible]:fade-in top-full z-[1] flex h-1.5 items-end justify-center overflow-hidden",
+      "top-full z-[1] flex h-1.5 items-end justify-center overflow-hidden data-[state=visible]:animate-in data-[state=hidden]:animate-out data-[state=hidden]:fade-out data-[state=visible]:fade-in",
       className,
     )}
     {...props}

--- a/packages/ui/src/popover.tsx
+++ b/packages/ui/src/popover.tsx
@@ -19,7 +19,7 @@ const PopoverContentWithoutPortal = React.forwardRef<
     sideOffset={sideOffset}
     style={{ zIndex: Z_INDEX.POPOVER_CONTENT }}
     className={cn(
-      "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 w-72 rounded-md border border-slate-200 bg-white p-4 text-slate-950 shadow-md outline-none dark:border-slate-800 dark:bg-slate-950 dark:text-slate-50",
+      "w-72 rounded-md border border-slate-200 bg-white p-4 text-slate-950 shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 dark:border-slate-800 dark:bg-slate-950 dark:text-slate-50",
       className,
     )}
     {...props}
@@ -38,7 +38,7 @@ const PopoverContent = React.forwardRef<
       sideOffset={sideOffset}
       style={{ zIndex: Z_INDEX.POPOVER_CONTENT }}
       className={cn(
-        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 w-72 rounded-md border border-slate-200 bg-white p-4 text-slate-950 shadow-md outline-none dark:border-slate-800 dark:bg-slate-950 dark:text-slate-50",
+        "w-72 rounded-md border border-slate-200 bg-white p-4 text-slate-950 shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 dark:border-slate-800 dark:bg-slate-950 dark:text-slate-50",
         className,
       )}
       {...props}

--- a/packages/ui/src/select.tsx
+++ b/packages/ui/src/select.tsx
@@ -101,7 +101,7 @@ const SelectContent = React.forwardRef<
     <SelectPrimitive.Content
       ref={ref}
       className={cn(
-        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative max-h-96 min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md",
+        "relative max-h-96 min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         position === "popper" &&
           "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
         className,

--- a/packages/ui/src/sheet.tsx
+++ b/packages/ui/src/sheet.tsx
@@ -26,7 +26,7 @@ const SheetOverlay = React.forwardRef<
   <SheetPrimitive.Overlay
     style={{ zIndex: Z_INDEX.SHEET_OVERLAY }}
     className={cn(
-      "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 bg-white/80 backdrop-blur-sm dark:bg-zinc-950/80",
+      "fixed inset-0 bg-white/80 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 dark:bg-zinc-950/80",
       className,
     )}
     {...props}
@@ -36,16 +36,16 @@ const SheetOverlay = React.forwardRef<
 SheetOverlay.displayName = SheetPrimitive.Overlay.displayName;
 
 const sheetVariants = cva(
-  `data-[state=open]:animate-in data-[state=closed]:animate-out fixed gap-4 bg-white p-6 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500 dark:bg-zinc-950`,
+  `fixed gap-4 bg-white p-6 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500 data-[state=open]:animate-in data-[state=closed]:animate-out dark:bg-zinc-950`,
   {
     variants: {
       side: {
-        top: "data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top inset-x-0 top-0 border-b",
+        top: "inset-x-0 top-0 border-b data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top",
         bottom:
-          "data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom inset-x-0 bottom-0 border-t",
-        left: "data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left inset-y-0 left-0 h-full w-3/4 border-r sm:max-w-sm",
+          "inset-x-0 bottom-0 border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
+        left: "inset-y-0 left-0 h-full w-3/4 border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm",
         right:
-          "data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right inset-y-0 right-0 h-full w-3/4 border-l sm:max-w-sm",
+          "inset-y-0 right-0 h-full w-3/4 border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm",
       },
     },
     defaultVariants: {

--- a/packages/ui/src/tooltip.tsx
+++ b/packages/ui/src/tooltip.tsx
@@ -24,7 +24,7 @@ const TooltipContent = React.forwardRef<
     sideOffset={sideOffset}
     style={{ zIndex: Z_INDEX.TOOLTIP_CONTENT }}
     className={cn(
-      "animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 overflow-hidden rounded-md border border-slate-200 bg-white px-3 py-1.5 text-sm text-slate-950 shadow-md dark:border-slate-800 dark:bg-slate-950 dark:text-slate-50",
+      "overflow-hidden rounded-md border border-slate-200 bg-white px-3 py-1.5 text-sm text-slate-950 shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 dark:border-slate-800 dark:bg-slate-950 dark:text-slate-50",
       className,
     )}
     {...props}

--- a/tooling/prettier/index.cjs
+++ b/tooling/prettier/index.cjs
@@ -1,37 +1,11 @@
-/** @typedef {import("prettier").Config} PrettierConfig */
-
-/** @type { PrettierConfig } */
+/** @type {import("prettier").Config} */
 const config = {
-  // arrowParens: "always",
-  // printWidth: 80,
-  // singleQuote: true,
-  // jsxSingleQuote: true,
-  // semi: false,
-  // trailingComma: "all",
-  // tabWidth: 2,
-  // Plugins temporarily disabled for CI compatibility testing
-  // plugins: [
-  //   "@ianvs/prettier-plugin-sort-imports",
-  //   "prettier-plugin-tailwindcss",
-  // ],
-  // tailwindFunctions: ["cn", "cva"],
-  // importOrder: [
-  //   "<TYPES>",
-  //   "^(react/(.*)$)|^(react$)|^(react-native(.*)$)",
-  //   "^(next/(.*)$)|^(next$)",
-  //   "^(expo(.*)$)|^(expo$)",
-  //   "<THIRD_PARTY_MODULES>",
-  //   "",
-  //   "<TYPES>^@acme",
-  //   "^@acme/(.*)$",
-  //   "",
-  //   "<TYPES>^[.|..|~]",
-  //   "^~/",
-  //   "^[../]",
-  //   "^[./]",
-  // ],
-  // importOrderParserPlugins: ["typescript", "jsx", "decorators-legacy"],
-  // importOrderTypeScriptVersion: "5.3.3",
+  plugins: [
+    // INFO: Enabling this plugin resorts a lot of imports and therefore leads to a lot of file diffs, do in own PR
+    // require.resolve("@ianvs/prettier-plugin-sort-imports"),
+    require.resolve("prettier-plugin-tailwindcss"),
+  ],
+  tailwindFunctions: ["cn", "cva"],
 };
 
 module.exports = config;


### PR DESCRIPTION
## Summary

- Re-enables `prettier-plugin-tailwindcss` in `tooling/prettier/index.cjs` (was commented out)
- Restores `tailwindFunctions: ["cn", "cva"]` config
- Removes stale commented-out config (dead options, disabled plugin block)
- Runs `pnpm format:fix` — 42 files get Tailwind class-order sorting applied

## Test plan

- [ ] CI format check passes
- [ ] No functional changes — purely class-order cosmetic reformats

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reordered Tailwind CSS utility classes across admin, auth, map, and profile components for improved consistency.

* **Chores**
  * Enabled `prettier-plugin-tailwindcss` to automatically format and organize CSS classes in the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->