### PR TITLE
ci(repo): repoint CI and release-please triggers from dev to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,14 +2,14 @@ name: CI
 
 on:
   push:
-    branches: [dev]
+    branches: [main]
   pull_request:
     branches: ["**"]
     types: [opened, synchronize, reopened]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/dev' }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:
   contents: read

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -21,7 +21,7 @@ jobs:
       # same commitlint.config.mjs used for commits (single source of truth).
       #
       # Exempt release-please's own bot PRs: their titles (e.g. "chore: release
-      # dev") intentionally omit a scope and are committed via the API. Gate the
+      # main") intentionally omit a scope and are committed via the API. Gate the
       # STEP (not the job) so a skipped run still reports green and never blocks
       # branch protection on the bot's release PRs.
       - name: Lint PR title with commitlint

--- a/.github/workflows/release-please-uv-lock.yml
+++ b/.github/workflows/release-please-uv-lock.yml
@@ -3,7 +3,7 @@ name: Release Please uv.lock
 on:
   pull_request:
     branches:
-      - dev
+      - main
     types:
       - opened
       - synchronize

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -3,7 +3,7 @@ name: Release Please
 on:
   push:
     branches:
-      - dev
+      - main
 
 permissions:
   contents: write

--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -41,8 +41,8 @@ export default {
         "repo",
         "release",
 
-        // release-please uses the target branch as the scope (e.g. "chore(dev): release me 1.2.0")
-        "dev",
+        // release-please uses the target branch as the scope (e.g. "chore(main): release me 1.2.0")
+        "main",
       ],
     ],
     "scope-empty": [2, "never"],


### PR DESCRIPTION
Part of #524 — the `dev` → `main` default-branch migration. This is the **automation-critical** half (Steps 1 + 2).

## Changes
- `ci.yml`: `push` trigger `dev` → `main`; drop the now-defunct `refs/heads/dev` from the concurrency `cancel-in-progress` guard.
- `release-please.yml`: `push` trigger `dev` → `main`.
- `release-please-uv-lock.yml`: `pull_request` base `dev` → `main`.

(PR-triggered CI is unaffected — `ci.yml`'s `pull_request` trigger is `branches: ["**"]`.)

## 🚫 Draft — blocked on the default-branch flip
**Do not merge this on its own.** GitHub runs the copy of a workflow that lives on the branch receiving the push. If this merges while `dev` is still the default/active branch, push-CI and release-please go **dormant on `dev`** during the interim.

Execute as one atomic sequence (#524):
1. Add the `main` branch ruleset (Step 3).
2. Flip the default branch `dev` → `main` (Step 4).
3. Merge this PR.
4. Verify one CI + release-please cycle on `main` (Step 9).

Pairs with the docs PR #562 (also merge at cutover).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated workflows to run against the main branch instead of the development branch.
  * Adjusted commit message validation to accept the main branch as a valid scope.
  * Improved workflow run cancellation so outdated runs stop more consistently on non-main branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->