### PR TITLE
chore(repo): add full version tags to digest-pinned Docker images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -305,7 +305,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres:18@sha256:22c89fe0d0f507606260237fd55e51f6137f58b2d5bcf6152242b96d9fe8f9a4
+        image: postgres:18.4-trixie@sha256:22c89fe0d0f507606260237fd55e51f6137f58b2d5bcf6152242b96d9fe8f9a4
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres

--- a/apps/slackbot/Dockerfile
+++ b/apps/slackbot/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 python:3.12-slim@sha256:423ed6ab25b1921a477529254bfeeabf5855151dc2c3141699a1bfc852199fbf
+FROM --platform=linux/amd64 python:3.12.13-slim@sha256:423ed6ab25b1921a477529254bfeeabf5855151dc2c3141699a1bfc852199fbf
 
 COPY --from=ghcr.io/astral-sh/uv:0.9.17@sha256:5cb6b54d2bc3fe2eb9a8483db958a0b9eebf9edff68adedb369df8e7b98711a2 /uv /uvx /bin/
 

--- a/apps/slackbot/scripts/Dockerfile
+++ b/apps/slackbot/scripts/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 python:3.12-slim@sha256:423ed6ab25b1921a477529254bfeeabf5855151dc2c3141699a1bfc852199fbf
+FROM --platform=linux/amd64 python:3.12.13-slim@sha256:423ed6ab25b1921a477529254bfeeabf5855151dc2c3141699a1bfc852199fbf
 
 COPY --from=ghcr.io/astral-sh/uv:0.9.17@sha256:5cb6b54d2bc3fe2eb9a8483db958a0b9eebf9edff68adedb369df8e7b98711a2 /uv /uvx /bin/
 


### PR DESCRIPTION
## Summary

Follow-up to the docker-compose.yml version-tag change: bring the two remaining digest-pinned images without a full human-readable version up to the same `name:FULL_VERSION@sha256:...` pattern.

- `.github/workflows/ci.yml` postgres service container: `postgres:18` → `postgres:18.4-trixie` (same digest docker-compose.yml already labels `18.4-trixie`, keeping the two in sync)
- `apps/slackbot/Dockerfile` + `apps/slackbot/scripts/Dockerfile`: `python:3.12-slim` → `python:3.12.13-slim`

No digests changed — the images are bit-for-bit identical; only the tags now document what each digest is. Renovate's `dockerfile`/`docker-compose` managers rewrite tag+digest together, so the tags cannot go stale (unlike trailing comments). The `python` image remains excluded from Renovate updates per `renovate.json`, so its pin stays frozen as before.

Already compliant (unchanged): `node:24.18.0-alpine` in the five app Dockerfiles, and all of `docker-compose.yml`.

## Verification

- Docker Hub tags API confirms `postgres:18.4-trixie` and `python:3.12.13-slim` resolve to exactly the pinned digests
- `docker pull python:3.12.13-slim@sha256:423ed6a...` succeeds
- CI on this PR exercises the postgres service container for real

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the application’s build and test environments to use fixed, reproducible platform images.
  - Improved consistency across continuous integration and containerized tooling.
  - No user-facing functionality or application behavior has changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->