### PR TITLE
docs(repo): point release/branch references from dev to main

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,7 +84,7 @@ that app's `AGENTS.md`.
 - Drive the Node version from `.nvmrc` via `actions/setup-node` (`node-version-file: .nvmrc`) — `.nvmrc` is the single source of truth. Never hardcode `node-version:` in a workflow.
 - **Set the Docker target platform at build time, not in the `Dockerfile`.** Cloud Run only runs `linux/amd64`. The app `Dockerfile` `FROM` lines must **not** pin `--platform` (BuildKit's `FromPlatformFlagConstDisallowed` lint, and it forces emulation on arm64 dev machines). Instead pass the platform at the build invocation: `platforms: linux/amd64` on `docker/build-push-action` (CI) and `--platform=linux/amd64` on `docker build` (deploy). Building a **deployable** image locally on Apple Silicon therefore requires an explicit `docker build --platform=linux/amd64 …`. Do **not** switch to `$BUILDPLATFORM` cross-builds — `sharp`'s native binaries are platform-specific and would break in the amd64 runtime.
 - Share toolchain setup through the composite action [`.github/actions/setup`](.github/actions/setup/action.yml) (pnpm + Node + pnpm-store cache + frozen install) instead of repeating setup steps per job.
-- The five CI check names (`format-check`, `lint`, `typecheck`, `build`, `test-coverage`) are referenced by the `dev` branch ruleset and by `check-regexp` in the deploy workflows — renaming a job requires updating both.
+- The five CI check names (`format-check`, `lint`, `typecheck`, `build`, `test-coverage`) are referenced by the `main` branch ruleset and by `check-regexp` in the deploy workflows — renaming a job requires updating both.
 
 ## Testing Guidelines
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,7 +132,7 @@ Scopes are defined in `commitlint.config.mjs` and map to monorepo packages:
 | Apps & Packages | `api`, `auth` (exist in both `apps/` and `packages/`)               |
 | Packages        | `db`, `env`, `mail`, `shared`, `sso`, `storage`, `ui`, `validators` |
 | Tooling         | `eslint`, `prettier`, `tsconfig`, `scripts`, `github`, `tailwind`   |
-| Cross-cutting   | `deps`, `ci`, `repo`, `release`, `dev` (used by Release Please)     |
+| Cross-cutting   | `deps`, `ci`, `repo`, `release`, `main` (used by Release Please)    |
 
 **Choosing a scope:**
 

--- a/apps/me/README.md
+++ b/apps/me/README.md
@@ -153,15 +153,15 @@ f3-me uses **tag-based deployment** via GitHub Actions and GCP Cloud Run. This i
 
 **How it works:**
 
-1. You PR into `dev` as usual — CI runs lint, typecheck, and tests
-2. When you're ready to deploy, you tag the commit on `dev` with `me@X.Y.Z`
+1. You PR into `main` as usual — CI runs lint, typecheck, and tests
+2. When you're ready to deploy, you tag the commit on `main` with `me@X.Y.Z`
 3. GitHub Actions builds a Docker image **once**
 4. The image deploys to **staging** automatically
 5. You verify on staging, then go to GitHub Actions and **approve** the production deploy
 6. The **same image** (no rebuild) deploys to **production**
 
 ```text
-PR → dev → tag me@1.2.3 → [CI passes] → build image → deploy staging → [approve] → deploy prod
+PR → main → tag me@1.2.3 → [CI passes] → build image → deploy staging → [approve] → deploy prod
 ```
 
 ### GCP Projects
@@ -173,18 +173,18 @@ PR → dev → tag me@1.2.3 → [CI passes] → build image → deploy staging �
 
 ### How to Deploy (Step by Step)
 
-#### 1. Merge your PR into `dev`
+#### 1. Merge your PR into `main`
 
-Wait for CI to pass on `dev`. You can verify in the GitHub Actions tab.
+Wait for CI to pass on `main`. You can verify in the GitHub Actions tab.
 
 #### 2. Tag the commit
 
 From the command line:
 
 ```bash
-# Make sure you're on dev and up to date
-git checkout dev
-git pull origin dev
+# Make sure you're on main and up to date
+git checkout main
+git pull origin main
 
 # Create the tag (use semantic versioning)
 git tag me@1.0.0
@@ -197,7 +197,7 @@ Or from GitHub's web UI:
 
 1. Go to the repo → **Releases** → **Draft a new release**
 2. Click **Choose a tag** → type `me@1.0.0` → **Create new tag: me@1.0.0 on publish**
-3. Set **Target** to `dev` (or the specific commit SHA)
+3. Set **Target** to `main` (or the specific commit SHA)
 4. Click **Publish release**
 
 **Tag naming:** Use `me@MAJOR.MINOR.PATCH` (e.g., `me@1.0.0`, `me@1.1.0`, `me@1.1.1`). The `me@` prefix scopes it to this app so other app tags won't trigger it.

--- a/docs/AI_AUDIT_PLAYBOOK.md
+++ b/docs/AI_AUDIT_PLAYBOOK.md
@@ -38,7 +38,7 @@ speculative ones. A wrong finding erodes trust in the whole batch.
 ### Confirm your tools and context
 
 - **GitHub CLI:** Confirm `gh auth status` and the target repo
-  (`F3-Nation/f3-nation`). The default branch is `dev`. The repo is **public** —
+  (`F3-Nation/f3-nation`). The default branch is `main`. The repo is **public** —
   do not paste secrets, tokens, or real user PII into issue bodies.
 - **Shell:** In bash, prefix commands with `set +H` so `!` characters don't
   trigger history expansion. If `pnpm` isn't on `PATH`, run

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -1,13 +1,13 @@
 # Release Process
 
-This document describes how code merged to `dev` becomes a tagged release and triggers a production deployment.
+This document describes how code merged to `main` becomes a tagged release and triggers a production deployment.
 
 ---
 
 ## Overview
 
 ```
-feature branch → PR → dev
+feature branch → PR → main
                          ↓
                   Release Please runs
                          ↓
@@ -50,9 +50,9 @@ This matters for shared packages: a `fix(api): ...` commit that only touches `pa
 
 ### 2. Release Please opens a PR automatically
 
-After a push to `dev`, the `release-please.yml` workflow runs. It:
+After a push to `main`, the `release-please.yml` workflow runs. It:
 
-- Scans commits to `dev` since the last release for each app
+- Scans commits to `main` since the last release for each app
 - Determines the appropriate semver bump per app
 - Opens (or updates) a PR titled something like `chore(main): release me 1.2.0` that:
   - Bumps the version in `apps/me/package.json`
@@ -64,11 +64,11 @@ and pushes any resulting `uv.lock` change back to the release PR using the same
 GitHub App token. This keeps Docker's `uv sync --locked ...` build step aligned
 with Release Please's version bump.
 
-If multiple PRs are merged to `dev` before the Release Please PR is merged, Release Please accumulates all of them — the PR is updated in place, never duplicated.
+If multiple PRs are merged to `main` before the Release Please PR is merged, Release Please accumulates all of them — the PR is updated in place, never duplicated.
 
 ### 3. Review and merge the Release Please PR
 
-The PR is purely mechanical (version + changelog). Review the changelog entries to make sure they're accurate. When ready, merge it into `dev`.
+The PR is purely mechanical (version + changelog). Review the changelog entries to make sure they're accurate. When ready, merge it into `main`.
 
 ### 4. Release Please creates the tag
 
@@ -118,7 +118,7 @@ The changelogs live alongside each app's source and can be referenced during rel
 
 | File                                   | Purpose                                                                               |
 | -------------------------------------- | ------------------------------------------------------------------------------------- |
-| `.github/workflows/release-please.yml` | Runs on push to `dev`; creates/updates release PRs and tags                           |
+| `.github/workflows/release-please.yml` | Runs on push to `main`; creates/updates release PRs and tags                          |
 | `release-please-config.json`           | Defines which packages are tracked, tag format, changelog sections                    |
 | `.release-please-manifest.json`        | Tracks the last-released version of each app; updated automatically by Release Please |
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -11,7 +11,7 @@ drifting across config comments.
 - A single app/package: `pnpm -C apps/map test` (append `--run` for a one-shot,
   non-watch run)
 - CI runs these under the `test-coverage` check (one of the five required checks
-  enforced by the `dev` branch ruleset — see [AGENTS.md](../AGENTS.md)).
+  enforced by the `main` branch ruleset — see [AGENTS.md](../AGENTS.md)).
 
 Use Vitest for unit and integration tests. Name test files `*.test.ts[x]` and
 place them next to the source or under `__tests__`. Reset databases before any


### PR DESCRIPTION
Part of #524 — the `dev` → `main` default-branch migration.

Updates docs that describe `dev` as the release/default branch to reference `main` instead:

- `docs/RELEASE_PROCESS.md` — the release flow (headline, flow diagram, release-please push/scan/merge mentions, file table).
- `docs/AI_AUDIT_PLAYBOOK.md` — "The default branch is `dev`" → `main`.
- `AGENTS.md` — the CI check names are referenced by the `main` branch ruleset (post-cutover).

### ⚠️ Merge timing
These describe the **post-cutover state**. This PR breaks no automation, but the text will be inaccurate until the default branch is actually flipped. **Merge this at or immediately after the default-branch flip** (Step 4 in #524), alongside the workflow-trigger PR — not weeks ahead.

Docs-only; no code or workflow changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated release and deployment guidance to use `main` as the default branch and release source.
  * Revised the release process steps and workflow descriptions to reflect `main`-triggered release behavior.
  * Updated deployment documentation for tag-based Cloud Run releases to reference `main`.
  * Adjusted CI documentation and ruleset wording so `format-check`, `lint`, `typecheck`, `build`, and `test-coverage` align with `main`-based enforcement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->