### PR TITLE
fix(slackbot,tailwind,sso): fixing local lint issues

### DIFF
--- a/apps/slackbot/features/calendar/location.py
+++ b/apps/slackbot/features/calendar/location.py
@@ -337,7 +337,11 @@ def handle_location_add(body: dict, client: WebClient, logger: Logger, context: 
             address_zip=safe_get(form_data, _LOCATION_ZIP),
             address_country=safe_get(form_data, _LOCATION_COUNTRY),
         )
-        trigger_map_revalidation(logger=logger, action="map.updated", map_update_data=MapUpdateData(locationId=int(location_id)))
+        trigger_map_revalidation(
+            logger=logger,
+            action="map.updated",
+            map_update_data=MapUpdateData(locationId=int(location_id)),
+        )
         created_location_id = int(location_id)
     else:
         new_location = service.create_location(
@@ -353,7 +357,11 @@ def handle_location_add(body: dict, client: WebClient, logger: Logger, context: 
             address_zip=safe_get(form_data, _LOCATION_ZIP),
             address_country=safe_get(form_data, _LOCATION_COUNTRY),
         )
-        trigger_map_revalidation(logger=logger, action="map.created", map_update_data=MapUpdateData(locationId=new_location.id))
+        trigger_map_revalidation(
+            logger=logger,
+            action="map.created",
+            map_update_data=MapUpdateData(locationId=new_location.id),
+        )
         created_location_id = new_location.id
 
     if safe_get(metadata, "update_view_id"):
@@ -415,7 +423,11 @@ def handle_location_edit_delete(
         locations = service.get_org_locations(region_record.org_id)
         deleted_name = next((get_location_display_name(loc) for loc in locations if loc.id == location_id), "selected")
         service.delete_location(location_id)
-        trigger_map_revalidation(logger=logger, action="map.deleted", map_update_data=MapUpdateData(locationId=location_id))
+        trigger_map_revalidation(
+            logger=logger,
+            action="map.deleted",
+            map_update_data=MapUpdateData(locationId=location_id),
+        )
         remaining = [loc for loc in locations if loc.id != location_id]
         remaining.sort(key=lambda loc: get_location_display_name(loc).lower())
         views = LocationViews()

--- a/apps/slackbot/features/calendar/series.py
+++ b/apps/slackbot/features/calendar/series.py
@@ -312,7 +312,11 @@ def handle_series_add(body: dict, client: WebClient, logger: Logger, context: di
         build_series_list_form(
             body, client, logger, context, region_record, update_view_id=safe_get(body, "view", "previous_view_id")
         )
-        trigger_map_revalidation(logger=logger, action="map.updated", map_update_data=MapUpdateData(eventId=metadata["series_id"]))
+        trigger_map_revalidation(
+            logger=logger,
+            action="map.updated",
+            map_update_data=MapUpdateData(eventId=metadata["series_id"]),
+        )
         post_bot_log(
             client=client,
             region_record=region_record,
@@ -353,7 +357,11 @@ def handle_series_add(body: dict, client: WebClient, logger: Logger, context: di
             created_series.append(created)
         # The API cascade automatically creates all future EventInstances; no local create needed.
         for record in created_series:
-            trigger_map_revalidation(logger=logger, action="map.created", map_update_data=MapUpdateData(eventId=record.id))
+            trigger_map_revalidation(
+                logger=logger,
+                action="map.created",
+                map_update_data=MapUpdateData(eventId=record.id),
+            )
         post_bot_log(
             client=client,
             region_record=region_record,

--- a/apps/slackbot/features/connect.py
+++ b/apps/slackbot/features/connect.py
@@ -23,6 +23,7 @@ from slack_sdk.models.views import View, ViewState
 from slack_sdk.web import WebClient
 
 # from features.calendar.series import create_events
+from utilities.constants import LOCAL_DEVELOPMENT
 from utilities.database.orm import SlackSettings
 from utilities.helper_functions import (
     get_region_record,
@@ -31,7 +32,6 @@ from utilities.helper_functions import (
     update_local_region_records,
 )
 from utilities.slack.actions import LOADING_ID
-from utilities.constants import LOCAL_DEVELOPMENT
 
 CONNECT_EXISTING_REGION = "connect_existing_region"
 CREATE_NEW_REGION = "create_new_region"
@@ -278,9 +278,9 @@ def handle_existing_region_selection(
             )
         except Exception as e:
             logger.error(f"Error sending region connection request: {e}")
-    
+
     # update modal to indicate that the request has been submitted and is pending review
-    
+
     form: View = View(
         type="modal",
         title="Connect existing region",
@@ -297,7 +297,7 @@ def handle_new_region_creation(
     body: dict, client: WebClient, logger: Logger, context: dict, region_record: SlackSettings
 ):
     state = ViewState(**safe_get(body, "view", "state"))
-    region_name = state.values.get(NEW_REGION_NAME).get(NEW_REGION_NAME)
+    _region_name = state.values.get(NEW_REGION_NAME).get(NEW_REGION_NAME)
 
 
 def handle_approve_connection(

--- a/apps/slackbot/features/db_admin.py
+++ b/apps/slackbot/features/db_admin.py
@@ -6,7 +6,6 @@ from logging import Logger
 from f3_data_models.models import Org, Org_Type, Org_x_SlackSpace, Role, Role_x_User_x_Org, SlackSpace
 from f3_data_models.utils import DbManager
 from slack_sdk.web import WebClient
-from sqlalchemy import engine
 
 # from features.calendar.series import create_events
 from scripts.calendar_images import generate_calendar_images

--- a/apps/slackbot/main.py
+++ b/apps/slackbot/main.py
@@ -89,7 +89,8 @@ try:
     )
 except Exception as exc:
     raise RuntimeError(
-        f"Error initializing Slackbot: you may need to set up your .env file with the appropriate Slack credentials. Exception: {exc}"
+        "Error initializing Slackbot: you may need to set up your .env file with the appropriate Slack credentials. "
+        f"Exception: {exc}"
     ) from exc
 
 # ----------------------------------------
@@ -196,7 +197,7 @@ try:
     app.event(MATCH_ALL_PATTERN)(*ARGS, **LAZY_KWARGS)
     app.options(MATCH_ALL_PATTERN)(*ARGS, **LAZY_KWARGS)
     app.shortcut(MATCH_ALL_PATTERN)(*ARGS, **LAZY_KWARGS)
-except Exception as exc:
+except Exception:
     pass
 
 
@@ -223,11 +224,13 @@ if __name__ == "__main__":
 
     if LOCAL_DEVELOPMENT and not SOCKET_MODE:
         raise RuntimeError("Local development requires SOCKET_MODE=true.")
-    
+
     # Ensure SLACK_APP_TOKEN is present
     app_token = os.environ.get("SLACK_APP_TOKEN")
     if not app_token:
-        logging.getLogger().error("SLACK_APP_TOKEN is required to run the Slackbot. Please set it in your .env file.")
+        logging.getLogger().error(
+            "SLACK_APP_TOKEN is required to run the Slackbot. Please set it in your .env file."
+        )
         exit(1)
 
     if not SOCKET_MODE:
@@ -241,7 +244,6 @@ if __name__ == "__main__":
         if LOCAL_DEVELOPMENT:
             start_local_health_server(local_http_port)
             logging.getLogger().info(f"Local HTTP health server listening on http://localhost:{local_http_port}")
-            
 
         logging.getLogger().info("Running in local Socket Mode.")
 

--- a/apps/slackbot/package.json
+++ b/apps/slackbot/package.json
@@ -5,6 +5,6 @@
   "scripts": {
     "dev": "uv run bash ./app_startup.sh",
     "test": "uv run pytest",
-    "lint": "uv run ruff check ."
+    "lint": "bash ./scripts/lint.sh"
   }
 }

--- a/apps/slackbot/pyproject.toml
+++ b/apps/slackbot/pyproject.toml
@@ -1,6 +1,7 @@
 [tool.ruff]
 line-length = 120
 
+[tool.ruff.lint]
 select = [
     "E", # pycodestyle errors (settings from FastAPI, thanks, @tiangolo!)
     "W", # pycodestyle warnings
@@ -13,7 +14,7 @@ ignore = [
     "C901", # too complex
 ]
 
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
 order-by-type = true
 relative-imports-order = "closest-to-furthest"
 extra-standard-library = ["typing"]
@@ -59,6 +60,7 @@ dev = [
     "pytest>=8.4.2,<9.0.0",
     "debugpy>=1.8.17,<2.0.0",
     "pre-commit>=4.2.0,<5.0.0",
+    "ruff>=0.14.0,<1.0.0",
 ]
 scripts = [
     "mplcyberpunk>=0.7.6,<0.8.0",

--- a/apps/slackbot/scripts/lint.sh
+++ b/apps/slackbot/scripts/lint.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ruff_args=()
+
+while (($#)); do
+  case "$1" in
+    --)
+      shift
+      ;;
+    --cache)
+      shift
+      ;;
+    --cache-location)
+      shift
+      if (($#)); then
+        shift
+      fi
+      ;;
+    --cache-location=*)
+      shift
+      ;;
+    *)
+      ruff_args+=("$1")
+      shift
+      ;;
+  esac
+done
+
+uv run ruff check . "${ruff_args[@]}"

--- a/apps/slackbot/utilities/helper_functions.py
+++ b/apps/slackbot/utilities/helper_functions.py
@@ -13,7 +13,6 @@ import requests
 from f3_data_models.models import (
     Location,
     Org,
-    Org_Type,
     Org_x_SlackSpace,
     Role,
     Role_x_User_x_Org,

--- a/apps/slackbot/utilities/slack/orm.py
+++ b/apps/slackbot/utilities/slack/orm.py
@@ -952,7 +952,7 @@ class BlockView:
                 res = client.views_update(external_id=actions.DEBUG_FORM_EXTERNAL_ID, view=view)
             else:
                 res = client.views_update(view_id=view_id, view=view)
-        except Exception as e:
+        except Exception:
             # TODO: handle "not found" errors; post new instead of update?
             res = None
 

--- a/apps/slackbot/utilities/slack/sdk_orm.py
+++ b/apps/slackbot/utilities/slack/sdk_orm.py
@@ -248,6 +248,6 @@ class SdkBlockView:
                 return client.views_update(external_id=external_id, view=view.to_dict())
             else:
                 return client.views_update(view_id=view_id, view=view.to_dict())
-        except Exception as e:
+        except Exception:
             # TODO: handle "not found" errors; post new instead of update?
             pass

--- a/packages/sso/eslint.config.js
+++ b/packages/sso/eslint.config.js
@@ -1,3 +1,3 @@
 import baseConfig from "@acme/eslint-config/base";
 
-export default [...baseConfig];
+export default [...baseConfig, { ignores: ["coverage/**", "dist/**"] }];

--- a/tooling/tailwind/package.json
+++ b/tooling/tailwind/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "clean": "rm -rf .turbo node_modules",
     "format": "prettier --check . --ignore-path ../../.gitignore --ignore-path ../../.prettierignore",
-    "lint": "eslint .",
+    "lint": "eslint \"src/**/*.{js,jsx,ts,tsx}\" --no-error-on-unmatched-pattern",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/uv.lock
+++ b/uv.lock
@@ -765,6 +765,7 @@ dev = [
     { name = "debugpy" },
     { name = "pre-commit" },
     { name = "pytest" },
+    { name = "ruff" },
 ]
 scripts = [
     { name = "dataframe-image" },
@@ -801,6 +802,7 @@ dev = [
     { name = "debugpy", specifier = ">=1.8.17,<2.0.0" },
     { name = "pre-commit", specifier = ">=4.2.0,<5.0.0" },
     { name = "pytest", specifier = ">=8.4.2,<9.0.0" },
+    { name = "ruff", specifier = ">=0.14.0,<1.0.0" },
 ]
 scripts = [
     { name = "dataframe-image", specifier = ">=0.2.7,<0.3.0" },
@@ -2852,6 +2854,31 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/77/65/38ab2f90df44c2febfb63cc10ced40763d9b4bc94d173e734528663fe7f5/rpds_py-2026.5.1-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:b1be5c35683684d5331b93600c210e8367c254683d8a6df6bd21bd2da3a334fb", size = 581839, upload-time = "2026-05-28T12:01:48.109Z" },
     { url = "https://files.pythonhosted.org/packages/15/2d/ce1f605fe036aadd460e5822e578c6c7ec3a860936cca37d6e0f299daa77/rpds_py-2026.5.1-cp315-cp315t-win32.whl", hash = "sha256:75808f6c38ce7749bb68cc2770161aae5045e6c6f6781a9782e74b93304399df", size = 207866, upload-time = "2026-05-28T12:01:49.648Z" },
     { url = "https://files.pythonhosted.org/packages/79/cb/966040123eb102371559746908ef2c9471f4d43e17ec9a645a2258dab64b/rpds_py-2026.5.1-cp315-cp315t-win_amd64.whl", hash = "sha256:90bd6630002a1c7f09e7843dd79f0d24f3d2897cc25a753480917865d14f15b3", size = 225441, upload-time = "2026-05-28T12:01:51.408Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.20"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/dc/35b341fc554ba02f217fc10da57d1a75168cfbcf75b0ef2202176d4c4f2d/ruff-0.15.20.tar.gz", hash = "sha256:1416eb04349192646b54de98f146c4f59afe37d0decfc02c3cbbf396f3a28566", size = 4755489, upload-time = "2026-06-25T17:20:37.578Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/d9/2d5014f0253ba541d2061d9fa7193f48e941c8b21bb88a7ff9bbe0bd0596/ruff-0.15.20-py3-none-linux_armv6l.whl", hash = "sha256:00e188c53e499c3c1637f73c91dcf2fb56d576cab76ce1be50a27c4e80e37078", size = 10839665, upload-time = "2026-06-25T17:19:44.702Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/d3/ac1798ba64f670698867fcfc591d50e7e421bef137db564858f619a30fcf/ruff-0.15.20-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:9ebd1fd9b9c95fc0bd7b2761aebec1f030013d2e193a2901b224af68fe47251b", size = 11208649, upload-time = "2026-06-25T17:19:48.787Z" },
+    { url = "https://files.pythonhosted.org/packages/47/47/d3ac899991202095dfcf3d5176be4272642be3cf981a2f1a30f72a2afb95/ruff-0.15.20-py3-none-macosx_11_0_arm64.whl", hash = "sha256:c5b16cdd67ca108185cd36dce98c576350c03b1660a751de725fb049193a0632", size = 10622638, upload-time = "2026-06-25T17:19:51.354Z" },
+    { url = "https://files.pythonhosted.org/packages/33/13/4e043fe30aa94d4ff5213a9881fc296d12960f5971b234a5263fdc225312/ruff-0.15.20-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3413bb3c3d2ca6a8208f1f4809cd2dca3c6de6d0b491c0e70847672bde6e6efd", size = 10984227, upload-time = "2026-06-25T17:19:54.044Z" },
+    { url = "https://files.pythonhosted.org/packages/76/e6/92e7bf40388bc5800073b96564f56264f7e48bfd1a498f5ced6ae6d5a769/ruff-0.15.20-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bd7ec42b3bb3da066488db093308a69c4ac5ee6d2af333a86ba6e2eb2e7dd44b", size = 10622882, upload-time = "2026-06-25T17:19:57.037Z" },
+    { url = "https://files.pythonhosted.org/packages/13/7a/43460be3f24495a3aa46d4b16873e2c4941b3b5f0b00cf88c03b7b94b339/ruff-0.15.20-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e1a36ad0eb77fba9aabfb69ede54de6f376d04ac18ebea022847046d340a8267", size = 11474808, upload-time = "2026-06-25T17:20:00.357Z" },
+    { url = "https://files.pythonhosted.org/packages/27/a0/f37077884873221c6b33b4ab49eb18f9f88e54a16a25a5bca59bef46dd66/ruff-0.15.20-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b6df3b1e4610432f0386dba04d853b5f08cbbc903410c6fcc02f620f05aff53c", size = 12293094, upload-time = "2026-06-25T17:20:03.446Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/74/165545b60256a9704c21ac0ec4a0d07933b320812f9584836c9f4aca4292/ruff-0.15.20-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e89f198a1ea6ef0d727c1cf16088bc91a6cb0ab947dedc966715691647186eae", size = 11526176, upload-time = "2026-06-25T17:20:06.301Z" },
+    { url = "https://files.pythonhosted.org/packages/86/b1/a976a136d40ade83ce743578399865f57001003a409acadc0ecbb3051082/ruff-0.15.20-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:309809086c2acb67624950a3c8133e80f32d0d3e27106c0cd60ff26657c9f24b", size = 11520767, upload-time = "2026-06-25T17:20:09.191Z" },
+    { url = "https://files.pythonhosted.org/packages/19/0f/f032696cb01c9b54c0263fa393474d7758f1cdc021a01b04e3cbc2500999/ruff-0.15.20-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:2d2374caa2f2c2f9e2b7da0a50802cfb8b79f55a9b5e49379f564544fbf56487", size = 11500132, upload-time = "2026-06-25T17:20:13.602Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f4/51b1a14bc69e8c224b15dab9cce8e99b425e0455d462caa2b3c9be2b6a8e/ruff-0.15.20-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:a1ed17b65293e0c2f22fc387bc13198a5de94bf4429589b0ff6946b0feaf21a3", size = 10943828, upload-time = "2026-06-25T17:20:16.635Z" },
+    { url = "https://files.pythonhosted.org/packages/71/4b/fe267640783cd02bf6c5cc290b1df1051be2ec294c678b5c15fe19e52343/ruff-0.15.20-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:f701305e66b38ea6c91882490eb73459796808e4c6362a1b765255e0cdcd4053", size = 10645418, upload-time = "2026-06-25T17:20:19.4Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/c0/a65aa4ec2f5e87a1df32dc3ec1fede434fe3dfd5cbcf3b503cafc676ab54/ruff-0.15.20-py3-none-musllinux_1_2_i686.whl", hash = "sha256:5b9c0c367ad8e5d0d5b5b8537864c469a0a0e55417aadfbeca41fa61333be9f4", size = 11211770, upload-time = "2026-06-25T17:20:22.033Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/a4/0caa331d954ae2723d729d351c989cb4ca8b6077d5c6c2cb6de75e98c041/ruff-0.15.20-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:01cc00dd58f0df339d0e902219dd53990ea99996a0344e5d9cc8d45d5307e460", size = 11618698, upload-time = "2026-06-25T17:20:25.259Z" },
+    { url = "https://files.pythonhosted.org/packages/10/9b/5f14927848d2fd4aa891fd88d883788c5a7baba561c7874732364045708c/ruff-0.15.20-py3-none-win32.whl", hash = "sha256:ed65ef510e43a137207e0f01cfcf998aeddb1aeeda5c9d35023e910284d7cf21", size = 10857322, upload-time = "2026-06-25T17:20:28.612Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/f0/fe47c501f9dea92a26d788ff98bb5d92ed4cb4c88792c5c88af6b697dc8e/ruff-0.15.20-py3-none-win_amd64.whl", hash = "sha256:a525c81c70fb0380344dd1d8745d8cc1c890b7fc94a58d5a07bd8eb9557b8415", size = 11993274, upload-time = "2026-06-25T17:20:31.871Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/2b/9555445e1201d92b3195f45cdb153a0b68f24e0a4273f6e3d5ab46e212bb/ruff-0.15.20-py3-none-win_arm64.whl", hash = "sha256:2f5b2a6d614e8700388806a14996c40fab2c47b819ef57d790a34878858ed9ca", size = 11343498, upload-time = "2026-06-25T17:20:35.03Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR brings the `ruff` formatter in as a development depenency, and cleans up Slackbot's `pyproject.yaml` to set the configuration more accurately.

The other files in this PR are just an output of the formatter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched the Slack bot linting workflow to a dedicated script and pinned Ruff for more consistent checks.
  * Updated Ruff configuration layout; adjusted Tailwind lint to target source files and tolerate unmatched patterns.
  * Updated SSO ESLint to ignore build and coverage output paths.
* **Bug Fixes**
  * Improved Slack bot startup error messaging when required configuration is missing.
  * Simplified exception handling in Slack modal update paths without changing fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->