### PR TITLE
fix(repo): purge pnpm-store sharp shadow so runner reinstall loads libvips

### DIFF
--- a/apps/admin/Dockerfile
+++ b/apps/admin/Dockerfile
@@ -65,8 +65,11 @@ COPY --from=installer --chown=admin:nodejs /app/apps/admin/.next/standalone ./
 COPY --from=installer --chown=admin:nodejs /app/apps/admin/.next/static ./apps/admin/.next/static
 COPY --from=installer --chown=admin:nodejs /app/apps/admin/public ./apps/admin/public
 
-# Reinstall sharp: Turbopack drops it from the standalone output.
-RUN rm -rf ./node_modules/sharp ./node_modules/@img && npm install --no-save --no-audit --no-fund sharp@0.35.2
+# Reinstall sharp: Turbopack drops libvips and leaves a pnpm-store shadow; purge both, then verify.
+RUN rm -rf ./node_modules/sharp ./node_modules/@img \
+      ./node_modules/.pnpm/sharp@* ./node_modules/.pnpm/@img+* && \
+    npm install --no-save --no-audit --no-fund sharp@0.35.2 && \
+    node -e "require('sharp'); console.log('sharp loaded OK')"
 
 USER admin
 

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -64,8 +64,11 @@
     COPY --from=installer --chown=api:nodejs /app/apps/api/.next/standalone ./
     COPY --from=installer --chown=api:nodejs /app/apps/api/.next/static ./apps/api/.next/static
 
-    # Reinstall sharp: Turbopack drops it from the standalone output.
-    RUN rm -rf ./node_modules/sharp ./node_modules/@img && npm install --no-save --no-audit --no-fund sharp@0.35.2
+    # Reinstall sharp: Turbopack drops libvips and leaves a pnpm-store shadow; purge both, then verify.
+    RUN rm -rf ./node_modules/sharp ./node_modules/@img \
+          ./node_modules/.pnpm/sharp@* ./node_modules/.pnpm/@img+* && \
+        npm install --no-save --no-audit --no-fund sharp@0.35.2 && \
+        node -e "require('sharp'); console.log('sharp loaded OK')"
 
     USER api
     

--- a/apps/auth/Dockerfile
+++ b/apps/auth/Dockerfile
@@ -65,8 +65,11 @@ COPY --from=installer --chown=auth:nodejs /app/apps/auth/.next/standalone ./
 COPY --from=installer --chown=auth:nodejs /app/apps/auth/.next/static ./apps/auth/.next/static
 COPY --from=installer --chown=auth:nodejs /app/apps/auth/public ./apps/auth/public
 
-# Reinstall sharp: Turbopack drops it from the standalone output.
-RUN rm -rf ./node_modules/sharp ./node_modules/@img && npm install --no-save --no-audit --no-fund sharp@0.35.2
+# Reinstall sharp: Turbopack drops libvips and leaves a pnpm-store shadow; purge both, then verify.
+RUN rm -rf ./node_modules/sharp ./node_modules/@img \
+      ./node_modules/.pnpm/sharp@* ./node_modules/.pnpm/@img+* && \
+    npm install --no-save --no-audit --no-fund sharp@0.35.2 && \
+    node -e "require('sharp'); console.log('sharp loaded OK')"
 
 USER auth
 

--- a/apps/map/Dockerfile
+++ b/apps/map/Dockerfile
@@ -69,8 +69,11 @@ COPY --from=installer --chown=map:nodejs /app/apps/map/.next/standalone ./
 COPY --from=installer --chown=map:nodejs /app/apps/map/.next/static ./apps/map/.next/static
 COPY --from=installer --chown=map:nodejs /app/apps/map/public ./apps/map/public
 
-# Reinstall sharp: Turbopack drops it from the standalone output.
-RUN rm -rf ./node_modules/sharp ./node_modules/@img && npm install --no-save --no-audit --no-fund sharp@0.35.2
+# Reinstall sharp: Turbopack drops libvips and leaves a pnpm-store shadow; purge both, then verify.
+RUN rm -rf ./node_modules/sharp ./node_modules/@img \
+      ./node_modules/.pnpm/sharp@* ./node_modules/.pnpm/@img+* && \
+    npm install --no-save --no-audit --no-fund sharp@0.35.2 && \
+    node -e "require('sharp'); console.log('sharp loaded OK')"
 
 USER map
 

--- a/apps/me/Dockerfile
+++ b/apps/me/Dockerfile
@@ -63,8 +63,11 @@ COPY --from=installer --chown=me:nodejs /app/apps/me/.next/standalone ./
 COPY --from=installer --chown=me:nodejs /app/apps/me/.next/static ./apps/me/.next/static
 COPY --from=installer --chown=me:nodejs /app/apps/me/public ./apps/me/public
 
-# Reinstall sharp: Turbopack drops it from the standalone output.
-RUN rm -rf ./node_modules/sharp ./node_modules/@img && npm install --no-save --no-audit --no-fund sharp@0.35.2
+# Reinstall sharp: Turbopack drops libvips and leaves a pnpm-store shadow; purge both, then verify.
+RUN rm -rf ./node_modules/sharp ./node_modules/@img \
+      ./node_modules/.pnpm/sharp@* ./node_modules/.pnpm/@img+* && \
+    npm install --no-save --no-audit --no-fund sharp@0.35.2 && \
+    node -e "require('sharp'); console.log('sharp loaded OK')"
 
 USER me
 

--- a/renovate.json
+++ b/renovate.json
@@ -21,9 +21,9 @@
   "customManagers": [
     {
       "customType": "regex",
-      "description": "Keep the `npm install sharp@x.y.z` pin in app Dockerfiles updated",
+      "description": "Keep the `sharp@x.y.z` reinstall pin in app Dockerfiles updated",
       "managerFilePatterns": ["/^apps/.+/Dockerfile$/"],
-      "matchStrings": ["npm install sharp@(?<currentValue>[0-9.]+)"],
+      "matchStrings": ["sharp@(?<currentValue>[0-9.]+)"],
       "depNameTemplate": "sharp",
       "datasourceTemplate": "npm"
     }


### PR DESCRIPTION
## Problem

Staging (built from `dev`) still crashed on sharp load after #550 added a runner-stage sharp reinstall:

```
Could not load the "sharp" module using the linuxmusl-x64 runtime
ERR_DLOPEN_FAILED: Error loading shared library libvips-cpp.so.8.18.3: No such file or directory
(needed by /app/node_modules/.pnpm/@img+sharp-linuxmusl-x64@0.35.2/.../sharp-linuxmusl-x64-0.35.2.node)
```

## Root cause

sharp 0.35 splits its native code across two packages: `@img/sharp-<platform>` (the JS binding) and `@img/sharp-libvips-<platform>` (the `libvips-cpp.so` it `dlopen`s at runtime). Next/Turbopack's standalone tracer follows the JS `require()` graph, so it copies the binding but not the `dlopen`'d `.so`, and leaves an **incomplete copy in the pnpm virtual store**.

The #550 fix only removed the top-level `node_modules/sharp` and `node_modules/@img`; it never touched `node_modules/.pnpm/`. So the incomplete store copy kept winning module resolution — which is exactly why the error path is under `.pnpm/` — and libvips stayed missing.

## Fix

For all five app Dockerfiles:
- Purge the sharp/`@img` copies in **both** locations — flat *and* the pnpm store (`.pnpm/sharp@*`, `.pnpm/@img+*`) — so nothing shadows the reinstall.
- `npm install` with **native** platform detection (no forced `--os/--libc/--cpu`), which restores the binding *and* libvips for the runner's real architecture.
- Add a build-time `node -e "require('sharp')"` gate so a broken sharp **fails the Docker build** instead of shipping.

Also fixes the `renovate.json` custom-manager regex to `sharp@x.y.z` — the old `npm install sharp@…` form never matched because of the intervening npm flags.

## Verification

Built `apps/me/Dockerfile` locally:
- Build gate: `added 6 packages` (sharp + its 5 `@img/*` platform packages incl. libvips) → `sharp loaded OK`.
- Runtime smoke test: `require('sharp').versions` reports `"vips":"8.18.3"` — the exact `libvips-cpp.so.8.18.3` that was missing — with all formats available.

An early iteration hardcoded `--cpu=x64`; the build gate correctly failed it on arm64, confirming native detection is the right approach (a runner-stage `RUN` executes on the same platform the container runs on).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved container builds across several apps by more thoroughly clearing old image-processing package artifacts before reinstalling.
  * Added a build-time verification step to confirm the package loads successfully after installation, reducing the risk of runtime failures.
* **Chores**
  * Updated the automated dependency update rules to match the new package reinstall pattern.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->