### PR TITLE
fix(admin): correct request review feedback toasts

### DIFF
--- a/apps/admin/__tests__/app/_components/modal/admin-requests-modal.test.tsx
+++ b/apps/admin/__tests__/app/_components/modal/admin-requests-modal.test.tsx
@@ -1,0 +1,164 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import AdminRequestsModal from "~/app/_components/modal/admin-requests-modal";
+
+const { toastMock, validateMutateAsync, rejectMutateAsync } = vi.hoisted(
+  () => ({
+    toastMock: {
+      success: vi.fn(),
+      error: vi.fn(),
+      info: vi.fn(),
+      warning: vi.fn(),
+    },
+    validateMutateAsync: vi.fn(),
+    rejectMutateAsync: vi.fn(),
+  }),
+);
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: vi.fn() }),
+}));
+
+vi.mock("@acme/ui/toast", () => ({ toast: toastMock }));
+
+vi.mock("~/utils/store/modal", () => ({
+  closeModal: vi.fn(),
+}));
+
+vi.mock("~/utils/image/upload-logo", () => ({
+  uploadLogo: vi.fn(),
+}));
+
+vi.mock("~/app/_components/forms/location-event-form", () => ({
+  LocationEventForm: () => null,
+  FormDebugData: () => null,
+}));
+
+// Bypass react-hook-form so clicking Approve always reaches the submit
+// handler with valid values.
+vi.mock("~/utils/forms", () => ({
+  useUpdateLocationForm: () => ({
+    watch: () => "request-1",
+    reset: vi.fn(),
+    setError: vi.fn(),
+    handleSubmit:
+      (
+        onValid: (values: Record<string, unknown>) => Promise<void>,
+        _onInvalid?: unknown,
+      ) =>
+      () =>
+        onValid({
+          id: "request-1",
+          regionId: 1,
+          eventStartTime: "05:30",
+          eventEndTime: "06:15",
+        }),
+  }),
+}));
+
+vi.mock("@acme/ui/form", () => ({
+  Form: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("~/orpc/react", () => ({
+  ORPCError: class ORPCError extends Error {},
+  invalidateQueries: vi.fn(),
+  useQuery: (options: { queryKey: string[] }) => {
+    if (options.queryKey.includes("request.byId")) {
+      return {
+        data: {
+          request: {
+            id: "request-1",
+            requestType: "edit",
+            regionId: 1,
+          },
+        },
+      };
+    }
+    return { data: [] };
+  },
+  useMutation: (options: { mutationKey: string[] }) => {
+    if (options.mutationKey.includes("request.validateSubmissionByAdmin")) {
+      return { mutateAsync: validateMutateAsync };
+    }
+    return { mutateAsync: rejectMutateAsync };
+  },
+  orpc: {
+    request: {
+      byId: {
+        queryOptions: (input: unknown) => ({
+          queryKey: ["request.byId"],
+          input,
+        }),
+      },
+      validateSubmissionByAdmin: {
+        mutationOptions: () => ({
+          mutationKey: ["request.validateSubmissionByAdmin"],
+        }),
+      },
+      rejectSubmission: {
+        mutationOptions: () => ({
+          mutationKey: ["request.rejectSubmission"],
+        }),
+      },
+    },
+    eventType: {
+      all: {
+        queryOptions: (input: unknown) => ({
+          queryKey: ["eventType.all"],
+          input,
+        }),
+      },
+    },
+  },
+}));
+
+const renderModal = () =>
+  render(<AdminRequestsModal data={{ id: "request-1" }} />);
+
+describe("AdminRequestsModal review feedback toasts", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows a success (non-error) toast when a reject succeeds (AC-13)", async () => {
+    rejectMutateAsync.mockResolvedValue({ status: "rejected" });
+    renderModal();
+
+    fireEvent.click(screen.getByRole("button", { name: "Reject" }));
+
+    await waitFor(() => {
+      expect(toastMock.success).toHaveBeenCalledWith("Rejected update");
+    });
+    expect(toastMock.error).not.toHaveBeenCalled();
+  });
+
+  it("shows 'Approved update' when the approval is applied (status approved)", async () => {
+    validateMutateAsync.mockResolvedValue({ status: "approved" });
+    renderModal();
+
+    fireEvent.click(screen.getByRole("button", { name: "Approve" }));
+
+    await waitFor(() => {
+      expect(toastMock.success).toHaveBeenCalledWith("Approved update");
+    });
+    expect(toastMock.info).not.toHaveBeenCalled();
+    expect(toastMock.error).not.toHaveBeenCalled();
+  });
+
+  it("surfaces further review instead of 'Approved update' when the approval is re-recorded as pending (AC-17)", async () => {
+    validateMutateAsync.mockResolvedValue({ status: "pending" });
+    renderModal();
+
+    fireEvent.click(screen.getByRole("button", { name: "Approve" }));
+
+    await waitFor(() => {
+      expect(toastMock.info).toHaveBeenCalledWith(
+        "You don't have permission for every affected region — the request was submitted for further review",
+      );
+    });
+    expect(toastMock.success).not.toHaveBeenCalledWith("Approved update");
+    expect(toastMock.error).not.toHaveBeenCalled();
+  });
+});

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -10,6 +10,8 @@
     "format": "prettier --check . --ignore-path ../../.gitignore --ignore-path ../../.prettierignore",
     "lint": "dotenv -v SKIP_ENV_VALIDATION=1 eslint .",
     "start": "pnpm with-env next start",
+    "test": "vitest --run",
+    "test:watch": "vitest -w",
     "typecheck": "tsc --noEmit",
     "with-env": "dotenv -e ../../.env --"
   },
@@ -51,16 +53,22 @@
     "@acme/prettier-config": "workspace:*",
     "@acme/tsconfig": "workspace:*",
     "@tailwindcss/postcss": "catalog:",
+    "@testing-library/jest-dom": "catalog:",
+    "@testing-library/react": "catalog:",
     "@types/google.maps": "catalog:",
     "@types/lodash": "catalog:",
     "@types/node": "catalog:",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
+    "@vitejs/plugin-react": "catalog:",
     "eslint": "catalog:",
     "jiti": "catalog:",
+    "jsdom": "catalog:",
     "postcss": "catalog:",
     "prettier": "catalog:",
-    "typescript": "catalog:"
+    "typescript": "catalog:",
+    "vite": "catalog:",
+    "vitest": "catalog:"
   },
   "prettier": "@acme/prettier-config"
 }

--- a/apps/admin/src/app/_components/modal/admin-requests-modal.tsx
+++ b/apps/admin/src/app/_components/modal/admin-requests-modal.tsx
@@ -93,7 +93,7 @@ export default function AdminRequestsModal({
           valuesToSubmit.aoLogo = aoLogo;
         }
 
-        await validateSubmissionByAdmin.mutateAsync({
+        const result = await validateSubmissionByAdmin.mutateAsync({
           ...valuesToSubmit,
           eventStartTime: convertHH_mmToHHmm(
             valuesToSubmit.eventStartTime ?? "",
@@ -105,7 +105,13 @@ export default function AdminRequestsModal({
         void invalidateQueries("event");
         void invalidateQueries("location");
         router.refresh();
-        toast.success("Approved update");
+        if (result.status === "approved") {
+          toast.success("Approved update");
+        } else {
+          toast.info(
+            "You don't have permission for every affected region — the request was submitted for further review",
+          );
+        }
         closeModal();
       } catch (error) {
         console.log(error);
@@ -143,7 +149,7 @@ export default function AdminRequestsModal({
         void invalidateQueries("request");
         router.refresh();
         setStatus("idle");
-        toast.error("Rejected update");
+        toast.success("Rejected update");
         closeModal();
       });
   };

--- a/apps/admin/vitest.config.ts
+++ b/apps/admin/vitest.config.ts
@@ -1,0 +1,19 @@
+import path from "path";
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    globals: true,
+    environment: "jsdom",
+    env: { NODE_ENV: "test" },
+    include: ["src/**/*.test.{ts,tsx}", "__tests__/**/*.test.{ts,tsx}"],
+    setupFiles: ["./vitest.setup.ts"],
+  },
+  resolve: {
+    alias: {
+      "~": path.resolve(__dirname, "./src"),
+    },
+  },
+});

--- a/apps/admin/vitest.setup.ts
+++ b/apps/admin/vitest.setup.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -543,6 +543,12 @@ importers:
       '@tailwindcss/postcss':
         specifier: 'catalog:'
         version: 4.3.1
+      '@testing-library/jest-dom':
+        specifier: 'catalog:'
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: 'catalog:'
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@types/google.maps':
         specifier: 'catalog:'
         version: 3.65.2
@@ -558,12 +564,18 @@ importers:
       '@types/react-dom':
         specifier: 'catalog:'
         version: 19.2.3(@types/react@19.2.17)
+      '@vitejs/plugin-react':
+        specifier: 'catalog:'
+        version: 6.0.3(vite@8.1.0(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       eslint:
         specifier: 'catalog:'
         version: 10.5.0(jiti@2.7.0)
       jiti:
         specifier: 'catalog:'
         version: 2.7.0
+      jsdom:
+        specifier: 'catalog:'
+        version: 29.1.1
       postcss:
         specifier: 'catalog:'
         version: 8.5.15
@@ -573,6 +585,12 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
+      vite:
+        specifier: 'catalog:'
+        version: 8.1.0(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1)(vite@8.1.0(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
   apps/api:
     dependencies:
@@ -8024,10 +8042,6 @@ packages:
     resolution: {integrity: sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==}
     engines: {node: '>=18'}
 
-  tinyglobby@0.2.16:
-    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
-    engines: {node: '>=12.0.0'}
-
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
@@ -14442,11 +14456,6 @@ snapshots:
 
   tinyexec@1.1.1: {}
 
-  tinyglobby@0.2.16:
-    dependencies:
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
-
   tinyglobby@0.2.17:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
@@ -14690,7 +14699,7 @@ snapshots:
       std-env: 4.1.0
       tinybench: 2.9.0
       tinyexec: 1.1.1
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
       vite: 8.1.0(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
       why-is-node-running: 2.3.0
@@ -14720,7 +14729,7 @@ snapshots:
       std-env: 4.1.0
       tinybench: 2.9.0
       tinyexec: 1.1.1
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
       vite: 8.1.0(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
       why-is-node-running: 2.3.0


### PR DESCRIPTION
### 👋 TL;DR

Two small review-feedback fixes in the admin requests modal, both from owner decisions on the map update-request spec (#551, §10 decisions 3–4):

- **Reject** now shows a success toast (was `toast.error` on a successful rejection) — spec AC-13.
- **Approve** now checks the returned status: if the validator lacks permission on an affected region and the request is re-recorded as `pending`, the admin sees *"You don't have permission for every affected region — the request was submitted for further review"* instead of an unconditional "Approved update" — spec AC-17.

### 🔎 Details

`validateSubmissionByAdmin` returns `{ status: "approved" | "pending" | "rejected" }`; the modal previously ignored it. Also bootstraps a minimal Vitest setup for **apps/admin** (none existed) mirroring apps/me — three tests pin the new toast behavior.

### ✅ How to Test

`pnpm -F f3-admin test` — 3 tests pass. Manually: reject a pending request → green toast; approve a request in a region you can't edit → info toast, request stays pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)