### PR TITLE
ci(release): propagate shared-package changes to app releases

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -5,5 +5,17 @@
   "apps/homepage": "1.2.1",
   "apps/map": "7.0.4",
   "apps/me": "2.0.4",
-  "apps/slackbot": "2.0.1"
+  "apps/slackbot": "2.0.1",
+  "packages/api": "0.2.0",
+  "packages/auth": "0.1.1",
+  "packages/db": "0.1.0",
+  "packages/env": "0.1.0",
+  "packages/logger": "0.1.0",
+  "packages/mail": "0.1.0",
+  "packages/shared": "0.1.0",
+  "packages/sso": "0.1.0",
+  "packages/storage": "0.2.0",
+  "packages/ui": "0.1.0",
+  "packages/validators": "0.1.0",
+  "tooling/tailwind": "0.1.0"
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,6 +4,8 @@
   "include-v-in-tag": false,
   "tag-separator": "@",
   "include-component-in-tag": true,
+  "bootstrap-sha": "7bd372dda0d73246b319c5851a98ab5b808424ce",
+  "plugins": ["node-workspace"],
   "changelog-sections": [
     { "type": "feat", "section": "Features" },
     { "type": "fix", "section": "Bug Fixes" },
@@ -53,6 +55,66 @@
       "changelog-path": "CHANGELOG.md",
       "path": "apps/slackbot",
       "release-type": "python"
+    },
+    "packages/api": {
+      "component": "pkg-api",
+      "changelog-path": "CHANGELOG.md",
+      "path": "packages/api"
+    },
+    "packages/auth": {
+      "component": "pkg-auth",
+      "changelog-path": "CHANGELOG.md",
+      "path": "packages/auth"
+    },
+    "packages/db": {
+      "component": "pkg-db",
+      "changelog-path": "CHANGELOG.md",
+      "path": "packages/db"
+    },
+    "packages/env": {
+      "component": "pkg-env",
+      "changelog-path": "CHANGELOG.md",
+      "path": "packages/env"
+    },
+    "packages/logger": {
+      "component": "pkg-logger",
+      "changelog-path": "CHANGELOG.md",
+      "path": "packages/logger"
+    },
+    "packages/mail": {
+      "component": "pkg-mail",
+      "changelog-path": "CHANGELOG.md",
+      "path": "packages/mail"
+    },
+    "packages/shared": {
+      "component": "pkg-shared",
+      "changelog-path": "CHANGELOG.md",
+      "path": "packages/shared"
+    },
+    "packages/sso": {
+      "component": "pkg-sso",
+      "changelog-path": "CHANGELOG.md",
+      "path": "packages/sso"
+    },
+    "packages/storage": {
+      "component": "pkg-storage",
+      "changelog-path": "CHANGELOG.md",
+      "path": "packages/storage"
+    },
+    "packages/ui": {
+      "component": "pkg-ui",
+      "changelog-path": "CHANGELOG.md",
+      "path": "packages/ui"
+    },
+    "packages/validators": {
+      "component": "pkg-validators",
+      "changelog-path": "CHANGELOG.md",
+      "path": "packages/validators"
+    },
+    "tooling/tailwind": {
+      "component": "tailwind-config",
+      "changelog-path": "CHANGELOG.md",
+      "path": "tooling/tailwind"
     }
   }
 }


### PR DESCRIPTION
## Problem

PR #582 (the `@acme/ui` cmdk + `@acme/tailwind-config` cursor fixes for #580/#581) merged to `main`, but the [Release Please run](https://github.com/F3-Nation/f3-nation/actions/runs/28742607958) cut **no app release** — so nothing redeployed and both regressions are still live in production.

**Root cause:** Release Please runs in path-scoped monorepo mode and every registered package lived under `apps/*`. It buckets each merged commit by the file paths it touched; #582 changed only `packages/ui/**` and `tooling/tailwind/**` — outside every registered path — so the commits fell into no bucket and produced no version bump. Release Please is dependency-blind: it has no idea the apps import `@acme/ui`.

**Deploy coupling:** each `deploy-<app>.yml` fires only on a per-app tag (`me@*`, `api@*`, …) that only Release Please creates. So an app ships only if Release Please bumps it.

## Fix

Enable the [`node-workspace`](https://github.com/googleapis/release-please/blob/main/docs/manifest-releaser.md) plugin and register the runtime shared packages as components. When a shared package has a releasable commit, `node-workspace` walks the pnpm workspace graph and force-patches every dependent app (changelog + version bump + tag), even with no direct commits — while preserving each app's independent version line (unlike `linked-versions`, which would force one shared version and was rejected since apps are on divergent majors).

- **Registered:** all 11 `packages/*` + `tooling/tailwind` (its CSS ships to runtime — it caused half of #582).
- **Excluded:** dev-only tooling (`eslint`, `prettier`, `typescript`, `vitest`, `scripts`) so lint/format changes don't redeploy apps.
- **Component naming:** shared packages use a `pkg-*` prefix so tags like `pkg-auth@*` / `pkg-api@*` never collide with the `auth@*` / `api@*` deploy globs.
- **`bootstrap-sha`:** pinned to `7bd372dd` (parent of #582's squash `a7ac4d2a`) so the newly-registered components' first release captures exactly the #582 fixes forward instead of replaying full history.

## Expected result

Once merged, the next Release Please run should open a release PR bumping `pkg-ui`, `tailwind-config`, and apps **admin, api, auth, homepage, map, me** (not slackbot). Merging that release PR creates the per-app tags that fire the deploys — shipping the #582 fixes as a natural side effect of closing the gap.

## Verification

- ✅ Both files valid JSON; config `packages` keys match manifest keys exactly.
- ✅ No newly-added component matches a deploy glob (`me|admin|auth|map|api|homepage|slackbot`).
- ⚠️ **Review the first release PR before merging it** — confirm `node-workspace` preserves pnpm's `workspace:^` prefix (e.g. `"@acme/ui": "workspace:^0.1.0"` → `workspace:^0.1.1`) rather than rewriting it to a bare version.

Config-only; no app code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)