### PR TITLE
chore(repo): hold TypeScript at 6.x in Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -44,6 +44,12 @@
       "enabled": false
     },
     {
+      "description": "Hold TypeScript at 6.x: 7.0 is the native (Go) port and is too new to adopt. Renovate rolls all 7.x into one \"to v7\" upgrade, so raise this to <7.2.0 (or drop the rule) when ready to migrate rather than closing the PR.",
+      "matchDatasources": ["npm"],
+      "matchPackageNames": ["typescript"],
+      "allowedVersions": "<7.0.0"
+    },
+    {
       "description": "Hold at <1.9.0: 1.9.0 rewired AdvancedMarker onClick to the gmp-click DOM event (upstream PR #997), dropping event.stop()/event.latLng. Shipped as a minor but breaks marker clicks at runtime. Remove this rule with the migration.",
       "matchDatasources": ["npm"],
       "matchPackageNames": ["@vis.gl/react-google-maps"],


### PR DESCRIPTION
## Summary

Adds a Renovate `packageRule` pinning `typescript` to `<7.0.0` instead of closing #699.

TypeScript 7.0 (the native Go port) is too new to adopt right now, but closing the Renovate PR is the wrong lever: `config:recommended` sets `separateMultipleMajor: false`, so all 7.x releases roll up into one "update dependency typescript to v7" upgrade sharing branch `renovate/typescript-7.x` and one PR title. Renovate's closed-PR dedup matches on branch + title, so closing #699 would silently suppress 7.1.x and every later 7.x as well.

Pinning in config instead:

- records *why* we're holding, in git, where reviewers can see it
- survives `dependencyDashboardAutoclose` (a dashboard checkbox does not)
- unblocks with a one-line edit — raise to `<7.2.0` for a controlled step, or drop the rule to take latest

Mirrors the existing `@vis.gl/react-google-maps` hold directly below it.

## Follow-up

Close #699 after this merges (Renovate won't recreate it once the rule is live).

## Commands run

- `pnpm format` — 22/22 tasks pass
- `prettier --check renovate.json` — the added block is clean. Note: this file has a **pre-existing** formatting drift (`enabledManagers` array expansion) that Prettier would collapse. It is unrelated to this change and no format task currently covers root-level JSON, so it is left as-is rather than bundled into this diff.

## Impact

None to DB, env, or runtime — Renovate config only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Constrained automatic TypeScript updates to versions below 7.0.0.
  * Deferred adoption of TypeScript 7.x until a future migration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->