### PR TITLE
chore(repo): removed minimum age, added flag if recently released package is included

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,174 @@ jobs:
       - uses: ./.github/actions/setup-node-pnpm
       - run: pnpm audit --prod --audit-level=high
 
+  recent-package-watch:
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup-node-pnpm
+      - name: Build recent release report
+        id: report
+        shell: bash
+        run: |
+          node <<'NODE' >> "$GITHUB_OUTPUT"
+          const fs = require('node:fs');
+          const path = require('node:path');
+          const cp = require('node:child_process');
+
+          const importers = JSON.parse(
+            cp.execFileSync('pnpm', ['list', '--json', '--depth', 'Infinity', '--prod', '--dev'], {
+              encoding: 'utf8',
+              maxBuffer: 20 * 1024 * 1024,
+            }),
+          );
+
+          const workspaceRefs = new Map();
+
+          for (const importer of importers) {
+            const references = [
+              ...(importer.dependencies ? Object.values(importer.dependencies) : []),
+              ...(importer.unsavedDependencies ? Object.values(importer.unsavedDependencies) : []),
+            ];
+
+            for (const dependency of references) {
+              const dependencyPath = dependency?.path;
+
+              if (
+                typeof dependencyPath !== 'string' ||
+                !dependencyPath.includes(`${path.sep}node_modules${path.sep}.pnpm${path.sep}`)
+              ) {
+                continue;
+              }
+
+              let packageJson;
+
+              try {
+                packageJson = JSON.parse(fs.readFileSync(path.join(dependencyPath, 'package.json'), 'utf8'));
+              } catch {
+                continue;
+              }
+
+              if (!packageJson?.name || !packageJson?.version) {
+                continue;
+              }
+
+              const packageKey = `${packageJson.name}@${packageJson.version}`;
+              const referencesForPackage = workspaceRefs.get(packageKey) ?? {
+                name: packageJson.name,
+                version: packageJson.version,
+                workspaces: new Set(),
+              };
+
+              referencesForPackage.workspaces.add(importer.name ?? importer.path ?? 'workspace');
+              workspaceRefs.set(packageKey, referencesForPackage);
+            }
+          }
+
+          const cutoffTime = Date.now() - 3 * 24 * 60 * 60 * 1000;
+          const recentPackages = [];
+
+          for (const { name, version, workspaces } of workspaceRefs.values()) {
+            let timeData;
+
+            try {
+              timeData = JSON.parse(cp.execFileSync('npm', ['view', `${name}@${version}`, 'time', '--json'], {
+                encoding: 'utf8',
+              }));
+            } catch {
+              continue;
+            }
+
+            const publishedAt = timeData?.[version];
+
+            if (!publishedAt) {
+              continue;
+            }
+
+            const publishedTime = Date.parse(publishedAt);
+
+            if (!Number.isFinite(publishedTime) || publishedTime < cutoffTime) {
+              continue;
+            }
+
+            recentPackages.push({
+              name,
+              version,
+              publishedAt,
+              workspaces: Array.from(workspaces).sort((left, right) => left.localeCompare(right)),
+            });
+          }
+
+          recentPackages.sort(
+            (left, right) => Date.parse(right.publishedAt) - Date.parse(left.publishedAt) || left.name.localeCompare(right.name),
+          );
+
+          const lines = [
+            '<!-- recent-package-watch -->',
+            '### Recently published dependencies',
+            '',
+          ];
+
+          if (recentPackages.length === 0) {
+            lines.push('No workspace dependency versions were published in the last 3 days.');
+          } else {
+            lines.push(`Found ${recentPackages.length} package${recentPackages.length === 1 ? '' : 's'} published in the last 3 days:`);
+            lines.push('');
+
+            for (const packageEntry of recentPackages) {
+              lines.push(
+                `- \`${packageEntry.name}@${packageEntry.version}\` published ${packageEntry.publishedAt.slice(0, 10)} in ${packageEntry.workspaces.join(', ')}`,
+              );
+            }
+          }
+
+          lines.push('');
+
+          const body = lines.join('\n');
+          const delimiter = 'EOF';
+
+          process.stdout.write(`comment_body<<${delimiter}\n${body}\n${delimiter}\n`);
+          NODE
+      - name: Upsert PR comment
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          script: |
+            const marker = '<!-- recent-package-watch -->';
+            const body = `${process.env.COMMENT_BODY}`;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              per_page: 100,
+            });
+
+            const existingComment = comments.find((comment) => comment.body?.includes(marker));
+
+            if (existingComment) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existingComment.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
+
+        env:
+          COMMENT_BODY: ${{ steps.report.outputs.comment_body }}
+
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      issues: write
       pull-requests: write
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -87,7 +88,7 @@ jobs:
           const cp = require('node:child_process');
 
           const importers = JSON.parse(
-            cp.execFileSync('pnpm', ['list', '--json', '--depth', 'Infinity', '--prod', '--dev'], {
+            cp.execFileSync('pnpm', ['list', '--json', '--depth', '0', '--prod', '--dev'], {
               encoding: 'utf8',
               maxBuffer: 20 * 1024 * 1024,
             }),
@@ -137,15 +138,31 @@ jobs:
 
           const cutoffTime = Date.now() - 3 * 24 * 60 * 60 * 1000;
           const recentPackages = [];
+          const failedChecks = [];
 
           for (const { name, version, workspaces } of workspaceRefs.values()) {
             let timeData;
 
             try {
-              timeData = JSON.parse(cp.execFileSync('npm', ['view', `${name}@${version}`, 'time', '--json'], {
-                encoding: 'utf8',
-              }));
-            } catch {
+              timeData = JSON.parse(  
+                cp.execFileSync('npm', ['view', `${name}@${version}`, 'time', '--json'], {  
+                  encoding: 'utf8',  
+                  timeout: 15000,  
+                  maxBuffer: 2 * 1024 * 1024,  
+                }),  
+              );  
+            } catch (error) {
+              const timedOut =
+                error?.code === 'ETIMEDOUT' ||
+                error?.signal === 'SIGTERM' ||
+                /timed out/i.test(String(error?.message ?? ''));
+
+              failedChecks.push({
+                name,
+                version,
+                reason: timedOut ? 'timeout' : `error (${error?.code ?? 'unknown'})`,
+              });
+
               continue;
             }
 
@@ -193,6 +210,23 @@ jobs:
           }
 
           lines.push('');
+          lines.push('### Publish-time check health');
+          lines.push('');
+
+          if (failedChecks.length === 0) {
+            lines.push('All package publish-time checks completed successfully.');
+          } else {
+            lines.push(
+              `Failed to fetch publish-time metadata for ${failedChecks.length} package${failedChecks.length === 1 ? '' : 's'}:`,
+            );
+            lines.push('');
+
+            for (const failure of failedChecks) {
+              lines.push(`- \`${failure.name}@${failure.version}\`: ${failure.reason}`);
+            }
+          }
+
+          lines.push('');
 
           const body = lines.join('\n');
           const delimiter = 'EOF';
@@ -205,15 +239,26 @@ jobs:
           script: |
             const marker = '<!-- recent-package-watch -->';
             const body = `${process.env.COMMENT_BODY}`;
+            const actor = (process.env.GITHUB_ACTOR ?? context.actor ?? '').toLowerCase();
 
-            const { data: comments } = await github.rest.issues.listComments({
+            const { data: authenticatedUser } = await github.rest.users.getAuthenticated();
+            const botLogin = (authenticatedUser?.login ?? '').toLowerCase();
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
               per_page: 100,
             });
 
-            const existingComment = comments.find((comment) => comment.body?.includes(marker));
+            const existingComment = comments.find((comment) => {
+              const commentAuthor = (comment.user?.login ?? '').toLowerCase();
+
+              return (
+                comment.body?.includes(marker) &&
+                (commentAuthor === botLogin || commentAuthor === actor)
+              );
+            });
 
             if (existingComment) {
               await github.rest.issues.updateComment({

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,6 @@ jobs:
     permissions:
       contents: read
       issues: write
-      pull-requests: write
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -240,9 +239,7 @@ jobs:
             const marker = '<!-- recent-package-watch -->';
             const body = `${process.env.COMMENT_BODY}`;
             const actor = (process.env.GITHUB_ACTOR ?? context.actor ?? '').toLowerCase();
-
-            const { data: authenticatedUser } = await github.rest.users.getAuthenticated();
-            const botLogin = (authenticatedUser?.login ?? '').toLowerCase();
+            const botLogin = 'github-actions[bot]';
 
             const comments = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -283,8 +283,8 @@ catalogs:
       specifier: ^0.4.4
       version: 0.4.6
     nodemailer:
-      specifier: ^8.0.10
-      version: 8.0.10
+      specifier: ^9.0.1
+      version: 9.0.1
     pg:
       specifier: ^8.11.3
       version: 8.20.0
@@ -720,7 +720,7 @@ importers:
         version: link:../../packages/shared
       '@auth/core':
         specifier: 0.41.0
-        version: 0.41.0(nodemailer@8.0.10)
+        version: 0.41.0(nodemailer@9.0.1)
       '@t3-oss/env-nextjs':
         specifier: 'catalog:'
         version: 0.9.2(typescript@6.0.3)(zod@3.25.76)
@@ -738,10 +738,10 @@ importers:
         version: 15.5.18(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       next-auth:
         specifier: 'catalog:'
-        version: 5.0.0-beta.30(next@15.5.18(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(nodemailer@8.0.10)(react@18.3.1)
+        version: 5.0.0-beta.30(next@15.5.18(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(nodemailer@9.0.1)(react@18.3.1)
       nodemailer:
         specifier: 'catalog:'
-        version: 8.0.10
+        version: 9.0.1
       pg:
         specifier: 'catalog:'
         version: 8.20.0
@@ -905,7 +905,7 @@ importers:
         version: link:../../packages/validators
       '@auth/core':
         specifier: 0.41.0
-        version: 0.41.0(nodemailer@8.0.10)
+        version: 0.41.0(nodemailer@9.0.1)
       '@orpc/client':
         specifier: 'catalog:'
         version: 1.13.13(@opentelemetry/api@1.9.1)
@@ -965,13 +965,13 @@ importers:
         version: 15.5.18(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       next-auth:
         specifier: 'catalog:'
-        version: 5.0.0-beta.30(next@15.5.18(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(nodemailer@8.0.10)(react@18.3.1)
+        version: 5.0.0-beta.30(next@15.5.18(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(nodemailer@9.0.1)(react@18.3.1)
       next-themes:
         specifier: 'catalog:'
         version: 0.4.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       nodemailer:
         specifier: 'catalog:'
-        version: 8.0.10
+        version: 9.0.1
       react:
         specifier: 'catalog:'
         version: 18.3.1
@@ -1301,7 +1301,7 @@ importers:
         version: link:../shared
       '@auth/core':
         specifier: 0.41.0
-        version: 0.41.0(nodemailer@8.0.10)
+        version: 0.41.0(nodemailer@9.0.1)
       dayjs:
         specifier: 'catalog:'
         version: 1.11.20
@@ -1316,10 +1316,10 @@ importers:
         version: 15.5.18(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       next-auth:
         specifier: 'catalog:'
-        version: 5.0.0-beta.30(next@15.5.18(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(nodemailer@8.0.10)(react@18.3.1)
+        version: 5.0.0-beta.30(next@15.5.18(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(nodemailer@9.0.1)(react@18.3.1)
       nodemailer:
         specifier: 'catalog:'
-        version: 8.0.10
+        version: 9.0.1
       react:
         specifier: 'catalog:'
         version: 18.3.1
@@ -1476,7 +1476,7 @@ importers:
         version: link:../env
       nodemailer:
         specifier: 'catalog:'
-        version: 8.0.10
+        version: 9.0.1
     devDependencies:
       '@acme/eslint-config':
         specifier: workspace:^0.2.0
@@ -1507,7 +1507,7 @@ importers:
         version: 4.18.1
       next-auth:
         specifier: 'catalog:'
-        version: 5.0.0-beta.30(next@15.5.18(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(nodemailer@8.0.10)(react@18.3.1)
+        version: 5.0.0-beta.30(next@15.5.18(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(nodemailer@9.0.1)(react@18.3.1)
       react:
         specifier: '>=18 <19'
         version: 18.3.1
@@ -1931,13 +1931,13 @@ importers:
     dependencies:
       '@auth/core':
         specifier: 0.41.0
-        version: 0.41.0(nodemailer@8.0.10)
+        version: 0.41.0(nodemailer@9.0.1)
       '@tanstack/table-core':
         specifier: 'catalog:'
         version: 8.21.3
       next-auth:
         specifier: 'catalog:'
-        version: 5.0.0-beta.30(next@15.5.18(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(nodemailer@8.0.10)(react@18.3.1)
+        version: 5.0.0-beta.30(next@15.5.18(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(nodemailer@9.0.1)(react@18.3.1)
 
   tooling/vitest:
     devDependencies:
@@ -7782,8 +7782,8 @@ packages:
   node-releases@2.0.37:
     resolution: {integrity: sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==}
 
-  nodemailer@8.0.10:
-    resolution: {integrity: sha512-BLFuSth7QtHOkBzyqTehWWyub0NTRDuK2Q2SQfnGLsrJnzyU+Yeh4WpV1eZGuARFj1xQJHIdnTuJZLP+b9R1GQ==}
+  nodemailer@9.0.1:
+    resolution: {integrity: sha512-Gwv8SQewT616ZM/URn0H54b8PWo/Wum7md3EW2aWy1lO27+WZCX+Xyak3J+NlmHUjDh5ME+uesJUDRbR3Ye8Bw==}
     engines: {node: '>=6.0.0'}
 
   normalize-path@3.0.0:
@@ -9363,7 +9363,7 @@ snapshots:
 
   '@asamuzakjp/nwsapi@2.3.9': {}
 
-  '@auth/core@0.41.0(nodemailer@8.0.10)':
+  '@auth/core@0.41.0(nodemailer@9.0.1)':
     dependencies:
       '@panva/hkdf': 1.2.1
       jose: 6.2.2
@@ -9371,7 +9371,7 @@ snapshots:
       preact: 10.24.3
       preact-render-to-string: 6.5.11(preact@10.24.3)
     optionalDependencies:
-      nodemailer: 8.0.10
+      nodemailer: 9.0.1
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -15184,17 +15184,17 @@ snapshots:
 
   next-auth@5.0.0-beta.30(next@15.5.18(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1):
     dependencies:
-      '@auth/core': 0.41.0(nodemailer@8.0.10)
+      '@auth/core': 0.41.0(nodemailer@9.0.1)
       next: 15.5.18(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
 
-  next-auth@5.0.0-beta.30(next@15.5.18(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(nodemailer@8.0.10)(react@18.3.1):
+  next-auth@5.0.0-beta.30(next@15.5.18(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(nodemailer@9.0.1)(react@18.3.1):
     dependencies:
-      '@auth/core': 0.41.0(nodemailer@8.0.10)
+      '@auth/core': 0.41.0(nodemailer@9.0.1)
       next: 15.5.18(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
     optionalDependencies:
-      nodemailer: 8.0.10
+      nodemailer: 9.0.1
 
   next-themes@0.4.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
@@ -15264,7 +15264,7 @@ snapshots:
 
   node-releases@2.0.37: {}
 
-  nodemailer@8.0.10: {}
+  nodemailer@9.0.1: {}
 
   normalize-path@3.0.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -99,7 +99,7 @@ catalog:
   next: ^15.5.18
   next-auth: 5.0.0-beta.30
   next-themes: ^0.4.4
-  nodemailer: ^8.0.10
+  nodemailer: ^9.0.1
   pg: ^8.11.3
   pg-connection-string: ^2.12.0
   pino: ^10.3.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -154,17 +154,6 @@ allowBuilds:
   lefthook: true
   sharp: true
   unrs-resolver: true
-minimumReleaseAge: 10080
-# esbuild 0.28.1 patches GHSA-gv7w-rqvm-qjhr but was published <7 days ago; exempt
-# it from the release-age gate so the security patch is adopted now. @esbuild/*
-# covers its platform-specific binary optional deps, which are age-gated too.
-# Remove once the gate naturally allows 0.28.1 (~2026-06-19) — tracked by issue #435.
-# form-data 2.5.6 patches GHSA-hmw2-7cc7-3qxx (CRLF injection); published 2026-06-12.
-# Remove once the gate naturally allows 2.5.6 (~2026-06-19).
-minimumReleaseAgeExclude:
-  - esbuild
-  - "@esbuild/*"
-  - form-data@2.5.6
 catalogMode: strict
 cleanupUnusedCatalogs: true
 # pnpm's publicHoistPattern defaults to [] (nothing is hoisted); the patterns below


### PR DESCRIPTION
This pull request introduces a new workflow to automatically monitor and report recently published package dependencies used in the workspace. It also removes the manual exceptions for the minimum release age gate in the `pnpm-workspace.yaml` configuration. The changes aim to improve visibility of dependency freshness and simplify the package gating configuration.

**Dependency monitoring and reporting:**

* Adds a `recent-package-watch` job to `.github/workflows/ci.yml` that, on pull requests from the same repository, scans all workspace dependencies for any that were published within the last 3 days and posts a summary comment on the PR. This helps reviewers stay aware of newly published dependencies and their adoption across workspaces.

**Package gating configuration cleanup:**

* Removes the `minimumReleaseAgeExclude` section and its package exceptions from `pnpm-workspace.yaml`, as well as the `minimumReleaseAge` setting and related comments. This simplifies the configuration by eliminating manual tracking of temporary exceptions for recently published dependencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated `nodemailer` to version `^9.0.1`
  * Simplified release-age gating configuration (release-age overrides removed)

* **CI / Automation**
  * Enhanced pull request checks to detect packages published within the last 3 days
  * Automatically posts/updates a PR comment with the “recent package” results
<!-- end of auto-generated comment: release notes by coderabbit.ai -->