### PR TITLE
fix(map,shared): consolidate search trigger to 3 chars, label panel close button

### DIFF
--- a/apps/map/src/app/_components/map/desktop-location-panel-content.tsx
+++ b/apps/map/src/app/_components/map/desktop-location-panel-content.tsx
@@ -30,6 +30,7 @@ export const DesktopLocationPanelContent = () => {
       <div className="h-8" />
       <div className="absolute top-2 right-2 flex flex-row gap-2">
         <button
+          aria-label="Close location panel"
           className="rounded-full bg-muted-foreground px-1 py-1 text-sm text-background"
           onClick={(e) => {
             closePanel();

--- a/apps/map/src/app/_components/map/map-searchbox-desktop.tsx
+++ b/apps/map/src/app/_components/map/map-searchbox-desktop.tsx
@@ -6,6 +6,7 @@ import { Search, XCircle } from "lucide-react";
 
 import {
   DEFAULT_CENTER,
+  MIN_TEXT_LENGTH_FOR_SEARCH_RESULTS,
   SIDEBAR_WIDTH,
   Z_INDEX,
 } from "@acme/shared/app/constants";
@@ -152,7 +153,9 @@ export function MapSearchBox({
                   if (!value) {
                     searchStore.setState({ placesResults: [] });
                     setIsLoading(false);
-                  } else if (value.length > 2) {
+                  } else if (
+                    value.length >= MIN_TEXT_LENGTH_FOR_SEARCH_RESULTS
+                  ) {
                     setIsLoading(true);
                     // Use debounced autocomplete to reduce API calls
                     debouncedPlacesAutocomplete(

--- a/apps/map/src/app/_components/map/map-searchbox-mobile.tsx
+++ b/apps/map/src/app/_components/map/map-searchbox-mobile.tsx
@@ -5,7 +5,11 @@ import Image from "next/image";
 import Link from "next/link";
 import { ChevronLeft, XCircle } from "lucide-react";
 
-import { DEFAULT_CENTER, Z_INDEX } from "@acme/shared/app/constants";
+import {
+  DEFAULT_CENTER,
+  MIN_TEXT_LENGTH_FOR_SEARCH_RESULTS,
+  Z_INDEX,
+} from "@acme/shared/app/constants";
 import { cn } from "@acme/ui";
 import { Input } from "@acme/ui/input";
 
@@ -142,7 +146,7 @@ export function MapSearchBoxMobile({
                 const value = e.target.value;
                 if (!value) {
                   searchStore.setState({ placesResults: [] });
-                } else if (value.length > 2) {
+                } else if (value.length >= MIN_TEXT_LENGTH_FOR_SEARCH_RESULTS) {
                   const center = mapStore.get("center") ?? {
                     lat: DEFAULT_CENTER[0] ?? 37.7937,
                     lng: DEFAULT_CENTER[1] ?? -122.3965,

--- a/packages/shared/src/app/constants.ts
+++ b/packages/shared/src/app/constants.ts
@@ -113,7 +113,7 @@ export const Z_INDEX = {
 
 export const MOBILE_SEARCH_RESULT_ITEM_HEIGHT = 128;
 
-export const MIN_TEXT_LENGTH_FOR_SEARCH_RESULTS = 2;
+export const MIN_TEXT_LENGTH_FOR_SEARCH_RESULTS = 3;
 
 export const feedbackSchema = z.object({
   type: z.enum(["bug", "feature request", "feedback", "other"]),


### PR DESCRIPTION
Two browse-spec accuracy fixes surfaced by the review on #551, so the spec's AC-4 and AC-8 describe one clean behavior:

1. **Search threshold** — F3 results triggered at 2 characters, Places geocoding at 3. Consolidated on a single **3-char** trigger by routing both searchboxes through `MIN_TEXT_LENGTH_FOR_SEARCH_RESULTS` (now 3), instead of the hard-coded `> 2`.
2. **Panel close button a11y** — the location-panel close control was an icon-only `<button>` with no accessible name. Added `aria-label="Close location panel"` so it's reachable by role/name (and stably selectable for the browse E2E).

Companion to #551 (browse spec). Merge this with or before #551 so AC-4/AC-8 are exactly true in main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)