### PR TITLE
fix(ui): make cmdk combobox options selectable and restore button cursor

### DIFF
--- a/packages/ui/src/command.tsx
+++ b/packages/ui/src/command.tsx
@@ -116,7 +116,7 @@ const CommandItem = React.forwardRef<
   <CommandPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex cursor-default items-center rounded-sm px-2 py-1.5 text-sm outline-hidden select-none aria-selected:bg-slate-100 aria-selected:text-slate-900 data-[disabled]:pointer-events-none data-[disabled]:opacity-50 dark:aria-selected:bg-slate-800 dark:aria-selected:text-slate-50",
+      "relative flex cursor-default items-center rounded-sm px-2 py-1.5 text-sm outline-hidden select-none aria-selected:bg-slate-100 aria-selected:text-slate-900 data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 dark:aria-selected:bg-slate-800 dark:aria-selected:text-slate-50",
       className,
     )}
     {...props}

--- a/tooling/tailwind/web.css
+++ b/tooling/tailwind/web.css
@@ -59,3 +59,13 @@
     height: 0;
   }
 }
+
+/* Tailwind v4 defaults interactive elements to `cursor: default`; restore the
+   pointer cursor users expect on enabled buttons.
+   https://tailwindcss.com/docs/upgrade-guide#buttons-use-the-default-cursor */
+@layer base {
+  button:not(:disabled),
+  [role="button"]:not(:disabled) {
+    cursor: pointer;
+  }
+}


### PR DESCRIPTION
Fixes two regressions introduced by recent dependency upgrades, both in the shared `@acme/ui` / Tailwind layer so every app benefits.

## 1. All combobox options greyed out & unselectable (#580)

Clicking a location in the admin Locations modal rendered **every** option in the Region dropdown greyed out and unclickable. Reported in production too.

**Root cause:** the `cmdk` `0.2.1 → 1.1.1` upgrade (#540) made `CommandItem` emit `data-disabled="false"` on *every* item unconditionally (`"data-disabled":!!A`). React serializes boolean `false` on `data-*` attributes as the literal string `"false"` rather than omitting the attribute, so the attribute is always present. The base class's Tailwind **presence** selector `data-[disabled]:` then matched every option and applied `opacity-50` + `pointer-events-none`.

**Fix:** switch `packages/ui/src/command.tsx` to the **value** selector `data-[disabled=true]:`, so only genuinely-disabled items are styled. This affects all `VirtualizedCombobox` / raw `CommandItem` usages (region, country, AO, location comboboxes, region filter). The Radix-backed `select` / `dropdown-menu` / `context-menu` components are intentionally left on the presence selector, since Radix emits `data-disabled` conditionally (empty string only when disabled) — switching them would break their disabled styling.

> Note: the issue's suggested fix (pass `undefined` instead of `false`) does not work — cmdk's `!!A` coerces both to `false` and still emits `data-disabled="false"`.

## 2. Buttons lost their pointer cursor (#581)

Tailwind CSS v4's Preflight defaults interactive elements to `cursor: default`. Restored the expected pointer cursor via the [base-layer rule from the Tailwind upgrade guide](https://tailwindcss.com/docs/upgrade-guide#buttons-use-the-default-cursor), added to the shared `tooling/tailwind/web.css`. Disabled buttons keep the default cursor, and explicit `cursor-*` utilities still win because the rule lives in `@layer base`.

## Verification

Drove the real admin app (`:3002`) with Playwright:
- Region dropdown options now report `data-disabled="false"`, `opacity: 1`, `pointer-events: auto`, and selecting one populates the field.
- Button cursor change verified locally.
- `prettier` / `eslint` / `typecheck` / `commitlint` pass via pre-commit hooks.

Fixes #580
Fixes #581

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined disabled-state styling so only items explicitly marked disabled are affected.
  * Restored pointer cursor behavior for enabled buttons and button-like elements, improving interactive feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->