### PR TITLE
chore(deps): consolidate Renovate dependency updates

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -151,17 +151,17 @@ catalogs:
       specifier: ^7946.0.16
       version: 7946.0.16
     '@types/google.maps':
-      specifier: ^3.65.0
-      version: 3.65.0
+      specifier: ^3.65.1
+      version: 3.65.2
     '@types/lodash':
-      specifier: ^4.14.195
+      specifier: ^4.17.24
       version: 4.17.24
     '@types/node':
       specifier: ^24.12.4
       version: 24.12.4
     '@types/nodemailer':
-      specifier: ^8.0.0
-      version: 8.0.0
+      specifier: ^8.0.1
+      version: 8.0.1
     '@types/pg':
       specifier: ^8.10.9
       version: 8.20.0
@@ -184,17 +184,17 @@ catalogs:
       specifier: ^10.5.0
       version: 10.5.0
     class-variance-authority:
-      specifier: ^0.7.0
+      specifier: ^0.7.1
       version: 0.7.1
     clsx:
-      specifier: ^2.1.0
+      specifier: ^2.1.1
       version: 2.1.1
     cmdk:
       specifier: ^0.2.1
       version: 0.2.1
     commitizen:
-      specifier: ^4.3.1
-      version: 4.3.1
+      specifier: ^4.3.2
+      version: 4.3.2
     dayjs:
       specifier: ^1.11.10
       version: 1.11.20
@@ -390,11 +390,11 @@ catalogs:
 
 overrides:
   braces: '>=3.0.3'
-  cross-spawn: '>=7.0.5'
+  cross-spawn: '>=7.0.6'
   fast-uri: '>=3.1.1'
   form-data@>=2.0.0 <2.5.6: ^2.5.6
   next: ^15.5.18
-  '@auth/core': 0.41.0
+  '@auth/core': 0.41.2
   '@vis.gl/react-google-maps': 1.5.2
 
 importers:
@@ -412,13 +412,13 @@ importers:
         version: 21.0.2
       '@commitlint/cz-commitlint':
         specifier: 'catalog:'
-        version: 21.0.2(@types/node@25.9.2)(commitizen@4.3.1(@types/node@25.9.2)(typescript@6.0.3))(inquirer@12.11.1(@types/node@25.9.2))(typescript@6.0.3)
+        version: 21.0.2(@types/node@25.9.2)(commitizen@4.3.2(@types/node@25.9.2)(typescript@6.0.3))(inquirer@12.11.1(@types/node@25.9.2))(typescript@6.0.3)
       '@turbo/gen':
         specifier: 'catalog:'
         version: 1.13.4(@types/node@25.9.2)(typescript@6.0.3)
       commitizen:
         specifier: 'catalog:'
-        version: 4.3.1(@types/node@25.9.2)(typescript@6.0.3)
+        version: 4.3.2(@types/node@25.9.2)(typescript@6.0.3)
       dotenv-cli:
         specifier: 'catalog:'
         version: 7.4.4
@@ -551,7 +551,7 @@ importers:
         version: link:../../tooling/typescript
       '@types/google.maps':
         specifier: 'catalog:'
-        version: 3.65.0
+        version: 3.65.2
       '@types/lodash':
         specifier: 'catalog:'
         version: 4.17.24
@@ -725,8 +725,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/shared
       '@auth/core':
-        specifier: 0.41.0
-        version: 0.41.0(nodemailer@9.0.1)
+        specifier: 0.41.2
+        version: 0.41.2(nodemailer@9.0.1)
       '@t3-oss/env-nextjs':
         specifier: 'catalog:'
         version: 0.9.2(typescript@6.0.3)(zod@3.25.76)
@@ -784,7 +784,7 @@ importers:
         version: 24.12.4
       '@types/nodemailer':
         specifier: 'catalog:'
-        version: 8.0.0
+        version: 8.0.1
       '@types/pg':
         specifier: 'catalog:'
         version: 8.20.0
@@ -913,8 +913,8 @@ importers:
         specifier: workspace:^0.1.0
         version: link:../../packages/validators
       '@auth/core':
-        specifier: 0.41.0
-        version: 0.41.0(nodemailer@9.0.1)
+        specifier: 0.41.2
+        version: 0.41.2(nodemailer@9.0.1)
       '@orpc/client':
         specifier: 'catalog:'
         version: 1.13.13(@opentelemetry/api@1.9.1)
@@ -1035,7 +1035,7 @@ importers:
         version: 7946.0.16
       '@types/google.maps':
         specifier: 'catalog:'
-        version: 3.65.0
+        version: 3.65.2
       '@types/lodash':
         specifier: 'catalog:'
         version: 4.17.24
@@ -1044,7 +1044,7 @@ importers:
         version: 24.12.4
       '@types/nodemailer':
         specifier: 'catalog:'
-        version: 8.0.0
+        version: 8.0.1
       '@types/react':
         specifier: 'catalog:'
         version: 18.3.28
@@ -1318,8 +1318,8 @@ importers:
         specifier: workspace:^0.1.0
         version: link:../shared
       '@auth/core':
-        specifier: 0.41.0
-        version: 0.41.0(nodemailer@9.0.1)
+        specifier: 0.41.2
+        version: 0.41.2(nodemailer@9.0.1)
       dayjs:
         specifier: 'catalog:'
         version: 1.11.20
@@ -1359,7 +1359,7 @@ importers:
         version: 4.17.24
       '@types/nodemailer':
         specifier: 'catalog:'
-        version: 8.0.0
+        version: 8.0.1
       eslint:
         specifier: 'catalog:'
         version: 10.4.0(jiti@2.7.0)
@@ -1507,7 +1507,7 @@ importers:
         version: link:../../tooling/typescript
       '@types/nodemailer':
         specifier: 'catalog:'
-        version: 8.0.0
+        version: 8.0.1
       eslint:
         specifier: 'catalog:'
         version: 10.4.0(jiti@2.7.0)
@@ -1951,8 +1951,8 @@ importers:
   tooling/typescript:
     dependencies:
       '@auth/core':
-        specifier: 0.41.0
-        version: 0.41.0(nodemailer@9.0.1)
+        specifier: 0.41.2
+        version: 0.41.2(nodemailer@9.0.1)
       '@tanstack/table-core':
         specifier: 'catalog:'
         version: 8.21.3
@@ -2008,12 +2008,12 @@ packages:
   '@asamuzakjp/nwsapi@2.3.9':
     resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
 
-  '@auth/core@0.41.0':
-    resolution: {integrity: sha512-Wd7mHPQ/8zy6Qj7f4T46vg3aoor8fskJm6g2Zyj064oQ3+p0xNZXAV60ww0hY+MbTesfu29kK14Zk5d5JTazXQ==}
+  '@auth/core@0.41.2':
+    resolution: {integrity: sha512-Hx5MNBxN2fJTbJKGUKAA0wca43D0Akl3TvufY54Gn8lop7F+34vU1zA1pn0vQfIoVuLIrpfc2nkyjwIaPJMW7w==}
     peerDependencies:
       '@simplewebauthn/browser': ^9.0.1
       '@simplewebauthn/server': ^9.0.2
-      nodemailer: ^6.8.0
+      nodemailer: ^7.0.7
     peerDependenciesMeta:
       '@simplewebauthn/browser':
         optional: true
@@ -5301,8 +5301,8 @@ packages:
   '@types/glob@7.2.0':
     resolution: {integrity: sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==}
 
-  '@types/google.maps@3.65.0':
-    resolution: {integrity: sha512-u4SHiRC3m27lPa4vDBxh2AI7mDcHcheX6GSHn1Mwi0Gap8/uhM2kFppiFTnWASXLHZO+1ahHciLeEIV+Sjqk/A==}
+  '@types/google.maps@3.65.2':
+    resolution: {integrity: sha512-e52bmOhGCQSNabFpL48iQlwJybq6rfns8NUVJ20MR7CdPlHQ2RmSCnPbJfrUYJfogrE4OiHQTZ4LXpop+eer1w==}
 
   '@types/inquirer@6.5.0':
     resolution: {integrity: sha512-rjaYQ9b9y/VFGOpqBEXRavc3jh0a+e6evAbI31tMda8VlPaSy0AZJfXsvmIe3wklc7W6C3zCSfleuMXR7NOyXw==}
@@ -5326,8 +5326,8 @@ packages:
   '@types/node@25.9.2':
     resolution: {integrity: sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw==}
 
-  '@types/nodemailer@8.0.0':
-    resolution: {integrity: sha512-fyf8jWULsCo0d0BuoQ75i6IeoHs47qcqxWc7yUdUcV0pOZGjUTTOvwdG1PRXUDqN/8A64yQdQdnA2pZgcdi+cA==}
+  '@types/nodemailer@8.0.1':
+    resolution: {integrity: sha512-PxpaInm8V1JQDd4j0ds5HfvWQk8JupS1C0Picb96QJsrrRDjBH+DlK7L4ZdNSqNULhiZRQHc40nLVShaGxXAMw==}
 
   '@types/pg-pool@2.0.6':
     resolution: {integrity: sha512-TaAUE5rq2VQYxab5Ts7WZhKNmuN78Q6PiFonTDdpbx8a1H0M1vhy3rhiMjl+e2iHmogyMw7jZF4FrE6eJUy5HQ==}
@@ -5912,6 +5912,10 @@ packages:
     resolution: {integrity: sha512-A+Fezp4zxnit6FanDmv9EqXNAi3vt9DWp51/71UEhXukb7QUuvtv9344h91dyAxuTLoSYJFU299qzR3tzwPAhw==}
     engines: {node: '>=6'}
 
+  cachedir@2.4.0:
+    resolution: {integrity: sha512-9EtFOZR8g22CL7BWjJ9BUx1+A/djkofnyW3aOXZORNW2kxoUpx2h+uN2cOqwPmFhnpVmxg+KW2OjOSgChTEvsQ==}
+    engines: {node: '>=6'}
+
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
@@ -6059,6 +6063,11 @@ packages:
   commitizen@4.3.1:
     resolution: {integrity: sha512-gwAPAVTy/j5YcOOebcCRIijn+mSjWJC+IYKivTu6aG8Ei/scoXgfsMRnuAk6b0GRste2J4NGxVdMN3ZpfNaVaw==}
     engines: {node: '>= 12'}
+    hasBin: true
+
+  commitizen@4.3.2:
+    resolution: {integrity: sha512-1Zs37z9JPvAcuTSSricZZwBhOPVNNxJouuY4yDEt+eD70EoxT2TU9kViG8CuB/PmVg2G4XsAGQiK4YCst97aDQ==}
+    engines: {node: '>= 18'}
     hasBin: true
 
   commondir@1.0.1:
@@ -9335,7 +9344,7 @@ snapshots:
 
   '@asamuzakjp/nwsapi@2.3.9': {}
 
-  '@auth/core@0.41.0(nodemailer@9.0.1)':
+  '@auth/core@0.41.2(nodemailer@9.0.1)':
     dependencies:
       '@panva/hkdf': 1.2.1
       jose: 6.2.2
@@ -9494,12 +9503,12 @@ snapshots:
       '@commitlint/types': 21.0.1
       ajv: 8.20.0
 
-  '@commitlint/cz-commitlint@21.0.2(@types/node@25.9.2)(commitizen@4.3.1(@types/node@25.9.2)(typescript@6.0.3))(inquirer@12.11.1(@types/node@25.9.2))(typescript@6.0.3)':
+  '@commitlint/cz-commitlint@21.0.2(@types/node@25.9.2)(commitizen@4.3.2(@types/node@25.9.2)(typescript@6.0.3))(inquirer@12.11.1(@types/node@25.9.2))(typescript@6.0.3)':
     dependencies:
       '@commitlint/ensure': 21.0.1
       '@commitlint/load': 21.0.2(@types/node@25.9.2)(typescript@6.0.3)
       '@commitlint/types': 21.0.1
-      commitizen: 4.3.1(@types/node@25.9.2)(typescript@6.0.3)
+      commitizen: 4.3.2(@types/node@25.9.2)(typescript@6.0.3)
       inquirer: 12.11.1(@types/node@25.9.2)
       is-plain-obj: 4.1.0
       picocolors: 1.1.1
@@ -12426,7 +12435,7 @@ snapshots:
       '@types/minimatch': 6.0.0
       '@types/node': 25.9.2
 
-  '@types/google.maps@3.65.0': {}
+  '@types/google.maps@3.65.2': {}
 
   '@types/inquirer@6.5.0':
     dependencies:
@@ -12453,7 +12462,7 @@ snapshots:
     dependencies:
       undici-types: 7.24.6
 
-  '@types/nodemailer@8.0.0':
+  '@types/nodemailer@8.0.1':
     dependencies:
       '@types/node': 25.9.2
 
@@ -12664,7 +12673,7 @@ snapshots:
 
   '@vis.gl/react-google-maps@1.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@types/google.maps': 3.65.0
+      '@types/google.maps': 3.65.2
       fast-deep-equal: 3.1.3
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -13101,6 +13110,8 @@ snapshots:
 
   cachedir@2.3.0: {}
 
+  cachedir@2.4.0: {}
+
   call-bind-apply-helpers@1.0.2:
     dependencies:
       es-errors: 1.3.0
@@ -13266,6 +13277,26 @@ snapshots:
       is-utf8: 0.2.1
       lodash: 4.17.21
       minimist: 1.2.7
+      strip-bom: 4.0.0
+      strip-json-comments: 3.1.1
+    transitivePeerDependencies:
+      - '@types/node'
+      - typescript
+
+  commitizen@4.3.2(@types/node@25.9.2)(typescript@6.0.3):
+    dependencies:
+      cachedir: 2.4.0
+      cz-conventional-changelog: 3.3.0(@types/node@25.9.2)(typescript@6.0.3)
+      dedent: 0.7.0
+      detect-indent: 6.1.0
+      find-node-modules: 2.1.3
+      find-root: 1.1.0
+      fs-extra: 9.1.0
+      glob: 7.2.3
+      inquirer: 8.2.7(@types/node@25.9.2)
+      is-utf8: 0.2.1
+      lodash: 4.18.1
+      minimist: 1.2.8
       strip-bom: 4.0.0
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -15091,13 +15122,13 @@ snapshots:
 
   next-auth@5.0.0-beta.30(next@15.5.18(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1):
     dependencies:
-      '@auth/core': 0.41.0(nodemailer@9.0.1)
+      '@auth/core': 0.41.2(nodemailer@9.0.1)
       next: 15.5.18(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
 
   next-auth@5.0.0-beta.30(next@15.5.18(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(nodemailer@9.0.1)(react@18.3.1):
     dependencies:
-      '@auth/core': 0.41.0(nodemailer@9.0.1)
+      '@auth/core': 0.41.2(nodemailer@9.0.1)
       next: 15.5.18(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,7 +4,7 @@ packages:
   - tooling/*
 
 catalog:
-  "@auth/core": 0.41.0
+  "@auth/core": 0.41.2
   "@commitlint/cli": ^21.0.2
   "@commitlint/config-conventional": ^21.0.2
   "@commitlint/cz-commitlint": ^21.0.2
@@ -53,10 +53,10 @@ catalog:
   "@testing-library/user-event": ^14.6.1
   "@turbo/gen": ^1.12.3
   "@types/geojson": ^7946.0.16
-  "@types/google.maps": ^3.65.0
-  "@types/lodash": ^4.14.195
+  "@types/google.maps": ^3.65.1
+  "@types/lodash": ^4.17.24
   "@types/node": ^24.12.4
-  "@types/nodemailer": ^8.0.0
+  "@types/nodemailer": ^8.0.1
   "@types/pg": ^8.10.9
   "@types/react": ^18.3.1
   "@types/react-dom": ^18.3.1
@@ -65,10 +65,10 @@ catalog:
   "@vitejs/plugin-react": ^5.2.0
   "@vitest/coverage-v8": ^4.1.8
   autoprefixer: ^10.5.0
-  class-variance-authority: ^0.7.0
-  clsx: ^2.1.0
+  class-variance-authority: ^0.7.1
+  clsx: ^2.1.1
   cmdk: ^0.2.1
-  commitizen: ^4.3.1
+  commitizen: ^4.3.2
   dayjs: ^1.11.10
   dompurify: ^3.4.9
   dotenv: ^16.3.2
@@ -139,11 +139,11 @@ catalog:
   zustand: ^4.5.2
 overrides:
   braces: ">=3.0.3"
-  cross-spawn: ">=7.0.5"
+  cross-spawn: ">=7.0.6"
   fast-uri: ">=3.1.1"
   "form-data@>=2.0.0 <2.5.6": "^2.5.6"
   next: "^15.5.18"
-  "@auth/core": "0.41.0"
+  "@auth/core": "0.41.2"
   "@vis.gl/react-google-maps": 1.5.2
 peerDependencyRules:
   allowedVersions:


### PR DESCRIPTION
## Summary

Consolidates the 8 open Renovate PRs into a single branch/PR to reduce review and CI churn. Each dependency is bumped in the pnpm catalog (`pnpm-workspace.yaml`) and `pnpm-lock.yaml` was regenerated in one coherent `pnpm install` pass (rather than cherry-picking, which would conflict on the shared lockfile).

| Renovate PR | Package | From → To |
|----|---------|-----------|
| #483 | `@auth/core` | `0.41.0` → `0.41.2` |
| #484 | `@types/google.maps` | `^3.65.0` → `^3.65.1` |
| #485 | `@types/lodash` | `^4.14.195` → `^4.17.24` |
| #486 | `@types/nodemailer` | `^8.0.0` → `^8.0.1` |
| #487 | `class-variance-authority` | `^0.7.0` → `^0.7.1` |
| #488 | `clsx` | `^2.1.0` → `^2.1.1` |
| #489 | `commitizen` | `^4.3.1` → `^4.3.2` |
| #490 | `cross-spawn` (override) | `>=7.0.5` → `>=7.0.6` |

Once these versions land on `dev`, Renovate will auto-close #483–#490 on its next run.

## Verification

- `pnpm install` — clean; lockfile diff reflects only the bumped deps + their transitive churn
- `pnpm typecheck` — 22/22 ✓
- `pnpm lint` — 21/21 ✓ (only the pre-existing `tooling/release-it` sherif warning)
- `pnpm test` — 7/7 ✓
- `pnpm format` — 22/22, no changes required

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project dependencies to latest stable versions for improved compatibility and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->