### PR TITLE
ci(github): validate PR titles against commitlint for release-please

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,7 @@ jobs:
     permissions:
       contents: read
       issues: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,31 @@
+name: PR Title
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  lint-title:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup-node-pnpm
+      # Squash-merge builds the squash commit subject from the PR title, and
+      # release-please parses that subject to decide version bumps. The local
+      # commit-msg hook never sees the PR title, so validate it here against the
+      # same commitlint.config.mjs used for commits (single source of truth).
+      #
+      # Exempt release-please's own bot PRs: their titles (e.g. "chore: release
+      # dev") intentionally omit a scope and are committed via the API. Gate the
+      # STEP (not the job) so a skipped run still reports green and never blocks
+      # branch protection on the bot's release PRs.
+      - name: Lint PR title with commitlint
+        if: ${{ !startsWith(github.head_ref, 'release-please--') }}
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: echo "$PR_TITLE" | pnpm exec commitlint

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -28,4 +28,4 @@ jobs:
         if: ${{ !startsWith(github.head_ref, 'release-please--') }}
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
-        run: echo "$PR_TITLE" | pnpm exec commitlint
+        run: printf '%s\n' "$PR_TITLE" | pnpm exec commitlint


### PR DESCRIPTION
## TL;DR

Our release tool (Release-Please) decides which apps get a new version and a deploy by reading the **title of each pull request** (because we squash-merge). If a title doesn't start with `feat:` or `fix:`, the change quietly ships with **no version bump and no deploy** — the exact problem @taterhead247 flagged.

This PR adds an automatic check that reviews every PR title and **fails if the title isn't formatted correctly**, so a mistyped title can't slip through. The check uses the *same rules we already enforce on commit messages*, so there's nothing new to learn.

## What this changes

- Adds one small automation that runs on every pull request and validates the PR title.
- A correctly formatted title (e.g. `feat(map): add workout modal` or `fix(auth): handle expired token`) passes.
- A vague title (e.g. `update map stuff`) fails with a clear message telling the author how to fix it.
- Release-Please's own automated PRs are intentionally skipped, so this never gets in the bot's way.

## 🔑 Action required from @taterhead247 

Merging this PR turns the check **on**, but it will only show a warning — it won't yet *block* a bad title from being merged. Two quick settings in GitHub finish the job. **Both require Admin access**

**1. Make the check mandatory (so a bad title blocks the merge button)**
   - Go to: **Settings → Branches**
   - Edit (or add) the protection rule for the **`dev`** branch
   - Turn on **"Require status checks to pass before merging"**
   - In the search box, add the check named **`lint-title`**
   - Save
   - *(Note: the `lint-title` option only appears in that search box after this PR has run once — which it will, automatically, as soon as this PR is opened.)*

**2. Confirm the squash-merge setting uses the PR title** *(this is what makes the whole thing work)*
   - Go to: **Settings → General → scroll to "Pull Requests"**
   - Under **"Allow squash merging"**, make sure the default commit message is set to **"Default to pull request title"** (or "…title and description")
   - If this is set to "commit messages" instead, the title check will pass but Release-Please could still read the wrong text — so please confirm this one.

That's it. After those two settings, a PR can't be merged into `dev` until its title is formatted in a way Release-Please understands.

## How to test

This PR is its own test: its title is correctly formatted, so the new **PR Title** check should pass on this PR. If you rename this PR to something like `test bad title` and re-save, you'll see the check turn red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)