### PR TITLE
docs(repo): point AI agents to bundled Next.js docs via AGENTS.md

### DIFF
--- a/apps/admin/AGENTS.md
+++ b/apps/admin/AGENTS.md
@@ -1,0 +1,7 @@
+<!-- BEGIN:nextjs-agent-rules -->
+
+# Next.js: ALWAYS read docs before coding
+
+Before any Next.js work, find and read the relevant doc in `node_modules/next/dist/docs/`. Your training data is outdated — the docs are the source of truth.
+
+<!-- END:nextjs-agent-rules -->

--- a/apps/api/AGENTS.md
+++ b/apps/api/AGENTS.md
@@ -1,0 +1,7 @@
+<!-- BEGIN:nextjs-agent-rules -->
+
+# Next.js: ALWAYS read docs before coding
+
+Before any Next.js work, find and read the relevant doc in `node_modules/next/dist/docs/`. Your training data is outdated — the docs are the source of truth.
+
+<!-- END:nextjs-agent-rules -->

--- a/apps/auth/AGENTS.md
+++ b/apps/auth/AGENTS.md
@@ -1,3 +1,11 @@
+<!-- BEGIN:nextjs-agent-rules -->
+
+# Next.js: ALWAYS read docs before coding
+
+Before any Next.js work, find and read the relevant doc in `node_modules/next/dist/docs/`. Your training data is outdated — the docs are the source of truth.
+
+<!-- END:nextjs-agent-rules -->
+
 # F3 Auth -- Agent Guide
 
 > Context for AI coding agents and QA-automation agents working with the F3 SSO server.

--- a/apps/homepage/AGENTS.md
+++ b/apps/homepage/AGENTS.md
@@ -1,0 +1,7 @@
+<!-- BEGIN:nextjs-agent-rules -->
+
+# Next.js: ALWAYS read docs before coding
+
+Before any Next.js work, find and read the relevant doc in `node_modules/next/dist/docs/`. Your training data is outdated — the docs are the source of truth.
+
+<!-- END:nextjs-agent-rules -->

--- a/apps/map/AGENTS.md
+++ b/apps/map/AGENTS.md
@@ -1,0 +1,7 @@
+<!-- BEGIN:nextjs-agent-rules -->
+
+# Next.js: ALWAYS read docs before coding
+
+Before any Next.js work, find and read the relevant doc in `node_modules/next/dist/docs/`. Your training data is outdated — the docs are the source of truth.
+
+<!-- END:nextjs-agent-rules -->

--- a/apps/me/AGENTS.md
+++ b/apps/me/AGENTS.md
@@ -1,3 +1,11 @@
+<!-- BEGIN:nextjs-agent-rules -->
+
+# Next.js: ALWAYS read docs before coding
+
+Before any Next.js work, find and read the relevant doc in `node_modules/next/dist/docs/`. Your training data is outdated — the docs are the source of truth.
+
+<!-- END:nextjs-agent-rules -->
+
 # F3 Me — Agent Guide
 
 > This document provides context for AI coding agents working on the F3 Me app.


### PR DESCRIPTION
## What

Adds the Next.js **`nextjs-agent-rules`** block to every Next.js app's `AGENTS.md`, directing AI coding agents to read the version-matched documentation bundled at `node_modules/next/dist/docs/` before writing any Next.js code — instead of relying on potentially outdated training data.

## Why

This follows Next.js' official recommendation from **[How to set up your Next.js project for AI coding agents](https://nextjs.org/docs/app/guides/ai-agents)**. Next.js ships its docs inside the `next` package, matched to the installed version, so agents get accurate APIs and patterns with no network lookup. The guide prescribes exactly this delimited block:

```md
<!-- BEGIN:nextjs-agent-rules -->

# Next.js: ALWAYS read docs before coding

Before any Next.js work, find and read the relevant doc in `node_modules/next/dist/docs/`. Your training data is outdated — the docs are the source of truth.

<!-- END:nextjs-agent-rules -->
```

The `BEGIN`/`END:nextjs-agent-rules` markers delimit a Next.js-managed section. Any app-specific guidance lives outside these markers and is safe from being overwritten by future updates or the `@next/codemod agents-md` codemod.

## Changes

All 6 Next.js apps in the monorepo are now covered:

| App | Change |
| --- | --- |
| `apps/auth` | Block prepended above the existing agent guide |
| `apps/me` | Block prepended above the existing agent guide |
| `apps/admin` | New `AGENTS.md` (block only — no prior guide) |
| `apps/homepage` | New `AGENTS.md` (block only) |
| `apps/map` | New `AGENTS.md` (block only) |
| `apps/api` | New `AGENTS.md` (block only) |

`apps/slackbot` is not a Next.js app, so it is intentionally excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added standardized Next.js guidance across application development instructions.
  * Contributors are now directed to consult the relevant Next.js documentation before beginning Next.js work.
  * Guidance is clearly marked for easier maintenance and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->