### PR TITLE
fix(deps): pin patched next-auth, @auth/core, postcss to clear security-audit

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -280,8 +280,8 @@ catalogs:
       specifier: ^16.2.11
       version: 16.2.11
     next-auth:
-      specifier: 5.0.0-beta.31
-      version: 5.0.0-beta.31
+      specifier: 5.0.0-beta.32
+      version: 5.0.0-beta.32
     next-themes:
       specifier: ^0.4.6
       version: 0.4.6
@@ -384,12 +384,13 @@ catalogs:
 
 overrides:
   form-data@>=2.0.0 <2.5.6: ^4.0.6
-  '@auth/core': 0.41.2
+  '@auth/core': 0.41.3
   brace-expansion@<1.1.16: 1.1.16
   brace-expansion@>=3.0.0 <5.0.7: 5.0.7
   fast-uri@<3.1.4: 3.1.4
   sharp@<0.35.0: 0.35.3
   next@>=16.0.0 <16.2.11: 16.2.11
+  postcss@<8.5.12: ^8.5.19
 
 packageExtensionsChecksum: sha256-MiHZ3mgtOUb60KfpkAkui5ad/9eLmcQda0MiZKaTRqA=
 
@@ -628,7 +629,7 @@ importers:
         version: 16.2.11(@babel/core@7.29.0(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       next-auth:
         specifier: 'catalog:'
-        version: 5.0.0-beta.31(next@16.2.11(@babel/core@7.29.0(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(nodemailer@9.0.3)(react@19.2.7)
+        version: 5.0.0-beta.32(next@16.2.11(@babel/core@7.29.0(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(nodemailer@9.0.3)(react@19.2.7)
       react:
         specifier: 'catalog:'
         version: 19.2.7
@@ -706,8 +707,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/shared
       '@auth/core':
-        specifier: 0.41.2
-        version: 0.41.2(nodemailer@9.0.3)
+        specifier: 0.41.3
+        version: 0.41.3(nodemailer@9.0.3)
       '@t3-oss/env-nextjs':
         specifier: 'catalog:'
         version: 0.13.11(typescript@6.0.3)(zod@4.4.3)
@@ -725,7 +726,7 @@ importers:
         version: 16.2.11(@babel/core@7.29.0(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       next-auth:
         specifier: 'catalog:'
-        version: 5.0.0-beta.31(next@16.2.11(@babel/core@7.29.0(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(nodemailer@9.0.3)(react@19.2.7)
+        version: 5.0.0-beta.32(next@16.2.11(@babel/core@7.29.0(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(nodemailer@9.0.3)(react@19.2.7)
       nodemailer:
         specifier: 'catalog:'
         version: 9.0.3
@@ -891,8 +892,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/validators
       '@auth/core':
-        specifier: 0.41.2
-        version: 0.41.2(nodemailer@9.0.3)
+        specifier: 0.41.3
+        version: 0.41.3(nodemailer@9.0.3)
       '@orpc/client':
         specifier: 'catalog:'
         version: 1.14.8(@opentelemetry/api@1.9.1)
@@ -946,7 +947,7 @@ importers:
         version: 16.2.11(@babel/core@7.29.0(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       next-auth:
         specifier: 'catalog:'
-        version: 5.0.0-beta.31(next@16.2.11(@babel/core@7.29.0(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(nodemailer@9.0.3)(react@19.2.7)
+        version: 5.0.0-beta.32(next@16.2.11(@babel/core@7.29.0(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(nodemailer@9.0.3)(react@19.2.7)
       next-themes:
         specifier: 'catalog:'
         version: 0.4.6(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -1280,8 +1281,8 @@ importers:
         specifier: workspace:*
         version: link:../shared
       '@auth/core':
-        specifier: 0.41.2
-        version: 0.41.2(nodemailer@9.0.3)
+        specifier: 0.41.3
+        version: 0.41.3(nodemailer@9.0.3)
       dayjs:
         specifier: 'catalog:'
         version: 1.11.21
@@ -1296,7 +1297,7 @@ importers:
         version: 16.2.11(@babel/core@7.29.0(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@types/node@25.9.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       next-auth:
         specifier: 'catalog:'
-        version: 5.0.0-beta.31(next@16.2.11(@babel/core@7.29.0(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@types/node@25.9.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(nodemailer@9.0.3)(react@19.2.7)
+        version: 5.0.0-beta.32(next@16.2.11(@babel/core@7.29.0(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@types/node@25.9.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(nodemailer@9.0.3)(react@19.2.7)
       nodemailer:
         specifier: 'catalog:'
         version: 9.0.3
@@ -1487,7 +1488,7 @@ importers:
         version: 4.18.1
       next-auth:
         specifier: 'catalog:'
-        version: 5.0.0-beta.31(next@16.2.11(@babel/core@7.29.0(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(nodemailer@9.0.3)(react@19.2.7)
+        version: 5.0.0-beta.32(next@16.2.11(@babel/core@7.29.0(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(nodemailer@9.0.3)(react@19.2.7)
       zod:
         specifier: 'catalog:'
         version: 4.4.3
@@ -1905,14 +1906,14 @@ importers:
   tooling/typescript:
     dependencies:
       '@auth/core':
-        specifier: 0.41.2
-        version: 0.41.2(nodemailer@9.0.3)
+        specifier: 0.41.3
+        version: 0.41.3(nodemailer@9.0.3)
       '@tanstack/table-core':
         specifier: 'catalog:'
         version: 8.21.3
       next-auth:
         specifier: 'catalog:'
-        version: 5.0.0-beta.31(next@16.2.11(@babel/core@7.29.0(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@types/node@25.9.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(nodemailer@9.0.3)(react@19.2.7)
+        version: 5.0.0-beta.32(next@16.2.11(@babel/core@7.29.0(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@types/node@25.9.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(nodemailer@9.0.3)(react@19.2.7)
 
   tooling/vitest:
     devDependencies:
@@ -1973,12 +1974,12 @@ packages:
   '@asamuzakjp/nwsapi@2.3.9':
     resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
 
-  '@auth/core@0.41.2':
-    resolution: {integrity: sha512-Hx5MNBxN2fJTbJKGUKAA0wca43D0Akl3TvufY54Gn8lop7F+34vU1zA1pn0vQfIoVuLIrpfc2nkyjwIaPJMW7w==}
+  '@auth/core@0.41.3':
+    resolution: {integrity: sha512-sJ3JMHHkXMD3aOjopv7mOBTO1Ocw4b0fAEXJBz6k7YHLpYQI6C40jCUPc5fNvUKxXRXNE1/sRISA15UrwWJBTw==}
     peerDependencies:
       '@simplewebauthn/browser': ^9.0.1
       '@simplewebauthn/server': ^9.0.2
-      nodemailer: ^7.0.7
+      nodemailer: ^7.0.7 || ^8.0.5
     peerDependenciesMeta:
       '@simplewebauthn/browser':
         optional: true
@@ -6945,13 +6946,13 @@ packages:
   neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
 
-  next-auth@5.0.0-beta.31:
-    resolution: {integrity: sha512-1OBgCKPzo+S7UWWMp3xgvGvIJ0OpV7B3vR4ZDRqD9a4Ch+OT6dakLXG9ivhtmIWVa71nTSXattOHyCg8sNi8/Q==}
+  next-auth@5.0.0-beta.32:
+    resolution: {integrity: sha512-CGlChIEWZ6LltNVxrE5yiySMID+Idpmry47JYA5lLwgD8Sx02a8M65VL0TWVz9nbnOioS/tCW/rP/0+mE7Qp4Q==}
     peerDependencies:
       '@simplewebauthn/browser': ^9.0.1
       '@simplewebauthn/server': ^9.0.2
       next: 16.2.11
-      nodemailer: ^7.0.7
+      nodemailer: ^7.0.7 || ^8.0.5
       react: ^18.2.0 || ^19.0.0
     peerDependenciesMeta:
       '@simplewebauthn/browser':
@@ -7201,7 +7202,7 @@ packages:
     engines: {node: '>= 18'}
     peerDependencies:
       jiti: '>=1.21.0'
-      postcss: '>=8.0.9'
+      postcss: ^8.5.19
       tsx: ^4.8.1
       yaml: ^2.4.2
     peerDependenciesMeta:
@@ -7213,10 +7214,6 @@ packages:
         optional: true
       yaml:
         optional: true
-
-  postcss@8.4.31:
-    resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
-    engines: {node: ^10 || ^12 || >=14}
 
   postcss@8.5.20:
     resolution: {integrity: sha512-lW616l85ucIQL+FocMmL7pQFPqBmwejrCMg+iPxyImlrANNJG9NHq/RkyCZopDhd8C3LA03PHRJDjkbGu8vvug==}
@@ -8327,7 +8324,7 @@ snapshots:
 
   '@asamuzakjp/nwsapi@2.3.9': {}
 
-  '@auth/core@0.41.2(nodemailer@9.0.3)':
+  '@auth/core@0.41.3(nodemailer@9.0.3)':
     dependencies:
       '@panva/hkdf': 1.2.1
       jose: 6.2.3
@@ -13095,17 +13092,17 @@ snapshots:
 
   neo-async@2.6.2: {}
 
-  next-auth@5.0.0-beta.31(next@16.2.11(@babel/core@7.29.0(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(nodemailer@9.0.3)(react@19.2.7):
+  next-auth@5.0.0-beta.32(next@16.2.11(@babel/core@7.29.0(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(nodemailer@9.0.3)(react@19.2.7):
     dependencies:
-      '@auth/core': 0.41.2(nodemailer@9.0.3)
+      '@auth/core': 0.41.3(nodemailer@9.0.3)
       next: 16.2.11(@babel/core@7.29.0(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react: 19.2.7
     optionalDependencies:
       nodemailer: 9.0.3
 
-  next-auth@5.0.0-beta.31(next@16.2.11(@babel/core@7.29.0(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@types/node@25.9.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(nodemailer@9.0.3)(react@19.2.7):
+  next-auth@5.0.0-beta.32(next@16.2.11(@babel/core@7.29.0(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@types/node@25.9.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(nodemailer@9.0.3)(react@19.2.7):
     dependencies:
-      '@auth/core': 0.41.2(nodemailer@9.0.3)
+      '@auth/core': 0.41.3(nodemailer@9.0.3)
       next: 16.2.11(@babel/core@7.29.0(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@types/node@25.9.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react: 19.2.7
     optionalDependencies:
@@ -13122,7 +13119,7 @@ snapshots:
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.10.16
       caniuse-lite: 1.0.30001793
-      postcss: 8.4.31
+      postcss: 8.5.20
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
       styled-jsx: 5.1.6(@babel/core@7.29.0(supports-color@8.1.1))(react@19.2.7)
@@ -13148,7 +13145,7 @@ snapshots:
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.10.16
       caniuse-lite: 1.0.30001793
-      postcss: 8.4.31
+      postcss: 8.5.20
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
       styled-jsx: 5.1.6(@babel/core@7.29.0(supports-color@8.1.1))(react@19.2.7)
@@ -13442,12 +13439,6 @@ snapshots:
       postcss: 8.5.20
       tsx: 4.23.1
       yaml: 2.9.0
-
-  postcss@8.4.31:
-    dependencies:
-      nanoid: 3.3.16
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
 
   postcss@8.5.20:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,7 +4,7 @@ packages:
   - tooling/*
 
 catalog:
-  "@auth/core": 0.41.2
+  "@auth/core": 0.41.3
   "@commitlint/cli": ^21.2.1
   "@commitlint/config-conventional": ^21.2.0
   "@commitlint/cz-commitlint": ^21.2.0
@@ -96,7 +96,7 @@ catalog:
   lottie-react: ^2.4.1
   lucide-react: ^1.24.0
   next: ^16.2.11
-  next-auth: 5.0.0-beta.31
+  next-auth: 5.0.0-beta.32
   next-themes: ^0.4.6
   nodemailer: ^9.0.3
   pg: ^8.22.0
@@ -135,7 +135,7 @@ catalog:
   zustand: ^5.0.14
 overrides:
   "form-data@>=2.0.0 <2.5.6": "^4.0.6"
-  "@auth/core": "0.41.2"
+  "@auth/core": "0.41.3" # GHSA-7rqj-j65f-68wh / GHSA-xmf8-cvqr-rfgj (Auth.js email normalizer & getToken DoS)
   # Force patched versions of transitive deps flagged by `pnpm audit --prod
   # --audit-level=high`. Scoped to the vulnerable ranges so unaffected
   # consumers are untouched. Remove an entry once every dependent has upgraded.
@@ -144,6 +144,7 @@ overrides:
   "fast-uri@<3.1.4": "3.1.4" # host confusion via failed IDN canonicalization
   "sharp@<0.35.0": "0.35.3" # inherited libvips vulnerabilities
   "next@>=16.0.0 <16.2.11": "16.2.11" # GHSA-89xv-2m56-2m9x / GHSA-p9j2-gv94-2wf4 (SSRF in rewrites); covers transitive geist>next & @scalar>next
+  "postcss@<8.5.12": "^8.5.19" # GHSA-6g55-p6wh-862q (sourceMappingURL arbitrary file read)
 peerDependencyRules:
   allowedVersions:
     eslint-plugin-react>eslint: "10"


### PR DESCRIPTION
## Summary

Bumps Auth.js and postcss to their patched releases to resolve **four** high/critical advisories flagged by the `security-audit` CI job (`pnpm audit --prod --audit-level=high`). All changes are confined to `pnpm-workspace.yaml` (+ the regenerated `pnpm-lock.yaml`) — the repo's `catalog:` / `overrides:` convention under `catalogMode: strict`.

| Advisory | Severity | Package | Fix |
|---|---|---|---|
| [GHSA-8fpg-xm3f-6cx3](https://github.com/advisories/GHSA-8fpg-xm3f-6cx3) | Critical 9.1 | `next-auth` v5 — auth **fails open** on config error (`!!auth` true for all requests) | `next-auth@5.0.0-beta.32` |
| [GHSA-7rqj-j65f-68wh](https://github.com/advisories/GHSA-7rqj-j65f-68wh) | Critical 9.1 | Auth.js email normalizer homoglyph → passwordless-link account takeover | `@auth/core@0.41.3`, `next-auth@5.0.0-beta.32` |
| [GHSA-xmf8-cvqr-rfgj](https://github.com/advisories/GHSA-xmf8-cvqr-rfgj) | High 7.5 | `getToken()` unhandled throw on malformed Bearer header (DoS) | `@auth/core@0.41.3`, `next-auth@5.0.0-beta.32` |
| [GHSA-6g55-p6wh-862q](https://github.com/advisories/GHSA-6g55-p6wh-862q) | High 7.5 | `postcss` ≤ 8.5.11 `sourceMappingURL` arbitrary file read | `postcss` ≥ 8.5.12 |

## Changes (`pnpm-workspace.yaml`)

- **catalog** `@auth/core` `0.41.2 → 0.41.3`; `next-auth` `5.0.0-beta.31 → 5.0.0-beta.32`
- **overrides** existing unscoped `@auth/core` bumped to `0.41.3` (leaving it at `0.41.2` would pin the transitive copy back down)
- **overrides** new scoped `"postcss@<8.5.12": "^8.5.19"` — the direct catalog copy was already patched (`8.5.20`); this forces a stale **transitive** `postcss@8.4.31` up onto that same resolution (dedupes rather than adding a third version)

`next-auth` needs no override — it's only ever a direct catalog dep, fully covered by the catalog bump under `catalogMode: strict`.

## Verification

- ✅ `pnpm audit --prod --audit-level=high` → exit 0; none of the four GHSA IDs remain (`pnpm audit` full tree: only 2 low + 2 moderate, below the gate)
- ✅ Lockfile resolves single patched versions: `@auth/core@0.41.3`, `next-auth@5.0.0-beta.32`, `postcss@8.5.20` (no lingering `0.41.2` / `beta.31` / `8.4.31`)
- ✅ `pnpm typecheck` (22/22)
- ✅ `pnpm lint` (all JS projects; the `f3-slackbot` failure is a pre-existing Python-env/bash-script issue unrelated to this change)
- ✅ `pnpm build` for `f3-auth` + `f3-map` (exercises the NextAuth routes and the postcss/tailwind pipeline)

**Recommended manual follow-up:** a local sign-in / MFA smoke test against `apps/auth` to confirm the `beta.31 → beta.32` bump didn't alter runtime auth behavior (CI runs the full `pnpm test` suite).

## Impact

- No DB migrations, no env-var changes, no source changes — dependency pins only.
- The scoped overrides can be removed later once every dependent has upgraded, per the block's header comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)