### PR TITLE
fix(slackbot): added gh workflow to update uv.lock on slackbot release

### DIFF
--- a/.github/workflows/release-please-uv-lock.yml
+++ b/.github/workflows/release-please-uv-lock.yml
@@ -1,0 +1,57 @@
+name: Release Please uv.lock
+
+on:
+  pull_request:
+    branches:
+      - dev
+    types:
+      - opened
+      - synchronize
+      - reopened
+    paths:
+      - apps/slackbot/pyproject.toml
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  refresh-uv-lock:
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      startsWith(github.head_ref, 'release-please--')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        id: app-token
+        with:
+          app-id: ${{ secrets.RELEASE_PLEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ steps.app-token.outputs.token }}
+          persist-credentials: true
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+
+      - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
+
+      - name: Refresh uv.lock
+        run: uv lock
+
+      - name: Commit uv.lock if changed
+        run: |
+          if git diff --quiet -- uv.lock; then
+            echo "uv.lock is already up to date."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add uv.lock
+          git commit -m "chore(slackbot): refresh uv.lock for release"
+          git push

--- a/.github/workflows/release-please-uv-lock.yml
+++ b/.github/workflows/release-please-uv-lock.yml
@@ -11,9 +11,11 @@ on:
     paths:
       - apps/slackbot/pyproject.toml
 
+concurrency:
+  group: uv-lock-${{ github.event.pull_request.number }}
+
 permissions:
-  contents: write
-  pull-requests: read
+  contents: read # required for actions/checkout fallback auth; actual writes use the App token
 
 jobs:
   refresh-uv-lock:
@@ -27,6 +29,7 @@ jobs:
         with:
           app-id: ${{ secrets.RELEASE_PLEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
+          permission-contents: write
 
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -58,6 +58,12 @@ After a push to `dev`, the `release-please.yml` workflow runs. It:
   - Bumps the version in `apps/me/package.json`
   - Generates/updates `apps/me/CHANGELOG.md`
 
+For Slackbot release PRs, `.github/workflows/release-please-uv-lock.yml` runs
+after Release Please updates `apps/slackbot/pyproject.toml`. It runs `uv lock`
+and pushes any resulting `uv.lock` change back to the release PR using the same
+GitHub App token. This keeps Docker's `uv sync --locked ...` build step aligned
+with Release Please's version bump.
+
 If multiple PRs are merged to `dev` before the Release Please PR is merged, Release Please accumulates all of them — the PR is updated in place, never duplicated.
 
 ### 3. Review and merge the Release Please PR

--- a/uv.lock
+++ b/uv.lock
@@ -737,7 +737,7 @@ source = { virtual = "." }
 
 [[package]]
 name = "f3-nation-slack-bot"
-version = "1.13.0"
+version = "2.0.0"
 source = { editable = "apps/slackbot" }
 dependencies = [
     { name = "cloud-sql-python-connector" },


### PR DESCRIPTION
- New: `.github/workflows/release-please-uv-lock.yml`
  - Runs only on same-repo Release Please PRs whose changes include `apps/slackbot/pyproject.toml`
  - Checks out the release PR branch
  - Runs `uv lock`
  - Commits/pushes `uv.lock` back to the release PR if it changed
  - Uses the same GitHub App token so downstream CI still triggers

Also updated:
- `docs/RELEASE_PROCESS.md `with the Slackbot `uv.lock` behavior
- `uv.lock` current stale Slackbot version from `1.13.0` → `2.0.0`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added an automated release workflow that refreshes the Python lockfile on release pull requests and updates the branch when dependencies change.

* **Documentation**
  * Updated the release process guide to explain the new lockfile update step and how it keeps builds aligned with version changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->