### PR TITLE
fix(repo): repoint Turbopack hashed sharp symlink after runner reinstall

### DIFF
--- a/apps/admin/Dockerfile
+++ b/apps/admin/Dockerfile
@@ -65,10 +65,13 @@ COPY --from=installer --chown=admin:nodejs /app/apps/admin/.next/standalone ./
 COPY --from=installer --chown=admin:nodejs /app/apps/admin/.next/static ./apps/admin/.next/static
 COPY --from=installer --chown=admin:nodejs /app/apps/admin/public ./apps/admin/public
 
-# Reinstall sharp: Turbopack drops libvips and leaves a pnpm-store shadow; purge both, then verify.
+# Reinstall sharp: Turbopack drops libvips and leaves a pnpm-store shadow; purge both,
+# repoint Turbopack's hashed sharp-<hash> external symlinks (which targeted the purged
+# pnpm copy) at the reinstalled sharp, fail on any dangling external, then verify.
 RUN rm -rf ./node_modules/sharp ./node_modules/@img \
       ./node_modules/.pnpm/sharp@* ./node_modules/.pnpm/@img+* && \
     npm install --no-save --no-audit --no-fund sharp@0.35.2 && \
+    node -e "const fs=require('fs'),d='apps/admin/.next/node_modules';if(fs.existsSync(d))for(const n of fs.readdirSync(d)){const f=d+'/'+n;if(n.startsWith('sharp-')){fs.rmSync(f);fs.symlinkSync('/app/node_modules/sharp',f)}if(!fs.existsSync(f))throw Error('dangling external symlink: '+f)}" && \
     node -e "require('sharp'); console.log('sharp loaded OK')"
 
 USER admin

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -64,10 +64,13 @@
     COPY --from=installer --chown=api:nodejs /app/apps/api/.next/standalone ./
     COPY --from=installer --chown=api:nodejs /app/apps/api/.next/static ./apps/api/.next/static
 
-    # Reinstall sharp: Turbopack drops libvips and leaves a pnpm-store shadow; purge both, then verify.
+    # Reinstall sharp: Turbopack drops libvips and leaves a pnpm-store shadow; purge both,
+    # repoint Turbopack's hashed sharp-<hash> external symlinks (which targeted the purged
+    # pnpm copy) at the reinstalled sharp, fail on any dangling external, then verify.
     RUN rm -rf ./node_modules/sharp ./node_modules/@img \
           ./node_modules/.pnpm/sharp@* ./node_modules/.pnpm/@img+* && \
         npm install --no-save --no-audit --no-fund sharp@0.35.2 && \
+        node -e "const fs=require('fs'),d='apps/api/.next/node_modules';if(fs.existsSync(d))for(const n of fs.readdirSync(d)){const f=d+'/'+n;if(n.startsWith('sharp-')){fs.rmSync(f);fs.symlinkSync('/app/node_modules/sharp',f)}if(!fs.existsSync(f))throw Error('dangling external symlink: '+f)}" && \
         node -e "require('sharp'); console.log('sharp loaded OK')"
 
     USER api

--- a/apps/auth/Dockerfile
+++ b/apps/auth/Dockerfile
@@ -65,10 +65,13 @@ COPY --from=installer --chown=auth:nodejs /app/apps/auth/.next/standalone ./
 COPY --from=installer --chown=auth:nodejs /app/apps/auth/.next/static ./apps/auth/.next/static
 COPY --from=installer --chown=auth:nodejs /app/apps/auth/public ./apps/auth/public
 
-# Reinstall sharp: Turbopack drops libvips and leaves a pnpm-store shadow; purge both, then verify.
+# Reinstall sharp: Turbopack drops libvips and leaves a pnpm-store shadow; purge both,
+# repoint Turbopack's hashed sharp-<hash> external symlinks (which targeted the purged
+# pnpm copy) at the reinstalled sharp, fail on any dangling external, then verify.
 RUN rm -rf ./node_modules/sharp ./node_modules/@img \
       ./node_modules/.pnpm/sharp@* ./node_modules/.pnpm/@img+* && \
     npm install --no-save --no-audit --no-fund sharp@0.35.2 && \
+    node -e "const fs=require('fs'),d='apps/auth/.next/node_modules';if(fs.existsSync(d))for(const n of fs.readdirSync(d)){const f=d+'/'+n;if(n.startsWith('sharp-')){fs.rmSync(f);fs.symlinkSync('/app/node_modules/sharp',f)}if(!fs.existsSync(f))throw Error('dangling external symlink: '+f)}" && \
     node -e "require('sharp'); console.log('sharp loaded OK')"
 
 USER auth

--- a/apps/map/Dockerfile
+++ b/apps/map/Dockerfile
@@ -69,10 +69,13 @@ COPY --from=installer --chown=map:nodejs /app/apps/map/.next/standalone ./
 COPY --from=installer --chown=map:nodejs /app/apps/map/.next/static ./apps/map/.next/static
 COPY --from=installer --chown=map:nodejs /app/apps/map/public ./apps/map/public
 
-# Reinstall sharp: Turbopack drops libvips and leaves a pnpm-store shadow; purge both, then verify.
+# Reinstall sharp: Turbopack drops libvips and leaves a pnpm-store shadow; purge both,
+# repoint Turbopack's hashed sharp-<hash> external symlinks (which targeted the purged
+# pnpm copy) at the reinstalled sharp, fail on any dangling external, then verify.
 RUN rm -rf ./node_modules/sharp ./node_modules/@img \
       ./node_modules/.pnpm/sharp@* ./node_modules/.pnpm/@img+* && \
     npm install --no-save --no-audit --no-fund sharp@0.35.2 && \
+    node -e "const fs=require('fs'),d='apps/map/.next/node_modules';if(fs.existsSync(d))for(const n of fs.readdirSync(d)){const f=d+'/'+n;if(n.startsWith('sharp-')){fs.rmSync(f);fs.symlinkSync('/app/node_modules/sharp',f)}if(!fs.existsSync(f))throw Error('dangling external symlink: '+f)}" && \
     node -e "require('sharp'); console.log('sharp loaded OK')"
 
 USER map

--- a/apps/me/Dockerfile
+++ b/apps/me/Dockerfile
@@ -63,10 +63,13 @@ COPY --from=installer --chown=me:nodejs /app/apps/me/.next/standalone ./
 COPY --from=installer --chown=me:nodejs /app/apps/me/.next/static ./apps/me/.next/static
 COPY --from=installer --chown=me:nodejs /app/apps/me/public ./apps/me/public
 
-# Reinstall sharp: Turbopack drops libvips and leaves a pnpm-store shadow; purge both, then verify.
+# Reinstall sharp: Turbopack drops libvips and leaves a pnpm-store shadow; purge both,
+# repoint Turbopack's hashed sharp-<hash> external symlinks (which targeted the purged
+# pnpm copy) at the reinstalled sharp, fail on any dangling external, then verify.
 RUN rm -rf ./node_modules/sharp ./node_modules/@img \
       ./node_modules/.pnpm/sharp@* ./node_modules/.pnpm/@img+* && \
     npm install --no-save --no-audit --no-fund sharp@0.35.2 && \
+    node -e "const fs=require('fs'),d='apps/me/.next/node_modules';if(fs.existsSync(d))for(const n of fs.readdirSync(d)){const f=d+'/'+n;if(n.startsWith('sharp-')){fs.rmSync(f);fs.symlinkSync('/app/node_modules/sharp',f)}if(!fs.existsSync(f))throw Error('dangling external symlink: '+f)}" && \
     node -e "require('sharp'); console.log('sharp loaded OK')"
 
 USER me


### PR DESCRIPTION
## Summary
- Staging map (and all Next standalone apps) crashed at startup after the Next.js 15 → 16 upgrade with `ERR_MODULE_NOT_FOUND: Cannot find package 'sharp-c3881177eeca60af'` from the Turbopack runtime.
- Root cause: Turbopack no longer loads sharp via `require('sharp')` — it imports a hashed external alias resolved through a symlink the standalone output emits at `apps/<app>/.next/node_modules/sharp-<hash>`, targeting `node_modules/.pnpm/sharp@0.35.2/...`. The runner-stage sharp reinstall from #556 purges exactly that pnpm path, leaving the symlink dangling; the npm-reinstalled `./node_modules/sharp` is never consulted because the import specifier isn't `sharp`.
- Fix: after the npm reinstall, repoint any `sharp-*` hashed symlink at `/app/node_modules/sharp`, and fail the image build if **any** hashed external symlink (sharp, pino, import-in-the-middle, …) is left dangling, so this class of bug is caught at build time instead of at Cloud Run startup. Removing the #556 reinstall instead was not an option — the hashed symlink resolves into the pnpm sharp copy, which still carries the libvips stub that caused the original `ERR_DLOPEN_FAILED`.
- Applied to all five app Dockerfiles (admin, api, auth, map, me), which share the same reinstall block.

## Validation
- Reproduced the failure locally: simulating the runner purge against the real `apps/map/.next/standalone` output leaves `sharp-c3881177eeca60af` dangling; the repoint script restores resolution.
- Built the map image for `linux/amd64` with the updated Dockerfile: the new RUN step passes (`sharp loaded OK`, no dangling externals; symlink inside the image points at `/app/node_modules/sharp`).
- Ran the container: Next.js 16.2.9 starts with no `Failed to prepare server` / instrumentation error, and `/` returns HTTP 200 (staging currently returns Internal Server Error).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved production image reliability by adding stricter checks during Sharp reinstall steps.
  * Prevents builds from succeeding when required Sharp symlinks are missing or broken.
  * Ensures app runtimes can load image-processing dependencies correctly after deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->