### PR TITLE
fix(slackbot): fixed the 'no preblast text entered' bug

### DIFF
--- a/apps/slackbot/features/calendar/event_preblast.py
+++ b/apps/slackbot/features/calendar/event_preblast.py
@@ -1116,7 +1116,7 @@ def build_preblast_info(
         preblast_rich = DEFAULT_PREBLAST
 
     # Double check for valid preblast text (avoid "" text and misformed text)
-    if not safe_get(preblast_rich, 0, "elements", "text"):
+    if not safe_get(preblast_rich, "elements", 0, "elements", 0, "text"):
         preblast_rich = DEFAULT_PREBLAST
 
     preblast_blocks: list[dict[str, Any]] = [

--- a/apps/slackbot/features/calendar/event_preblast.py
+++ b/apps/slackbot/features/calendar/event_preblast.py
@@ -1115,10 +1115,6 @@ def build_preblast_info(
     else:
         preblast_rich = DEFAULT_PREBLAST
 
-    # Double check for valid preblast text (avoid "" text and misformed text)
-    if not safe_get(preblast_rich, "elements", 0, "elements", 0, "text"):
-        preblast_rich = DEFAULT_PREBLAST
-
     preblast_blocks: list[dict[str, Any]] = [
         {
             "type": "section",


### PR DESCRIPTION
The check I had added to check for misformed text was bad, and resulted in always defaulting to a global preblast text of "no preblast entered". This should fix it.