### PR TITLE
feat(admin): add Short Location Description field to Region editor

### DIFF
--- a/apps/admin/src/app/_components/modal/admin-regions-modal.tsx
+++ b/apps/admin/src/app/_components/modal/admin-regions-modal.tsx
@@ -459,6 +459,25 @@ export default function AdminRegionsModal({
               <div className="mb-4 w-full px-2 sm:w-1/2">
                 <FormField
                   control={form.control}
+                  name="meta.region_location_short_description"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Short Location Description</FormLabel>
+                      <FormControl>
+                        <Input
+                          placeholder="e.g. Denver, CO"
+                          {...field}
+                          value={field.value ?? ""}
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </div>
+              <div className="mb-4 w-full px-2 sm:w-1/2">
+                <FormField
+                  control={form.control}
                   name="isActive"
                   render={({ field }) => (
                     <FormItem>

--- a/packages/shared/src/app/types.ts
+++ b/packages/shared/src/app/types.ts
@@ -375,6 +375,7 @@ export type OrgMeta = {
   latLonKey?: string;
   mapSeed?: boolean;
   firstEventNotificationSent?: boolean;
+  region_location_short_description?: string;
 } & Record<string, unknown>;
 
 export type UpdateRequestMeta = Record<string, unknown>;


### PR DESCRIPTION
## Summary

- Adds optional **Short Location Description** input to the Region editor modal (e.g. "Denver, CO")
- Value persists to `orgs.meta.region_location_short_description` via the existing `meta` JSON field — no schema migration needed
- Added `region_location_short_description?: string` to the `OrgMeta` type in `packages/shared`

## Changes

- [`packages/shared/src/app/types.ts`](packages/shared/src/app/types.ts) — `region_location_short_description?: string` added to `OrgMeta`
- [`apps/admin/src/app/_components/modal/admin-regions-modal.tsx`](apps/admin/src/app/_components/modal/admin-regions-modal.tsx) — new half-width input field bound to `meta.region_location_short_description`, placed alongside the Status field

## Test plan

- [ ] Open Region editor for an existing region — field loads any saved value
- [ ] Enter a value (e.g. "Denver, CO"), save — confirm `meta.region_location_short_description` is populated in the DB
- [ ] Clear the field, save — confirm key is absent / null in meta
- [ ] Create a new region with the field set — confirm value persists

Closes #84

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Short Location Description" input field to the region admin modal, allowing administrators to enter concise location descriptions (e.g., "Denver, CO") with integrated form validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->