### PR TITLE
fix(map): switching ga tag from build to runtime

### DIFF
--- a/apps/map/src/app/_components/google-analytics.tsx
+++ b/apps/map/src/app/_components/google-analytics.tsx
@@ -2,8 +2,6 @@
 
 import Script from "next/script";
 
-import { env } from "~/env";
-
 /**
  * Google Analytics component
  *
@@ -11,19 +9,23 @@ import { env } from "~/env";
  * It is used to track user interactions with the website.
  * It is used to track user interactions with the website.
  */
-export const GoogleAnalytics = () => {
-  return env.NEXT_PUBLIC_GA_MEASUREMENT_ID ? (
+export const GoogleAnalytics = ({
+  measurementId,
+}: {
+  measurementId?: string;
+}) => {
+  return measurementId ? (
     <>
       <Script
         strategy="lazyOnload"
-        src={`https://www.googletagmanager.com/gtag/js?id=${env.NEXT_PUBLIC_GA_MEASUREMENT_ID}`}
+        src={`https://www.googletagmanager.com/gtag/js?id=${measurementId}`}
       />
       <Script id="google-analytics" strategy="lazyOnload">
         {`
           window.dataLayer = window.dataLayer || [];
           function gtag(){dataLayer.push(arguments);}
           gtag('js', new Date());
-          gtag('config', '${env.NEXT_PUBLIC_GA_MEASUREMENT_ID}', {
+          gtag('config', '${measurementId}', {
           page_path: window.location.pathname,
           });
         `}

--- a/apps/map/src/app/_components/google-analytics.tsx
+++ b/apps/map/src/app/_components/google-analytics.tsx
@@ -3,11 +3,7 @@
 import Script from "next/script";
 
 /**
- * Google Analytics component
- *
- * This component is used to track user interactions with the website.
- * It is used to track user interactions with the website.
- * It is used to track user interactions with the website.
+ * Google Analytics component that injects GA scripts when a measurement ID is provided.
  */
 export const GoogleAnalytics = ({
   measurementId,
@@ -25,7 +21,7 @@ export const GoogleAnalytics = ({
           window.dataLayer = window.dataLayer || [];
           function gtag(){dataLayer.push(arguments);}
           gtag('js', new Date());
-          gtag('config', '${measurementId}', {
+          gtag('config', ${JSON.stringify(measurementId)}, {
           page_path: window.location.pathname,
           });
         `}

--- a/apps/map/src/app/layout.tsx
+++ b/apps/map/src/app/layout.tsx
@@ -69,7 +69,7 @@ export default async function RootLayout(props: { children: React.ReactNode }) {
           GeistMono.variable,
         )}
       >
-        <GoogleAnalytics />
+        <GoogleAnalytics measurementId={env.NEXT_PUBLIC_GA_MEASUREMENT_ID} />
         <RouteChangeTracker />
         <DataProvider>
           <ElementProvider>{props.children}</ElementProvider>


### PR DESCRIPTION
This pull request refactors the Google Analytics integration in the app to make the `measurementId` configurable via props instead of being hardcoded from the environment variable within the component. This change improves the flexibility and reusability of the `GoogleAnalytics` component.

**Google Analytics Integration Refactor:**

* Updated the `GoogleAnalytics` component in `google-analytics.tsx` to accept a `measurementId` prop instead of importing the environment variable directly. The component now only renders if a `measurementId` is provided.
* Modified `layout.tsx` to pass the `env.NEXT_PUBLIC_GA_MEASUREMENT_ID` as a prop to the `GoogleAnalytics` component, aligning with the new interface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Analytics tracking now loads only when a measurement ID is available, preventing unnecessary script injection.
  * Improved how the app passes analytics configuration so tracking behavior is more reliable across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->