### PR TITLE
fix(repo): trace libvips into standalone output instead of reinstalling sharp

### DIFF
--- a/apps/admin/Dockerfile
+++ b/apps/admin/Dockerfile
@@ -65,11 +65,6 @@ COPY --from=installer --chown=admin:nodejs /app/apps/admin/.next/standalone ./
 COPY --from=installer --chown=admin:nodejs /app/apps/admin/.next/static ./apps/admin/.next/static
 COPY --from=installer --chown=admin:nodejs /app/apps/admin/public ./apps/admin/public
 
-# outputFileTracingIncludes in next.config forces the complete @img/sharp-libvips-*
-# packages into the standalone trace; verify no external symlink dangles and every
-# runtime sharp (hashed external + complete traced pnpm copies) actually loads.
-RUN node -e "const fs=require('fs'),p=process.cwd()+'/',d='apps/admin/.next/node_modules';if(fs.existsSync(d))for(const n of fs.readdirSync(d)){const f=p+d+'/'+n;if(!fs.existsSync(f))throw Error('dangling external symlink: '+f);if(n.startsWith('sharp-'))require(fs.realpathSync(f))}for(const n of fs.readdirSync('node_modules/.pnpm'))if(n.startsWith('sharp@')&&fs.existsSync('node_modules/.pnpm/'+n+'/node_modules/sharp/dist'))require(p+'node_modules/.pnpm/'+n+'/node_modules/sharp');console.log('sharp externals verified')"
-
 USER admin
 
 ENV PORT=8080

--- a/apps/admin/Dockerfile
+++ b/apps/admin/Dockerfile
@@ -51,6 +51,9 @@ RUN printf '\nverifyDepsBeforeRun: false\n' >> pnpm-workspace.yaml
 
 RUN pnpm turbo build --filter=f3-admin
 
+# Assert the next.config libvips tracing include landed (a zero-match glob is a silent no-op).
+RUN test -n "$(find apps/admin/.next/standalone -name 'libvips-cpp*')"
+
 # ---------- Stage 3: Production runner ----------
 FROM node:24.18.0-alpine AS runner
 

--- a/apps/admin/Dockerfile
+++ b/apps/admin/Dockerfile
@@ -65,14 +65,10 @@ COPY --from=installer --chown=admin:nodejs /app/apps/admin/.next/standalone ./
 COPY --from=installer --chown=admin:nodejs /app/apps/admin/.next/static ./apps/admin/.next/static
 COPY --from=installer --chown=admin:nodejs /app/apps/admin/public ./apps/admin/public
 
-# Reinstall sharp: Turbopack drops libvips and leaves a pnpm-store shadow; purge both,
-# repoint Turbopack's hashed sharp-<hash> external symlinks (which targeted the purged
-# pnpm copy) at the reinstalled sharp, fail on any dangling external, then verify.
-RUN rm -rf ./node_modules/sharp ./node_modules/@img \
-      ./node_modules/.pnpm/sharp@* ./node_modules/.pnpm/@img+* && \
-    npm install --no-save --no-audit --no-fund sharp@0.35.2 && \
-    node -e "const fs=require('fs'),d='apps/admin/.next/node_modules';if(fs.existsSync(d))for(const n of fs.readdirSync(d)){const f=d+'/'+n;if(n.startsWith('sharp-')){fs.rmSync(f);fs.symlinkSync('/app/node_modules/sharp',f)}if(!fs.existsSync(f))throw Error('dangling external symlink: '+f)}" && \
-    node -e "require('sharp'); console.log('sharp loaded OK')"
+# outputFileTracingIncludes in next.config forces the complete @img/sharp-libvips-*
+# packages into the standalone trace; verify no external symlink dangles and every
+# runtime sharp (hashed external + complete traced pnpm copies) actually loads.
+RUN node -e "const fs=require('fs'),p=process.cwd()+'/',d='apps/admin/.next/node_modules';if(fs.existsSync(d))for(const n of fs.readdirSync(d)){const f=p+d+'/'+n;if(!fs.existsSync(f))throw Error('dangling external symlink: '+f);if(n.startsWith('sharp-'))require(fs.realpathSync(f))}for(const n of fs.readdirSync('node_modules/.pnpm'))if(n.startsWith('sharp@')&&fs.existsSync('node_modules/.pnpm/'+n+'/node_modules/sharp/dist'))require(p+'node_modules/.pnpm/'+n+'/node_modules/sharp');console.log('sharp externals verified')"
 
 USER admin
 

--- a/apps/admin/next.config.js
+++ b/apps/admin/next.config.js
@@ -17,6 +17,12 @@ const config = {
   // Next.js does not try to bundle it.
   serverExternalPackages: ["pino", "pino-pretty", "thread-stream"],
 
+  // Turbopack's standalone trace drops the dlopen'd libvips shared library from
+  // @img/sharp-libvips-*; force the complete packages into the trace.
+  outputFileTracingIncludes: {
+    "/*": ["../../node_modules/.pnpm/@img+sharp-libvips-*/**/*"],
+  },
+
   images: {
     remotePatterns: [
       {

--- a/apps/admin/next.config.js
+++ b/apps/admin/next.config.js
@@ -18,7 +18,8 @@ const config = {
   serverExternalPackages: ["pino", "pino-pretty", "thread-stream"],
 
   // Turbopack's standalone trace drops the dlopen'd libvips shared library from
-  // @img/sharp-libvips-*; force the complete packages into the trace.
+  // @img/sharp-libvips-*; force the complete packages into the trace. A zero-match
+  // glob is a silent no-op, so the Dockerfile asserts libvips landed in standalone.
   outputFileTracingIncludes: {
     "/*": ["../../node_modules/.pnpm/@img+sharp-libvips-*/**/*"],
   },

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -64,14 +64,10 @@
     COPY --from=installer --chown=api:nodejs /app/apps/api/.next/standalone ./
     COPY --from=installer --chown=api:nodejs /app/apps/api/.next/static ./apps/api/.next/static
 
-    # Reinstall sharp: Turbopack drops libvips and leaves a pnpm-store shadow; purge both,
-    # repoint Turbopack's hashed sharp-<hash> external symlinks (which targeted the purged
-    # pnpm copy) at the reinstalled sharp, fail on any dangling external, then verify.
-    RUN rm -rf ./node_modules/sharp ./node_modules/@img \
-          ./node_modules/.pnpm/sharp@* ./node_modules/.pnpm/@img+* && \
-        npm install --no-save --no-audit --no-fund sharp@0.35.2 && \
-        node -e "const fs=require('fs'),d='apps/api/.next/node_modules';if(fs.existsSync(d))for(const n of fs.readdirSync(d)){const f=d+'/'+n;if(n.startsWith('sharp-')){fs.rmSync(f);fs.symlinkSync('/app/node_modules/sharp',f)}if(!fs.existsSync(f))throw Error('dangling external symlink: '+f)}" && \
-        node -e "require('sharp'); console.log('sharp loaded OK')"
+    # outputFileTracingIncludes in next.config forces the complete @img/sharp-libvips-*
+    # packages into the standalone trace; verify no external symlink dangles and every
+    # runtime sharp (hashed external + complete traced pnpm copies) actually loads.
+    RUN node -e "const fs=require('fs'),p=process.cwd()+'/',d='apps/api/.next/node_modules';if(fs.existsSync(d))for(const n of fs.readdirSync(d)){const f=p+d+'/'+n;if(!fs.existsSync(f))throw Error('dangling external symlink: '+f);if(n.startsWith('sharp-'))require(fs.realpathSync(f))}for(const n of fs.readdirSync('node_modules/.pnpm'))if(n.startsWith('sharp@')&&fs.existsSync('node_modules/.pnpm/'+n+'/node_modules/sharp/dist'))require(p+'node_modules/.pnpm/'+n+'/node_modules/sharp');console.log('sharp externals verified')"
 
     USER api
     

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -50,7 +50,10 @@
     RUN printf '\nverifyDepsBeforeRun: false\n' >> pnpm-workspace.yaml
 
     RUN pnpm turbo build --filter=f3-api
-    
+
+    # Assert the next.config libvips tracing include landed (a zero-match glob is a silent no-op).
+    RUN test -n "$(find apps/api/.next/standalone -name 'libvips-cpp*')"
+
     # ---------- Stage 3: Production runner ----------
     FROM node:24.18.0-alpine AS runner
     

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -64,11 +64,6 @@
     COPY --from=installer --chown=api:nodejs /app/apps/api/.next/standalone ./
     COPY --from=installer --chown=api:nodejs /app/apps/api/.next/static ./apps/api/.next/static
 
-    # outputFileTracingIncludes in next.config forces the complete @img/sharp-libvips-*
-    # packages into the standalone trace; verify no external symlink dangles and every
-    # runtime sharp (hashed external + complete traced pnpm copies) actually loads.
-    RUN node -e "const fs=require('fs'),p=process.cwd()+'/',d='apps/api/.next/node_modules';if(fs.existsSync(d))for(const n of fs.readdirSync(d)){const f=p+d+'/'+n;if(!fs.existsSync(f))throw Error('dangling external symlink: '+f);if(n.startsWith('sharp-'))require(fs.realpathSync(f))}for(const n of fs.readdirSync('node_modules/.pnpm'))if(n.startsWith('sharp@')&&fs.existsSync('node_modules/.pnpm/'+n+'/node_modules/sharp/dist'))require(p+'node_modules/.pnpm/'+n+'/node_modules/sharp');console.log('sharp externals verified')"
-
     USER api
     
     ENV PORT=8080

--- a/apps/api/next.config.js
+++ b/apps/api/next.config.js
@@ -28,7 +28,8 @@ const config = {
   serverExternalPackages: ["pino", "pino-pretty", "thread-stream"],
 
   // Turbopack's standalone trace drops the dlopen'd libvips shared library from
-  // @img/sharp-libvips-*; force the complete packages into the trace.
+  // @img/sharp-libvips-*; force the complete packages into the trace. A zero-match
+  // glob is a silent no-op, so the Dockerfile asserts libvips landed in standalone.
   outputFileTracingIncludes: {
     "/*": ["../../node_modules/.pnpm/@img+sharp-libvips-*/**/*"],
   },

--- a/apps/api/next.config.js
+++ b/apps/api/next.config.js
@@ -27,6 +27,12 @@ const config = {
   // Next.js does not try to bundle it.
   serverExternalPackages: ["pino", "pino-pretty", "thread-stream"],
 
+  // Turbopack's standalone trace drops the dlopen'd libvips shared library from
+  // @img/sharp-libvips-*; force the complete packages into the trace.
+  outputFileTracingIncludes: {
+    "/*": ["../../node_modules/.pnpm/@img+sharp-libvips-*/**/*"],
+  },
+
   images: {
     remotePatterns: [
       {

--- a/apps/auth/Dockerfile
+++ b/apps/auth/Dockerfile
@@ -65,11 +65,6 @@ COPY --from=installer --chown=auth:nodejs /app/apps/auth/.next/standalone ./
 COPY --from=installer --chown=auth:nodejs /app/apps/auth/.next/static ./apps/auth/.next/static
 COPY --from=installer --chown=auth:nodejs /app/apps/auth/public ./apps/auth/public
 
-# outputFileTracingIncludes in next.config forces the complete @img/sharp-libvips-*
-# packages into the standalone trace; verify no external symlink dangles and every
-# runtime sharp (hashed external + complete traced pnpm copies) actually loads.
-RUN node -e "const fs=require('fs'),p=process.cwd()+'/',d='apps/auth/.next/node_modules';if(fs.existsSync(d))for(const n of fs.readdirSync(d)){const f=p+d+'/'+n;if(!fs.existsSync(f))throw Error('dangling external symlink: '+f);if(n.startsWith('sharp-'))require(fs.realpathSync(f))}for(const n of fs.readdirSync('node_modules/.pnpm'))if(n.startsWith('sharp@')&&fs.existsSync('node_modules/.pnpm/'+n+'/node_modules/sharp/dist'))require(p+'node_modules/.pnpm/'+n+'/node_modules/sharp');console.log('sharp externals verified')"
-
 USER auth
 
 ENV PORT=8080

--- a/apps/auth/Dockerfile
+++ b/apps/auth/Dockerfile
@@ -51,6 +51,9 @@ RUN printf '\nverifyDepsBeforeRun: false\n' >> pnpm-workspace.yaml
 
 RUN pnpm turbo build --filter=f3-auth
 
+# Assert the next.config libvips tracing include landed (a zero-match glob is a silent no-op).
+RUN test -n "$(find apps/auth/.next/standalone -name 'libvips-cpp*')"
+
 # ---------- Stage 3: Production runner ----------
 FROM node:24.18.0-alpine AS runner
 

--- a/apps/auth/Dockerfile
+++ b/apps/auth/Dockerfile
@@ -65,14 +65,10 @@ COPY --from=installer --chown=auth:nodejs /app/apps/auth/.next/standalone ./
 COPY --from=installer --chown=auth:nodejs /app/apps/auth/.next/static ./apps/auth/.next/static
 COPY --from=installer --chown=auth:nodejs /app/apps/auth/public ./apps/auth/public
 
-# Reinstall sharp: Turbopack drops libvips and leaves a pnpm-store shadow; purge both,
-# repoint Turbopack's hashed sharp-<hash> external symlinks (which targeted the purged
-# pnpm copy) at the reinstalled sharp, fail on any dangling external, then verify.
-RUN rm -rf ./node_modules/sharp ./node_modules/@img \
-      ./node_modules/.pnpm/sharp@* ./node_modules/.pnpm/@img+* && \
-    npm install --no-save --no-audit --no-fund sharp@0.35.2 && \
-    node -e "const fs=require('fs'),d='apps/auth/.next/node_modules';if(fs.existsSync(d))for(const n of fs.readdirSync(d)){const f=d+'/'+n;if(n.startsWith('sharp-')){fs.rmSync(f);fs.symlinkSync('/app/node_modules/sharp',f)}if(!fs.existsSync(f))throw Error('dangling external symlink: '+f)}" && \
-    node -e "require('sharp'); console.log('sharp loaded OK')"
+# outputFileTracingIncludes in next.config forces the complete @img/sharp-libvips-*
+# packages into the standalone trace; verify no external symlink dangles and every
+# runtime sharp (hashed external + complete traced pnpm copies) actually loads.
+RUN node -e "const fs=require('fs'),p=process.cwd()+'/',d='apps/auth/.next/node_modules';if(fs.existsSync(d))for(const n of fs.readdirSync(d)){const f=p+d+'/'+n;if(!fs.existsSync(f))throw Error('dangling external symlink: '+f);if(n.startsWith('sharp-'))require(fs.realpathSync(f))}for(const n of fs.readdirSync('node_modules/.pnpm'))if(n.startsWith('sharp@')&&fs.existsSync('node_modules/.pnpm/'+n+'/node_modules/sharp/dist'))require(p+'node_modules/.pnpm/'+n+'/node_modules/sharp');console.log('sharp externals verified')"
 
 USER auth
 

--- a/apps/auth/next.config.js
+++ b/apps/auth/next.config.js
@@ -10,7 +10,8 @@ const config = {
   serverExternalPackages: ["pino", "pino-pretty", "thread-stream"],
 
   // Turbopack's standalone trace drops the dlopen'd libvips shared library from
-  // @img/sharp-libvips-*; force the complete packages into the trace.
+  // @img/sharp-libvips-*; force the complete packages into the trace. A zero-match
+  // glob is a silent no-op, so the Dockerfile asserts libvips landed in standalone.
   outputFileTracingIncludes: {
     "/*": ["../../node_modules/.pnpm/@img+sharp-libvips-*/**/*"],
   },

--- a/apps/auth/next.config.js
+++ b/apps/auth/next.config.js
@@ -8,6 +8,12 @@ const config = {
   // pino-pretty relies on worker threads (thread-stream); keep pino external so
   // Next.js does not try to bundle it.
   serverExternalPackages: ["pino", "pino-pretty", "thread-stream"],
+
+  // Turbopack's standalone trace drops the dlopen'd libvips shared library from
+  // @img/sharp-libvips-*; force the complete packages into the trace.
+  outputFileTracingIncludes: {
+    "/*": ["../../node_modules/.pnpm/@img+sharp-libvips-*/**/*"],
+  },
   typescript: { ignoreBuildErrors: true },
 };
 

--- a/apps/map/Dockerfile
+++ b/apps/map/Dockerfile
@@ -69,14 +69,10 @@ COPY --from=installer --chown=map:nodejs /app/apps/map/.next/standalone ./
 COPY --from=installer --chown=map:nodejs /app/apps/map/.next/static ./apps/map/.next/static
 COPY --from=installer --chown=map:nodejs /app/apps/map/public ./apps/map/public
 
-# Reinstall sharp: Turbopack drops libvips and leaves a pnpm-store shadow; purge both,
-# repoint Turbopack's hashed sharp-<hash> external symlinks (which targeted the purged
-# pnpm copy) at the reinstalled sharp, fail on any dangling external, then verify.
-RUN rm -rf ./node_modules/sharp ./node_modules/@img \
-      ./node_modules/.pnpm/sharp@* ./node_modules/.pnpm/@img+* && \
-    npm install --no-save --no-audit --no-fund sharp@0.35.2 && \
-    node -e "const fs=require('fs'),d='apps/map/.next/node_modules';if(fs.existsSync(d))for(const n of fs.readdirSync(d)){const f=d+'/'+n;if(n.startsWith('sharp-')){fs.rmSync(f);fs.symlinkSync('/app/node_modules/sharp',f)}if(!fs.existsSync(f))throw Error('dangling external symlink: '+f)}" && \
-    node -e "require('sharp'); console.log('sharp loaded OK')"
+# outputFileTracingIncludes in next.config forces the complete @img/sharp-libvips-*
+# packages into the standalone trace; verify no external symlink dangles and every
+# runtime sharp (hashed external + complete traced pnpm copies) actually loads.
+RUN node -e "const fs=require('fs'),p=process.cwd()+'/',d='apps/map/.next/node_modules';if(fs.existsSync(d))for(const n of fs.readdirSync(d)){const f=p+d+'/'+n;if(!fs.existsSync(f))throw Error('dangling external symlink: '+f);if(n.startsWith('sharp-'))require(fs.realpathSync(f))}for(const n of fs.readdirSync('node_modules/.pnpm'))if(n.startsWith('sharp@')&&fs.existsSync('node_modules/.pnpm/'+n+'/node_modules/sharp/dist'))require(p+'node_modules/.pnpm/'+n+'/node_modules/sharp');console.log('sharp externals verified')"
 
 USER map
 

--- a/apps/map/Dockerfile
+++ b/apps/map/Dockerfile
@@ -69,11 +69,6 @@ COPY --from=installer --chown=map:nodejs /app/apps/map/.next/standalone ./
 COPY --from=installer --chown=map:nodejs /app/apps/map/.next/static ./apps/map/.next/static
 COPY --from=installer --chown=map:nodejs /app/apps/map/public ./apps/map/public
 
-# outputFileTracingIncludes in next.config forces the complete @img/sharp-libvips-*
-# packages into the standalone trace; verify no external symlink dangles and every
-# runtime sharp (hashed external + complete traced pnpm copies) actually loads.
-RUN node -e "const fs=require('fs'),p=process.cwd()+'/',d='apps/map/.next/node_modules';if(fs.existsSync(d))for(const n of fs.readdirSync(d)){const f=p+d+'/'+n;if(!fs.existsSync(f))throw Error('dangling external symlink: '+f);if(n.startsWith('sharp-'))require(fs.realpathSync(f))}for(const n of fs.readdirSync('node_modules/.pnpm'))if(n.startsWith('sharp@')&&fs.existsSync('node_modules/.pnpm/'+n+'/node_modules/sharp/dist'))require(p+'node_modules/.pnpm/'+n+'/node_modules/sharp');console.log('sharp externals verified')"
-
 USER map
 
 ENV PORT=8080

--- a/apps/map/Dockerfile
+++ b/apps/map/Dockerfile
@@ -55,6 +55,9 @@ RUN printf '\nverifyDepsBeforeRun: false\n' >> pnpm-workspace.yaml
 
 RUN pnpm turbo build --filter=f3-map
 
+# Assert the next.config libvips tracing include landed (a zero-match glob is a silent no-op).
+RUN test -n "$(find apps/map/.next/standalone -name 'libvips-cpp*')"
+
 # ---------- Stage 3: Production runner ----------
 FROM node:24.18.0-alpine AS runner
 

--- a/apps/map/next.config.js
+++ b/apps/map/next.config.js
@@ -27,7 +27,8 @@ const config = {
   serverExternalPackages: ["pino", "pino-pretty", "thread-stream"],
 
   // Turbopack's standalone trace drops the dlopen'd libvips shared library from
-  // @img/sharp-libvips-*; force the complete packages into the trace.
+  // @img/sharp-libvips-*; force the complete packages into the trace. A zero-match
+  // glob is a silent no-op, so the Dockerfile asserts libvips landed in standalone.
   outputFileTracingIncludes: {
     "/*": ["../../node_modules/.pnpm/@img+sharp-libvips-*/**/*"],
   },

--- a/apps/map/next.config.js
+++ b/apps/map/next.config.js
@@ -26,6 +26,12 @@ const config = {
   // Next.js does not try to bundle it.
   serverExternalPackages: ["pino", "pino-pretty", "thread-stream"],
 
+  // Turbopack's standalone trace drops the dlopen'd libvips shared library from
+  // @img/sharp-libvips-*; force the complete packages into the trace.
+  outputFileTracingIncludes: {
+    "/*": ["../../node_modules/.pnpm/@img+sharp-libvips-*/**/*"],
+  },
+
   images: {
     remotePatterns: [
       {

--- a/apps/me/Dockerfile
+++ b/apps/me/Dockerfile
@@ -49,6 +49,9 @@ RUN printf '\nverifyDepsBeforeRun: false\n' >> pnpm-workspace.yaml
 
 RUN pnpm turbo build --filter=f3-me
 
+# Assert the next.config libvips tracing include landed (a zero-match glob is a silent no-op).
+RUN test -n "$(find apps/me/.next/standalone -name 'libvips-cpp*')"
+
 # ---------- Stage 3: Production runner ----------
 FROM node:24.18.0-alpine AS runner
 

--- a/apps/me/Dockerfile
+++ b/apps/me/Dockerfile
@@ -63,11 +63,6 @@ COPY --from=installer --chown=me:nodejs /app/apps/me/.next/standalone ./
 COPY --from=installer --chown=me:nodejs /app/apps/me/.next/static ./apps/me/.next/static
 COPY --from=installer --chown=me:nodejs /app/apps/me/public ./apps/me/public
 
-# outputFileTracingIncludes in next.config forces the complete @img/sharp-libvips-*
-# packages into the standalone trace; verify no external symlink dangles and every
-# runtime sharp (hashed external + complete traced pnpm copies) actually loads.
-RUN node -e "const fs=require('fs'),p=process.cwd()+'/',d='apps/me/.next/node_modules';if(fs.existsSync(d))for(const n of fs.readdirSync(d)){const f=p+d+'/'+n;if(!fs.existsSync(f))throw Error('dangling external symlink: '+f);if(n.startsWith('sharp-'))require(fs.realpathSync(f))}for(const n of fs.readdirSync('node_modules/.pnpm'))if(n.startsWith('sharp@')&&fs.existsSync('node_modules/.pnpm/'+n+'/node_modules/sharp/dist'))require(p+'node_modules/.pnpm/'+n+'/node_modules/sharp');console.log('sharp externals verified')"
-
 USER me
 
 ENV NODE_ENV=production

--- a/apps/me/Dockerfile
+++ b/apps/me/Dockerfile
@@ -63,14 +63,10 @@ COPY --from=installer --chown=me:nodejs /app/apps/me/.next/standalone ./
 COPY --from=installer --chown=me:nodejs /app/apps/me/.next/static ./apps/me/.next/static
 COPY --from=installer --chown=me:nodejs /app/apps/me/public ./apps/me/public
 
-# Reinstall sharp: Turbopack drops libvips and leaves a pnpm-store shadow; purge both,
-# repoint Turbopack's hashed sharp-<hash> external symlinks (which targeted the purged
-# pnpm copy) at the reinstalled sharp, fail on any dangling external, then verify.
-RUN rm -rf ./node_modules/sharp ./node_modules/@img \
-      ./node_modules/.pnpm/sharp@* ./node_modules/.pnpm/@img+* && \
-    npm install --no-save --no-audit --no-fund sharp@0.35.2 && \
-    node -e "const fs=require('fs'),d='apps/me/.next/node_modules';if(fs.existsSync(d))for(const n of fs.readdirSync(d)){const f=d+'/'+n;if(n.startsWith('sharp-')){fs.rmSync(f);fs.symlinkSync('/app/node_modules/sharp',f)}if(!fs.existsSync(f))throw Error('dangling external symlink: '+f)}" && \
-    node -e "require('sharp'); console.log('sharp loaded OK')"
+# outputFileTracingIncludes in next.config forces the complete @img/sharp-libvips-*
+# packages into the standalone trace; verify no external symlink dangles and every
+# runtime sharp (hashed external + complete traced pnpm copies) actually loads.
+RUN node -e "const fs=require('fs'),p=process.cwd()+'/',d='apps/me/.next/node_modules';if(fs.existsSync(d))for(const n of fs.readdirSync(d)){const f=p+d+'/'+n;if(!fs.existsSync(f))throw Error('dangling external symlink: '+f);if(n.startsWith('sharp-'))require(fs.realpathSync(f))}for(const n of fs.readdirSync('node_modules/.pnpm'))if(n.startsWith('sharp@')&&fs.existsSync('node_modules/.pnpm/'+n+'/node_modules/sharp/dist'))require(p+'node_modules/.pnpm/'+n+'/node_modules/sharp');console.log('sharp externals verified')"
 
 USER me
 

--- a/apps/me/next.config.ts
+++ b/apps/me/next.config.ts
@@ -6,6 +6,12 @@ const nextConfig: NextConfig = {
   // pino-pretty relies on worker threads (thread-stream); keep pino external so
   // Next.js does not try to bundle it.
   serverExternalPackages: ["pino", "pino-pretty", "thread-stream"],
+
+  // Turbopack's standalone trace drops the dlopen'd libvips shared library from
+  // @img/sharp-libvips-*; force the complete packages into the trace.
+  outputFileTracingIncludes: {
+    "/*": ["../../node_modules/.pnpm/@img+sharp-libvips-*/**/*"],
+  },
   images: {
     // Local fake-gcs emulator serves images from localhost, which Next.js 16's
     // image optimizer blocks by default (SSRF guard). Only bypass it when the

--- a/apps/me/next.config.ts
+++ b/apps/me/next.config.ts
@@ -8,7 +8,8 @@ const nextConfig: NextConfig = {
   serverExternalPackages: ["pino", "pino-pretty", "thread-stream"],
 
   // Turbopack's standalone trace drops the dlopen'd libvips shared library from
-  // @img/sharp-libvips-*; force the complete packages into the trace.
+  // @img/sharp-libvips-*; force the complete packages into the trace. A zero-match
+  // glob is a silent no-op, so the Dockerfile asserts libvips landed in standalone.
   outputFileTracingIncludes: {
     "/*": ["../../node_modules/.pnpm/@img+sharp-libvips-*/**/*"],
   },

--- a/renovate.json
+++ b/renovate.json
@@ -5,8 +5,7 @@
     "github-actions",
     "npm",
     "docker-compose",
-    "dockerfile",
-    "custom.regex"
+    "dockerfile"
   ],
   "timezone": "America/New_York",
   "schedule": ["before 9am on Monday"],
@@ -18,16 +17,6 @@
   "pinDigests": true,
   "prConcurrentLimit": 10,
   "vulnerabilityAlerts": { "groupName": null, "schedule": [] },
-  "customManagers": [
-    {
-      "customType": "regex",
-      "description": "Keep the `sharp@x.y.z` reinstall pin in app Dockerfiles updated",
-      "managerFilePatterns": ["/^apps/.+/Dockerfile$/"],
-      "matchStrings": ["sharp@(?<currentValue>[0-9.]+)"],
-      "depNameTemplate": "sharp",
-      "datasourceTemplate": "npm"
-    }
-  ],
   "packageRules": [
     {
       "description": "Group first-party GitHub Actions (actions/*); auto-merge minor and patch — low supply-chain risk",


### PR DESCRIPTION
## Summary
- Replaces the runner-stage sharp purge/reinstall/symlink-repoint workaround (#556, #558) with a declarative fix at the actual source of the problem, leaving the runner Dockerfiles a plain copy-and-run of the standalone output.
- Root cause (established while investigating #558): the pnpm install is complete and working — Turbopack's **standalone output trace** drops the dlopen'd `libvips-cpp` shared library (~18MB) from the `@img/sharp-libvips-*@1.3.1` package paired with the externalized `sharp@0.35.2`, while fully tracing the `1.2.4` copy paired with Next's own `sharp@0.34.5`. The stripping is platform-agnostic (reproduced on darwin-arm64 and linuxmusl-x64), so it was never an Alpine/musl or install-scripts issue.
- Fix: `outputFileTracingIncludes: { "/*": ["../../node_modules/.pnpm/@img+sharp-libvips-*/**/*"] }` in each app's next config forces the complete libvips packages into the trace, so the traced pnpm sharp works as-is — no reinstall, no symlink surgery.
- Build-time guard: review found that a future tracing regression would **not** reliably surface as a startup error — that behavior only held for map (via its instrumentation → router import). api's route preload swallows `ERR_DLOPEN_FAILED` with an empty catch (`next-server.js` preload path), so a broken revision deploys healthy and 500s on every route; admin/me would degrade to quiet 500s on upload paths. A zero-match `outputFileTracingIncludes` glob is also a silent no-op in Next's trace pass. So each installer stage asserts the artifact that actually ships: `RUN test -n "$(find apps/<app>/.next/standalone -name 'libvips-cpp*')"` — one line, no reinstall, catches both a glob that stops matching (e.g. pnpm store layout change) and Next ceasing to honor the includes.

## Validation
- Local: all five apps rebuilt with the config; every standalone trace now contains the full libvips library, and sharp loads from each app's traced output (including auth, which externalizes no sharp — it has no runtime sharp usage).
- Docker (map, linux/amd64): image builds, both `sharp@0.34.5` and `sharp@0.35.2` load from the traced pnpm copies, container starts clean on Next.js 16.2.9 with no instrumentation error, `/` returns HTTP 200.
- The `find` assertion pattern verified against all five local standalone outputs (matches `lib/libvips-cpp.*` in both the 1.2.4 and 1.3.1 store dirs); the five docker-build CI jobs exercise it on linux.
- Image size: 352MB vs 380MB with the reinstall workaround (−28MB, no duplicate npm-installed sharp).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
