### PR TITLE
fix(slackbot): preblast hotfixes

### DIFF
--- a/apps/slackbot/features/calendar/__init__.py
+++ b/apps/slackbot/features/calendar/__init__.py
@@ -8,7 +8,7 @@ PREBLAST_MESSAGE_ACTION_ELEMENTS = [
 ]
 
 
-def get_preblast_action_buttons(has_q: bool = True, event_instance_id: int = None) -> List[orm.ButtonElement]:
+def get_preblast_action_buttons(has_q: bool = True, event_instance_id: int | None = None) -> List[orm.ButtonElement]:
     buttons = [
         orm.ButtonElement(label=":hc: HC/Un-HC", action=actions.EVENT_PREBLAST_HC_UN_HC),
         orm.ButtonElement(label=":pencil: Edit Preblast", action=actions.EVENT_PREBLAST_EDIT, value="Edit Preblast"),
@@ -31,7 +31,7 @@ def get_preblast_action_buttons(has_q: bool = True, event_instance_id: int = Non
     return buttons
 
 
-def get_preblast_action_blocks(has_q: bool = True, event_instance_id: int = None) -> List[orm.BaseBlock]:
+def get_preblast_action_blocks(has_q: bool = True, event_instance_id: int | None = None) -> List[orm.BaseBlock]:
     overflow_labels = [
         ":pencil: Edit Preblast",
         ":heavy_plus_sign: New Preblast",

--- a/apps/slackbot/features/calendar/event_instance.py
+++ b/apps/slackbot/features/calendar/event_instance.py
@@ -49,6 +49,7 @@ CALENDAR_ADD_EVENT_INSTANCE_START_TIME = "calendar_add_event_instance_start_time
 CALENDAR_ADD_EVENT_INSTANCE_END_TIME = "calendar_add_event_instance_end_time"
 CALENDAR_ADD_EVENT_INSTANCE_NAME = "calendar_add_event_instance_name"
 CALENDAR_ADD_EVENT_INSTANCE_HIGHLIGHT = "calendar_add_event_instance_highlight"
+CALENDAR_ADD_EVENT_INSTANCE_PREBLAST_CHANNEL = "calendar_add_event_instance_preblast_channel"
 CALENDAR_ADD_EVENT_INSTANCE_DOW = "calendar_add_event_instance_dow"
 CALENDAR_ADD_EVENT_AO = "calendar_add_event_ao"
 CALENDAR_ADD_EVENT_INSTANCE_FREQUENCY = "calendar_add_event_instance_frequency"
@@ -64,6 +65,7 @@ EVENT_CLOSE_CALLBACK_ID = "event_close_callback_id"
 
 META_DO_NOT_SEND_AUTO_PREBLASTS = "do_not_send_auto_preblasts"
 META_EXCLUDE_FROM_PAX_VAULT = "exclude_from_pax_vault"
+META_PREBLAST_CHANNEL_ID = "preblast_channel_id"
 
 
 # ---------------------------------------------------------------------------
@@ -139,6 +141,16 @@ def build_event_instance_add_form(
                 optional=False,
             ),
         )
+        form.blocks.insert(
+            -1,
+            orm.InputBlock(
+                label="Preblast Destination Channel",
+                action=CALENDAR_ADD_EVENT_INSTANCE_PREBLAST_CHANNEL,
+                element=orm.ChannelsSelectElement(placeholder="Select a channel..."),
+                optional=True,
+                hint="If selected, this preblast will be posted to this channel instead of the default.",
+            ),
+        )
         parent_metadata.update({"is_preblast": "True"})
 
     ao_service = _build_ao_service()
@@ -209,6 +221,10 @@ def build_event_instance_add_form(
             initial_values[CALENDAR_ADD_EVENT_INSTANCE_TAG] = [
                 str(edit_event_instance.event_tag_ids[0])
             ]  # TODO: handle multiple event tags
+        if safe_get(edit_event_instance.meta, META_PREBLAST_CHANNEL_ID):
+            initial_values[CALENDAR_ADD_EVENT_INSTANCE_PREBLAST_CHANNEL] = str(
+                edit_event_instance.meta[META_PREBLAST_CHANNEL_ID]
+            )
 
     # This is triggered when the AO is selected — defaults are loaded for the location
     action_id = safe_get(body, "actions", 0, "action_id")
@@ -264,6 +280,16 @@ def handle_event_instance_add(
                 optional=False,
             ),
         )
+        form.blocks.insert(
+            -1,
+            orm.InputBlock(
+                label="Preblast Destination Channel",
+                action=CALENDAR_ADD_EVENT_INSTANCE_PREBLAST_CHANNEL,
+                element=orm.ChannelsSelectElement(placeholder="Select a channel..."),
+                optional=True,
+                hint="If selected, this preblast will be posted to this channel instead of the default.",
+            ),
+        )
     form_data = form.get_selected_values(body)
     slack_user_id = safe_get(body, "user", "id") or safe_get(body, "user_id")
 
@@ -289,6 +315,12 @@ def handle_event_instance_add(
         merged_meta[META_DO_NOT_SEND_AUTO_PREBLASTS] = True
     else:
         merged_meta.pop(META_DO_NOT_SEND_AUTO_PREBLASTS, None)
+    if CALENDAR_ADD_EVENT_INSTANCE_PREBLAST_CHANNEL in form_data:
+        preblast_channel_id = safe_get(form_data, CALENDAR_ADD_EVENT_INSTANCE_PREBLAST_CHANNEL)
+        if preblast_channel_id:
+            merged_meta[META_PREBLAST_CHANNEL_ID] = preblast_channel_id
+        else:
+            merged_meta.pop(META_PREBLAST_CHANNEL_ID, None)
 
     # Resolve end time
     if safe_get(form_data, CALENDAR_ADD_EVENT_INSTANCE_END_TIME):

--- a/apps/slackbot/features/calendar/event_preblast.py
+++ b/apps/slackbot/features/calendar/event_preblast.py
@@ -519,6 +519,7 @@ def _build_and_show_preblast_form(
         existing_preblast_ts=record.preblast_ts,
         preblast_moleskin_template=region_record.preblast_moleskin_template,
         initial_coq_slack_ids=initial_coq_slack_ids,
+        user_is_q=preblast_info.user_is_q,
     )
 
     metadata = {

--- a/apps/slackbot/features/calendar/event_preblast.py
+++ b/apps/slackbot/features/calendar/event_preblast.py
@@ -13,6 +13,7 @@ Exported function names are preserved for routing compatibility with
 from __future__ import annotations
 
 import json
+import logging
 import random
 import time
 from dataclasses import dataclass
@@ -784,6 +785,7 @@ def send_preblast(
     Uses ``PreblastService.decide_post_mode()`` and ``persist_posted_preblast()``
     to handle all post-mode scenarios.
     """
+    logger = logger or logging.getLogger(__name__)
     outcome = "success" # used for logging and user feedback
     slack_user_id = safe_get(body, "user", "id") or safe_get(body, "user_id")
     preblast_info = build_preblast_info(body, client, logger, context, region_record, event_instance_id)
@@ -943,14 +945,16 @@ def send_preblast(
         logger=logger,
     )
 
-    update_submission_wait_view(
-        client=client,
-        title="Complete!" if outcome == "success" else "Error",
-        text=user_msg,
-        level=constants.AlertLevel.SUCCESS if outcome == "success" else constants.AlertLevel.ERROR,
-        logger=logger,
-        view_id=safe_get(body, "submission_view_id") or safe_get(body, "view", "id"),
-    )
+    submission_view_id = safe_get(body, "submission_view_id") or safe_get(body, "view", "id")
+    if submission_view_id:
+        update_submission_wait_view(
+            client=client,
+            title="Complete!" if outcome == "success" else "Error",
+            text=user_msg,
+            level=constants.AlertLevel.SUCCESS if outcome == "success" else constants.AlertLevel.ERROR,
+            logger=logger,
+            view_id=submission_view_id,
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -967,6 +971,7 @@ def build_preblast_info(
     event_instance_id: int = None,
 ) -> PreblastInfo:
     """Build preblast info using API services instead of DbManager."""
+    logger = logger or logging.getLogger(__name__)
     event_svc = _build_event_instance_service()
     att_svc = _build_attendance_service()
 

--- a/apps/slackbot/features/calendar/preblast_views.py
+++ b/apps/slackbot/features/calendar/preblast_views.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from typing import Any, Iterable
 
-from slack_sdk.models.blocks import InputBlock, SectionBlock
+from slack_sdk.models.blocks import ActionsBlock, ButtonElement, InputBlock, SectionBlock
 from slack_sdk.models.blocks.basic_components import MarkdownTextObject, PlainTextObject
 from slack_sdk.models.blocks.block_elements import (
     ChannelSelectElement,
@@ -62,6 +62,7 @@ class PreblastViews:
         existing_preblast_ts: int | float | None = None,
         preblast_moleskin_template: Any | None = None,
         initial_coq_slack_ids: list[str] | None = None,
+        user_is_q: bool = False,
     ) -> SdkBlockView:
         """Build the editable preblast form modal as an ``SdkBlockView``.
 
@@ -137,6 +138,19 @@ class PreblastViews:
                 block_id=actions.EVENT_PREBLAST_COQS,
             )
         )
+
+        if user_is_q:
+            blocks.append(
+                ActionsBlock(
+                    elements=[
+                        ButtonElement(
+                            text=":no_entry_sign: Take myself off Q",
+                            action_id=actions.EVENT_PREBLAST_REMOVE_Q,
+                            value=str(event.id),
+                        )
+                    ]
+                )
+            )
 
         # ── Event Tag ────────────────────────────────────────────────────
         tag_options = as_selector_options(

--- a/apps/slackbot/features/calendar/preblast_views.py
+++ b/apps/slackbot/features/calendar/preblast_views.py
@@ -110,7 +110,7 @@ class PreblastViews:
                     placeholder="Select a location",
                     options=loc_options,
                 ),
-                optional=False,
+                optional=True,
                 block_id=actions.EVENT_PREBLAST_LOCATION,
             )
         )
@@ -332,10 +332,7 @@ class PreblastViews:
                 )
             )
 
-            event_lines = "\n".join(
-                f"• {r.start_date} {r.name or 'Untitled'}"
-                for r in upcoming_events[:max_buttons]
-            )
+            event_lines = "\n".join(f"• {r.start_date} {r.name or 'Untitled'}" for r in upcoming_events[:max_buttons])
             blocks.append(
                 SectionBlock(
                     text=PlainTextObject(text=event_lines),

--- a/apps/slackbot/scripts/auto_preblast_send.py
+++ b/apps/slackbot/scripts/auto_preblast_send.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import ssl
 import sys
@@ -30,6 +31,8 @@ from sqlalchemy.orm import aliased
 from features.calendar import event_preblast
 from utilities.database.orm import SlackSettings
 from utilities.helper_functions import current_date_cst, safe_get
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -163,9 +166,10 @@ def send_automated_preblasts(force: bool = False):
                 event_instance_id=preblast.event.id,
                 region_record=preblast.slack_settings,
                 client=slack_client,
+                logger=logger,
             )
-        except Exception as e:
-            print(f"Error sending preblast for event {preblast.event.id}: {e}")
+        except Exception:
+            logger.exception("Error sending preblast for event %s", preblast.event.id)
             continue
 
 

--- a/apps/slackbot/tests/features/calendar/test_event_instance.py
+++ b/apps/slackbot/tests/features/calendar/test_event_instance.py
@@ -2,6 +2,7 @@ import os
 import sys
 import unittest
 from datetime import date
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../..")))
@@ -9,8 +10,20 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../.
 from application.event_instance import EventInstanceData
 from application.event_instance.service import EventInstanceService
 from features.calendar.event_instance import (
+    CALENDAR_ADD_EVENT_INSTANCE_AO,
+    CALENDAR_ADD_EVENT_INSTANCE_END_TIME,
+    CALENDAR_ADD_EVENT_INSTANCE_LOCATION,
+    CALENDAR_ADD_EVENT_INSTANCE_NAME,
+    CALENDAR_ADD_EVENT_INSTANCE_PREBLAST,
+    CALENDAR_ADD_EVENT_INSTANCE_PREBLAST_CHANNEL,
+    CALENDAR_ADD_EVENT_INSTANCE_START_DATE,
+    CALENDAR_ADD_EVENT_INSTANCE_START_TIME,
+    CALENDAR_ADD_EVENT_INSTANCE_TYPE,
+    META_PREBLAST_CHANNEL_ID,
     _build_event_instance_service,
+    build_event_instance_add_form,
     build_event_instance_list_form,
+    handle_event_instance_add,
     handle_event_instance_close,
     handle_event_instance_edit_delete,
     manage_event_instances,
@@ -670,6 +683,127 @@ class HandleEventInstanceEditDeleteTest(unittest.TestCase):
         # Close action opens the close-reason modal — views_update IS called, close_instance is NOT
         client.views_update.assert_called_once()
         mock_service.close_instance.assert_not_called()
+
+
+class EventInstancePreblastChannelTest(unittest.TestCase):
+    def _region_record(self):
+        r = MagicMock()
+        r.org_id = 10
+        return r
+
+    @patch("features.calendar.event_instance._build_event_tag_service")
+    @patch("features.calendar.event_instance._build_event_type_service")
+    @patch("features.calendar.event_instance._build_location_service")
+    @patch("features.calendar.event_instance._build_ao_service")
+    def test_unscheduled_preblast_form_includes_channel_selector(
+        self,
+        mock_build_ao,
+        mock_build_location,
+        mock_build_event_type,
+        mock_build_event_tag,
+    ):
+        mock_build_ao.return_value.get_region_aos.return_value = [SimpleNamespace(id=10, name="Alpha")]
+        mock_build_location.return_value.get_org_locations.return_value = []
+        mock_build_event_type.return_value.get_all_event_types_for_org.return_value = [
+            SimpleNamespace(id=5, name="Bootcamp")
+        ]
+        mock_build_event_tag.return_value.get_all_tags_for_org.return_value = []
+
+        client = MagicMock()
+        body = {"trigger_id": "T1", "view": {"private_metadata": "{}"}}
+        build_event_instance_add_form(body, client, MagicMock(), {}, self._region_record(), new_preblast=True)
+
+        view = client.views_push.call_args.kwargs["view"]
+        channel_block = next(
+            b for b in view["blocks"] if b.get("block_id") == CALENDAR_ADD_EVENT_INSTANCE_PREBLAST_CHANNEL
+        )
+        self.assertEqual(channel_block["element"]["type"], "channels_select")
+        self.assertTrue(channel_block["optional"])
+
+    @patch("features.calendar.event_instance.event_preblast.send_preblast")
+    @patch("features.calendar.event_instance.get_user")
+    @patch("features.calendar.event_instance.DbManager.create_record")
+    @patch("features.calendar.event_instance._build_event_instance_service")
+    def test_unscheduled_preblast_channel_saved_to_meta(
+        self,
+        mock_build_service,
+        mock_create_record,
+        mock_get_user,
+        mock_send_preblast,
+    ):
+        service = MagicMock()
+        service.create_instance.return_value = _make_instance(id=42)
+        mock_build_service.return_value = service
+        mock_get_user.return_value = SimpleNamespace(user_id=99)
+
+        body = {
+            "user": {"id": "U123"},
+            "view": {
+                "private_metadata": '{"is_preblast": "True"}',
+                "blocks": [
+                    {"block_id": CALENDAR_ADD_EVENT_INSTANCE_LOCATION, "element": {}},
+                    {"block_id": CALENDAR_ADD_EVENT_INSTANCE_TYPE, "element": {}},
+                ],
+                "state": {
+                    "values": {
+                        CALENDAR_ADD_EVENT_INSTANCE_AO: {
+                            CALENDAR_ADD_EVENT_INSTANCE_AO: {
+                                "type": "static_select",
+                                "selected_option": {"value": "10"},
+                            }
+                        },
+                        CALENDAR_ADD_EVENT_INSTANCE_LOCATION: {
+                            CALENDAR_ADD_EVENT_INSTANCE_LOCATION: {
+                                "type": "static_select",
+                                "selected_option": {"value": "20"},
+                            }
+                        },
+                        CALENDAR_ADD_EVENT_INSTANCE_TYPE: {
+                            CALENDAR_ADD_EVENT_INSTANCE_TYPE: {
+                                "type": "static_select",
+                                "selected_option": {"value": "5"},
+                            }
+                        },
+                        CALENDAR_ADD_EVENT_INSTANCE_START_DATE: {
+                            CALENDAR_ADD_EVENT_INSTANCE_START_DATE: {
+                                "type": "datepicker",
+                                "selected_date": "2026-07-25",
+                            }
+                        },
+                        CALENDAR_ADD_EVENT_INSTANCE_START_TIME: {
+                            CALENDAR_ADD_EVENT_INSTANCE_START_TIME: {"type": "timepicker", "selected_time": "06:00"}
+                        },
+                        CALENDAR_ADD_EVENT_INSTANCE_END_TIME: {
+                            CALENDAR_ADD_EVENT_INSTANCE_END_TIME: {"type": "timepicker", "selected_time": "07:00"}
+                        },
+                        CALENDAR_ADD_EVENT_INSTANCE_NAME: {
+                            CALENDAR_ADD_EVENT_INSTANCE_NAME: {"type": "plain_text_input", "value": "Pop Up"}
+                        },
+                        CALENDAR_ADD_EVENT_INSTANCE_PREBLAST: {
+                            CALENDAR_ADD_EVENT_INSTANCE_PREBLAST: {
+                                "type": "rich_text_input",
+                                "rich_text_value": {"elements": []},
+                            }
+                        },
+                        CALENDAR_ADD_EVENT_INSTANCE_PREBLAST_CHANNEL: {
+                            CALENDAR_ADD_EVENT_INSTANCE_PREBLAST_CHANNEL: {
+                                "type": "channels_select",
+                                "selected_channel": "CSELECTED",
+                            }
+                        },
+                    }
+                },
+            },
+        }
+
+        handle_event_instance_add(body, MagicMock(), MagicMock(), {}, self._region_record())
+
+        self.assertEqual(
+            service.create_instance.call_args.kwargs["meta"],
+            {META_PREBLAST_CHANNEL_ID: "CSELECTED"},
+        )
+        mock_create_record.assert_called_once()
+        mock_send_preblast.assert_called_once()
 
 
 class HandleEventInstanceCloseTest(unittest.TestCase):

--- a/apps/slackbot/tests/features/calendar/test_preblast_views.py
+++ b/apps/slackbot/tests/features/calendar/test_preblast_views.py
@@ -9,6 +9,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../.
 from application.attendance import CO_Q_TYPE_ID, HC_TYPE_ID, Q_TYPE_ID, AttendanceData
 from application.event_instance import EventInstanceData
 from application.preblast.service import PreblastService
+from features.calendar import get_preblast_action_blocks
 from features.calendar.event_preblast import build_preblast_info, handle_event_preblast_edit
 from features.calendar.preblast_views import PREBLAST_CHANNEL_SELECTOR, PreblastViews
 from utilities import constants
@@ -54,7 +55,7 @@ class PreblastViewsTest(unittest.TestCase):
     def setUp(self):
         self.service = PreblastService()
 
-    def _build_form(self, event, *, default_channel_id="CDEFAULT", existing_preblast_ts=None, **kw):
+    def _build_form(self, event, *, default_channel_id: str | None = "CDEFAULT", existing_preblast_ts=None, **kw):
         return PreblastViews.build_preblast_form(
             event,
             locations=_locations(),
@@ -156,8 +157,7 @@ class PreblastViewsTest(unittest.TestCase):
         self.assertIn(actions.EVENT_PREBLAST_MOLESKINE_EDIT, block_ids)
         # Check that the initial value was set
         rich_block = next(
-            b for b in result.blocks
-            if getattr(b, "block_id", None) == actions.EVENT_PREBLAST_MOLESKINE_EDIT
+            b for b in result.blocks if b.block_id == actions.EVENT_PREBLAST_MOLESKINE_EDIT
         )
         self.assertIsNotNone(rich_block.element.initial_value)
 
@@ -165,10 +165,7 @@ class PreblastViewsTest(unittest.TestCase):
         event = _event()
         result = self._build_form(event, initial_coq_slack_ids=["UCOQ1", "UCOQ2"])
 
-        coq_block = next(
-            b for b in result.blocks
-            if getattr(b, "block_id", None) == actions.EVENT_PREBLAST_COQS
-        )
+        coq_block = next(b for b in result.blocks if b.block_id == actions.EVENT_PREBLAST_COQS)
         self.assertEqual(coq_block.element.initial_users, ["UCOQ1", "UCOQ2"])
 
     def test_build_preblast_form_uses_moleskin_template_fallback(self):
@@ -180,8 +177,7 @@ class PreblastViewsTest(unittest.TestCase):
             preblast_moleskin_template={"type": "rich_text", "elements": [{"type": "text", "text": "template"}]},
         )
         rich_block = next(
-            b for b in result.blocks
-            if getattr(b, "block_id", None) == actions.EVENT_PREBLAST_MOLESKINE_EDIT
+            b for b in result.blocks if b.block_id == actions.EVENT_PREBLAST_MOLESKINE_EDIT
         )
         self.assertIsNotNone(rich_block.element.initial_value)
 
@@ -195,6 +191,30 @@ class PreblastViewsTest(unittest.TestCase):
         result = PreblastViews.build_select_form([])
         block_ids = [getattr(b, "block_id", None) for b in result.blocks]
         self.assertIn("preblast_select_empty", block_ids)
+
+    def test_preblast_action_blocks_do_not_show_remove_q(self):
+        blocks = [block.as_form_field() for block in get_preblast_action_blocks(has_q=True, event_instance_id=42)]
+        action_ids = [
+            element["action_id"]
+            for block in blocks
+            for element in block.get("elements", [])
+            if element.get("type") == "button"
+        ]
+
+        self.assertNotIn(actions.EVENT_PREBLAST_TAKE_Q, action_ids)
+        self.assertNotIn(actions.EVENT_PREBLAST_REMOVE_Q, action_ids)
+
+    def test_build_preblast_form_shows_remove_q_button_for_q(self):
+        event = _event()
+        result = self._build_form(event, user_is_q=True)
+
+        action_ids = [
+            getattr(element, "action_id", None)
+            for block in result.blocks
+            for element in getattr(block, "elements", [])
+        ]
+
+        self.assertIn(actions.EVENT_PREBLAST_REMOVE_Q, action_ids)
 
     @patch("f3_data_models.utils.DbManager.find_records")
     @patch("features.calendar.event_preblast._build_attendance_service")


### PR DESCRIPTION
Cleaning up a few issues from the preblast refactor:

- Adding channel selector to unscheduled preblast form
- Added 'Take Myself off Q' button back on preblast form
- Patched an issue for autopreblasts
- Made Location optional on preblast form

I'd like to move these through quickly if we can.
