### PR TITLE
fix(repo): patch brace-expansion GHSA-mh99-v99m-4gvg

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -392,7 +392,7 @@ overrides:
   form-data@>=2.0.0 <2.5.6: ^4.0.6
   '@auth/core': 0.41.3
   brace-expansion@<1.1.16: 1.1.16
-  brace-expansion@>=3.0.0 <5.0.7: 5.0.7
+  brace-expansion@>=3.0.0 <5.0.8: 5.0.8
   fast-uri@<3.1.4: 3.1.4
   sharp@<0.35.0: 0.35.3
   next@>=16.0.0 <16.2.11: 16.2.11
@@ -1793,10 +1793,19 @@ importers:
         version: 6.0.3
 
   tooling/eslint:
-    dependencies:
+    devDependencies:
+      '@acme/prettier-config':
+        specifier: workspace:*
+        version: link:../prettier
+      '@acme/tsconfig':
+        specifier: workspace:*
+        version: link:../typescript
       '@next/eslint-plugin-next':
         specifier: 'catalog:'
         version: 16.2.10
+      eslint:
+        specifier: 'catalog:'
+        version: 10.7.0(jiti@2.7.0)(supports-color@8.1.1)
       eslint-config-turbo:
         specifier: 'catalog:'
         version: 2.10.5(eslint@10.7.0(jiti@2.7.0)(supports-color@8.1.1))(turbo@2.10.5)
@@ -1812,25 +1821,15 @@ importers:
       eslint-plugin-react-hooks:
         specifier: 'catalog:'
         version: 7.1.1(eslint@10.7.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)
-      typescript-eslint:
-        specifier: 'catalog:'
-        version: 8.64.0(eslint@10.7.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
-    devDependencies:
-      '@acme/prettier-config':
-        specifier: workspace:*
-        version: link:../prettier
-      '@acme/tsconfig':
-        specifier: workspace:*
-        version: link:../typescript
-      eslint:
-        specifier: 'catalog:'
-        version: 10.7.0(jiti@2.7.0)(supports-color@8.1.1)
       prettier:
         specifier: 'catalog:'
         version: 3.9.5
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
+      typescript-eslint:
+        specifier: 'catalog:'
+        version: 8.64.0(eslint@10.7.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
 
   tooling/playwright:
     devDependencies:
@@ -5373,9 +5372,9 @@ packages:
   brace-expansion@1.1.16:
     resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
 
-  brace-expansion@5.0.7:
-    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.8:
+    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+    engines: {node: 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -11423,7 +11422,7 @@ snapshots:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@5.0.7:
+  brace-expansion@5.0.8:
     dependencies:
       balanced-match: 4.0.4
 
@@ -13134,7 +13133,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.8
 
   minimatch@3.1.5:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -141,8 +141,12 @@ overrides:
   # Force patched versions of transitive deps flagged by `pnpm audit --prod
   # --audit-level=high`. Scoped to the vulnerable ranges so unaffected
   # consumers are untouched. Remove an entry once every dependent has upgraded.
+  # 1.x cannot be forced to 5.x: minimatch@3 does `require('brace-expansion')()`
+  # and v5 exports only a named `expand`. No 1.x/2.x/3.x/4.x backport exists for
+  # GHSA-mh99-v99m-4gvg, so the two eslint-plugin paths on minimatch@3 are dev-only
+  # and excluded from the prod audit via tooling/eslint devDependencies instead.
   "brace-expansion@<1.1.16": "1.1.16" # GHSA-3jxr-9vmj-r5cp (DoS)
-  "brace-expansion@>=3.0.0 <5.0.7": "5.0.7" # GHSA-3jxr-9vmj-r5cp (DoS)
+  "brace-expansion@>=3.0.0 <5.0.8": "5.0.8" # GHSA-mh99-v99m-4gvg (DoS)
   "fast-uri@<3.1.4": "3.1.4" # host confusion via failed IDN canonicalization
   "sharp@<0.35.0": "0.35.3" # inherited libvips vulnerabilities
   "next@>=16.0.0 <16.2.11": "16.2.11" # GHSA-89xv-2m56-2m9x / GHSA-p9j2-gv94-2wf4 (SSRF in rewrites); covers transitive geist>next & @scalar>next

--- a/tooling/eslint/package.json
+++ b/tooling/eslint/package.json
@@ -20,21 +20,19 @@
     "lint": "eslint .",
     "typecheck": "tsc --noEmit"
   },
-  "dependencies": {
+  "devDependencies": {
+    "@acme/prettier-config": "workspace:*",
+    "@acme/tsconfig": "workspace:*",
     "@next/eslint-plugin-next": "catalog:",
+    "eslint": "catalog:",
     "eslint-config-turbo": "catalog:",
     "eslint-plugin-import-x": "catalog:",
     "eslint-plugin-jsx-a11y": "catalog:",
     "eslint-plugin-react": "catalog:",
     "eslint-plugin-react-hooks": "catalog:",
-    "typescript-eslint": "catalog:"
-  },
-  "devDependencies": {
-    "@acme/prettier-config": "workspace:*",
-    "@acme/tsconfig": "workspace:*",
-    "eslint": "catalog:",
     "prettier": "catalog:",
-    "typescript": "catalog:"
+    "typescript": "catalog:",
+    "typescript-eslint": "catalog:"
   },
   "prettier": "@acme/prettier-config"
 }


### PR DESCRIPTION
## Summary

`pnpm audit --prod --audit-level=high` (the `security-audit` CI job) went red on all branches with a new high-severity `brace-expansion` DoS advisory — [GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg), vulnerable `<=5.0.7`, patched `>=5.0.8`, **53 paths**.

Those 53 paths resolve to only **two** versions, and they need different fixes:

| Resolved version | Paths | Fix |
| --- | --- | --- |
| `5.0.7` | 51 | Re-ratchet the existing override |
| `1.1.16` | 2 | Not overridable — fixed structurally |

The audit is now clean at the gate (`4 vulnerabilities found / 2 low | 2 moderate`).

## 51 paths — the override was stale

`pnpm-workspace.yaml` already pinned `brace-expansion` for the *previous* advisory (GHSA-3jxr-9vmj-r5cp). Because the new advisory declares `<=5.0.7` vulnerable, **the pin target had itself become the vulnerable version**:

```diff
-  "brace-expansion@>=3.0.0 <5.0.7": "5.0.7" # GHSA-3jxr-9vmj-r5cp (DoS)
+  "brace-expansion@>=3.0.0 <5.0.8": "5.0.8" # GHSA-mh99-v99m-4gvg (DoS)
```

This is the general lesson for our version-scoped overrides: when a new advisory lands, check whether the existing entry needs re-ratcheting rather than appending a new one.

## 2 paths — not fixable by override

The remaining two paths are `tooling__eslint>eslint-plugin-{react,jsx-a11y}>minimatch>brace-expansion`, resolving to `1.1.16`. Every escape route is closed:

- **No backport.** `5.0.8` is the only patched release; there is no 1.x/2.x/3.x/4.x fix and `maintenance-v1` still points at `1.1.16`.
- **Can't force `1.1.16` → `5.0.8`** — it's a runtime `TypeError`. `minimatch@3.1.5` does `var expand = require('brace-expansion')` and calls the result, but v5's CJS build only does `exports.expand = expand`.
- **Can't override `minimatch@3` → `10`** — that breaks a level higher. `eslint-plugin-react` and `eslint-plugin-jsx-a11y` both `require('minimatch')` and call it directly, which minimatch 10's named-export CJS build doesn't support.
- **No upstream upgrade to wait for.** Both plugins are already at their latest published version (`7.37.5`, `6.10.2`) and still pin `minimatch: "^3.1.2"`. `minimatch`'s own `legacy-v3` tag still declares `brace-expansion: "^1.1.7"`.

### Fixed structurally instead

`pnpm audit --prod` walks **every workspace project's own `dependencies`** without asking whether that project is itself only reachable as a devDependency. `@acme/eslint-config` is a devDependency everywhere it's consumed, but its 7 plugins sat under `dependencies` — inflating the *production* audit surface with pure lint tooling. Moved all 7 to `devDependencies`.

This is safe because `tooling/eslint/package.json` is `"private": true` and consumers link it via `workspace:*`, so pnpm symlinks the real `tooling/eslint/node_modules` — the plugins are still installed and resolvable at lint time (verified below).

`pnpm.auditConfig.ignoreGhsas` was considered and rejected: it is advisory-scoped, not path-scoped, so it would have suppressed the genuine `@sentry/nextjs` findings along with these two.

## Residual risk

`brace-expansion@1.1.16` is still present in the dev tree, and the audit no longer tracks it — this half is a scope change, not a patch. I'd call that acceptable: the DoS needs attacker-controlled brace patterns, and the only input here is glob patterns from our own eslint config (`forbid-component-props`, `jsx-handler-names`, etc.), never untrusted data. Worth revisiting when `eslint-plugin-react` drops `minimatch@3`.

## Commands run

- `pnpm audit --prod --audit-level=high` — clean at the gate (was `1 high`)
- `pnpm typecheck` — 23/23
- `pnpm format` — 23/23
- `pnpm lint` — 22/23
- `pnpm lint:unused` (knip) — no unused/unlisted dependencies

The one `pnpm lint` failure is `f3-slackbot`'s ruff step (`ruff_args[@]: unbound variable`), which fails identically on a stashed tree because `uv` isn't installed locally. Pre-existing and not a regression; CI installs `uv`.

## Impact

No DB migrations, no environment variables, no runtime dependency changes for any app. Lockfile diff is limited to the `brace-expansion` `5.0.7` → `5.0.8` resolution and the `tooling/eslint` dep-block move.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Updated a transitive dependency override to use a patched version and improve vulnerability coverage.

* **Chores**
  * Reclassified ESLint and TypeScript linting packages as development-only tooling, without changing available linting commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->