### PR TITLE
chore(repo): removing minimumreleaseage default of 1 days; handled el…

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -179,3 +179,4 @@ cleanupUnusedCatalogs: true
 publicHoistPattern:
   - "sharp"
   - "@img/*"
+minimumReleaseAge: 0


### PR DESCRIPTION
I thought that in #478 I removed the pacakge.json minimumReleaseAge so that it would allow anything. Apparently I just exposed the default minimum of 1 days. This is to set to 0, actually.

It feels like a weird thing to do. But, I think this fits us. We will potentially have a number of developers who understand the apps and what they should do, but not the code or how it works. When confronted by a failed CI, they and their AI might taking things in an undesirable direction. If we remove the limit, we allow developer more flexibility to develop.

We have the Action that highlights any recent releases. So, we shift the responsibility for mitigating supply chain attacks from the developer to the deployer. I.e. the person releasing to stating and prod will need to ensure there are no recently released dependencies. It is assumed that the deployer has more context and experience.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the workspace release configuration to allow packages to be released without a waiting period.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->