### PR TITLE
fix(map): mask session replay text and media

### DIFF
--- a/apps/api/src/instrumentation-client.ts
+++ b/apps/api/src/instrumentation-client.ts
@@ -14,8 +14,8 @@ if (env.NODE_ENV === "production") {
     // Add optional integrations for additional features
     integrations: [
       Sentry.replayIntegration({
-        maskAllText: false,
-        blockAllMedia: false,
+        maskAllText: true,
+        blockAllMedia: true,
       }),
     ],
 

--- a/apps/map/src/instrumentation-client.ts
+++ b/apps/map/src/instrumentation-client.ts
@@ -18,8 +18,8 @@ if (typeof window !== "undefined" && process.env.NODE_ENV === "production") {
     // Add optional integrations for additional features
     integrations: [
       Sentry.replayIntegration({
-        maskAllText: false,
-        blockAllMedia: false,
+        maskAllText: true,
+        blockAllMedia: true,
       }),
     ],
 


### PR DESCRIPTION
### 👋 TL;DR

Sentry session replay was capturing **unmasked user input** — `maskAllText: false, blockAllMedia: false` — in both `apps/map` and `apps/api`'s client instrumentation. The map's update-request forms collect emails, so typed PII can appear in replays today. This flips both to masked.

### 🔎 Details

4-line diff, no other Sentry changes (DSN/sampling untouched — a broader observability change is being designed separately). Worth checking existing Sentry replays for captured user data.

### ✅ How to Test

`pnpm typecheck` + `lint` green for both apps. Replays after deploy show masked text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved privacy in session replay recordings by hiding text content and blocking media from captured sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->