### PR TITLE
fix(repo): sync Slackbot Python workspace packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "lint": "turbo run lint --continue -- --cache --cache-location node_modules/.cache/.eslintcache; pnpm run lint:ws",
     "local:setup": "bash scripts/local-setup.sh",
     "postinstall": "bash scripts/postinstall-uv-sync.sh",
-    "python:install": "uv sync",
+    "python:install": "uv sync --all-packages",
     "reset-test-db": "turbo run reset-test-db",
     "test": "turbo test",
     "typecheck": "turbo typecheck",

--- a/scripts/postinstall-uv-sync.sh
+++ b/scripts/postinstall-uv-sync.sh
@@ -4,7 +4,7 @@
 set -euo pipefail
 
 if command -v uv >/dev/null 2>&1; then
-  uv sync
+  uv sync --all-packages
   exit 0
 fi
 


### PR DESCRIPTION
## Problem
`pnpm python:install` ran `uv sync` for only the root project, so the Slackbot workspace packages were not installed into the active `.venv`. That left `sqlalchemy` missing even though it was declared in `apps/slackbot/pyproject.toml` and present in `uv.lock`.

## Fix
Update the Python install flow to sync all workspace packages:
- `pnpm python:install` now runs `uv sync --all-packages`
- the `postinstall` hook does the same so fresh installs populate the Slackbot environment automatically

## Validation
- `uv sync --all-packages`
- `uv run python -c "import sqlalchemy; print(sqlalchemy.__version__)"`

## Notes
This is a repo-level fix for the Slackbot Python environment. No DB or API changes.