### PR TITLE
feat(slackbot): add configurable weekly region reports

### DIFF
--- a/apps/slackbot/README.md
+++ b/apps/slackbot/README.md
@@ -72,6 +72,27 @@ pnpm test
 pnpm lint
 ```
 
+### Testing reporting scripts locally
+
+Scripts like `scripts/weekly_reporting.py`, `scripts/monthly_reporting.py`, and
+`scripts/award_achievements.py` query the `event_instance_expanded` /
+`attendance_expanded` materialized views, which exist in the cloud databases but
+are not created by the local Drizzle migrations. To run them against local data:
+
+```bash
+# one-time: create local versions of the views (re-run to refresh after seeding)
+docker exec -i f3-postgres psql -U f3local -d f3nation < apps/slackbot/scripts/sql/local-expanded-views.sql
+
+# print a region's weekly report without sending anything to Slack
+cd apps/slackbot
+uv run python scripts/weekly_reporting.py --org-id <region_org_id> --dry-run
+```
+
+`--dry-run` prints the fully rendered report to stdout (it also works for a
+region that has no Slack workspace connected yet). Drop `--dry-run` to actually
+send using the region's saved reporting settings, or use the "Send Weekly Report
+Now" button in `/f3-nation-settings` → Reporting Settings.
+
 ## Codebase notes
 
 - `main.py`: app entrypoint and Slack event handling

--- a/apps/slackbot/app_startup.sh
+++ b/apps/slackbot/app_startup.sh
@@ -86,7 +86,7 @@ echo "SOCKET_MODE=true; localtunnel is disabled."
 
 while true; do
   start_app
-  if ! wait -n "${APP_PID}"; then
+  if ! wait "${APP_PID}"; then
     :
   fi
 

--- a/apps/slackbot/features/backblast.py
+++ b/apps/slackbot/features/backblast.py
@@ -53,12 +53,56 @@ from utilities.helper_functions import (
     replace_user_channel_ids,
     safe_convert,
     safe_get,
+    update_local_region_records,
     upload_files_to_storage,
 )
 from utilities.slack import actions, forms
 from utilities.slack import orm as slack_orm
 
 META_EXCLUDE_FROM_PAX_VAULT = "exclude_from_pax_vault"
+
+# Custom field types backed by a native Slack picker (PAX -> users_select, Location ->
+# channels_select) store/display their value as ready-to-render Slack mention markup.
+CUSTOM_FIELD_MENTION_MARKUP = {
+    "PAX": ("<@", ">"),
+    "Location": ("<#", ">"),
+}
+
+# PAX/Location field types get a secondary "not in this Slack space" search field, mirroring
+# the main backblast form's existing "The PAX" + "PAX not in this Slack space" pattern —
+# native pickers only see the current workspace, so this covers PAX/AOs from other regions.
+CUSTOM_FIELD_XREGION_SUFFIX = {
+    "PAX": actions.CUSTOM_FIELD_PAX_XREGION_SUFFIX,
+    "Location": actions.CUSTOM_FIELD_LOCATION_XREGION_SUFFIX,
+}
+
+
+def local_picker_initial_value(raw_value: str, markup: tuple | None) -> str:
+    """Converts a stored custom-field value into what a local-workspace picker's initial
+    value should be: strips Slack mention markup back to a raw id for PAX/Location fields
+    (a cross-region-sourced or manually-typed plain name, with no markup, can't be
+    represented by the local picker and is left blank instead — the Q can re-select via the
+    cross-region or manual field), or returns the value unchanged for other field types."""
+    if not markup:
+        return raw_value
+    prefix, suffix = markup
+    if raw_value.startswith(prefix) and raw_value.endswith(suffix):
+        return raw_value.removeprefix(prefix).removesuffix(suffix)
+    return ""
+
+
+def manual_fallback_initial_value(raw_value: str, markup: tuple | None) -> str:
+    """Converts a stored custom-field value into what the plain-text 'not on Slack at all'
+    fallback field's initial value should be: the stored value as-is, but only when it isn't
+    Slack mention markup (that's already covered by the local picker) — a value resolved via
+    the cross-region search is also plain text and gets offered here too, which is harmless
+    since the Q can simply leave or clear it."""
+    if not raw_value or not markup:
+        return ""
+    prefix, suffix = markup
+    if raw_value.startswith(prefix) and raw_value.endswith(suffix):
+        return ""
+    return raw_value
 
 
 def add_custom_field_blocks(
@@ -69,15 +113,16 @@ def add_custom_field_blocks(
     output_form = copy.deepcopy(form)
     for custom_field in (region_record.custom_fields or {}).values():
         if safe_get(custom_field, "enabled"):
+            field_type = safe_get(custom_field, "type")
             output_form.add_block(
                 slack_orm.InputBlock(
-                    element=forms.CUSTOM_FIELD_TYPE_MAP[custom_field["type"]],
+                    element=forms.CUSTOM_FIELD_TYPE_MAP[field_type],
                     action=actions.CUSTOM_FIELD_PREFIX + custom_field["name"],
                     label=custom_field["name"],
                     optional=True,
                 )
             )
-            if safe_get(custom_field, "type") == "Dropdown":
+            if field_type == "Dropdown":
                 output_form.set_options(
                     {
                         actions.CUSTOM_FIELD_PREFIX + custom_field["name"]: slack_orm.as_selector_options(
@@ -86,18 +131,112 @@ def add_custom_field_blocks(
                         )
                     }
                 )
+            markup = CUSTOM_FIELD_MENTION_MARKUP.get(field_type)
             if initial_values and custom_field["name"] in initial_values:
-                output_form.set_initial_values(
-                    {
-                        actions.CUSTOM_FIELD_PREFIX + custom_field["name"]: safe_convert(
-                            safe_get(initial_values, custom_field["name"]), str
-                        )
-                        or ""
-                    }
-                )
+                # This specific event already has a value for this field (editing an existing
+                # backblast/preblast) — always respect it over the sticky auto-populate value.
+                raw_value = safe_convert(safe_get(initial_values, custom_field["name"]), str) or ""
+            elif custom_field.get("auto_populate") and custom_field.get("current_value"):
+                # New backblast/preblast, no value yet for this event — fall back to the
+                # region's sticky "last submitted value" for this field, if enabled.
+                raw_value = str(custom_field["current_value"])
             else:
-                output_form.set_initial_values({actions.CUSTOM_FIELD_PREFIX + custom_field["name"]: None})
+                raw_value = ""
+            local_key = actions.CUSTOM_FIELD_PREFIX + custom_field["name"]
+            output_form.set_initial_values({local_key: local_picker_initial_value(raw_value, markup) or None})
+
+            xregion_suffix = CUSTOM_FIELD_XREGION_SUFFIX.get(field_type)
+            if xregion_suffix:
+                output_form.add_block(
+                    slack_orm.InputBlock(
+                        element=slack_orm.ExternalSelectElement(
+                            placeholder="Type to search all regions...",
+                            min_query_length=2,
+                        ),
+                        action=local_key + xregion_suffix,
+                        label=f"{custom_field['name']} (not in this Slack space)",
+                        optional=True,
+                        hint="To filter by region, include it in parentheses, e.g. 'money (wash)' -> "
+                        "Moneyball (WashMo).",
+                    )
+                )
+                manual_key = local_key + actions.CUSTOM_FIELD_MANUAL_SUFFIX
+                output_form.add_block(
+                    slack_orm.InputBlock(
+                        element=slack_orm.PlainTextInputElement(placeholder="Type a name..."),
+                        action=manual_key,
+                        label=f"{custom_field['name']} (not on Slack / not in the system at all)",
+                        optional=True,
+                        hint="Only if they're not found by either search above.",
+                    )
+                )
+                output_form.set_initial_values({manual_key: manual_fallback_initial_value(raw_value, markup) or None})
     return output_form
+
+
+def resolve_cross_region_custom_fields(backblast_data: dict, region_record: SlackSettings) -> dict:
+    """Resolves each PAX/Location custom field to its final display-ready value under the
+    field's own key, in priority order: (1) the local picker's raw Slack id, wrapped as a
+    mention (<@U0123..> / <#C0123..>); (2) the cross-region search's selection (a User/Org id
+    from another region — see _search_users / _search_locations in utilities/options.py),
+    resolved to a plain display name, since a Slack mention can't reference a person/channel
+    from a different workspace; (3) the plain-text "not on Slack at all" fallback, for a
+    PAX/AO that isn't in F3's database anywhere, used as typed. Downstream formatting (weekly
+    report, post text) renders a plain name as "@name" / "#name", same as a typed
+    Dropdown/Text value.
+
+    Also syncs each "auto-populate" field's sticky current_value (used to pre-fill future
+    backblasts/preblasts until a Q changes it — see add_custom_field_blocks) to whatever was
+    just submitted, for every field type, persisting the change immediately."""
+    backblast_data = dict(backblast_data)
+    custom_fields = region_record.custom_fields or {}
+    sticky_changed = False
+
+    for custom_field_name, custom_field in custom_fields.items():
+        field_type = safe_get(custom_field, "type")
+        markup = CUSTOM_FIELD_MENTION_MARKUP.get(field_type)
+        xregion_suffix = CUSTOM_FIELD_XREGION_SUFFIX.get(field_type)
+        local_key = actions.CUSTOM_FIELD_PREFIX + custom_field_name
+
+        if markup and xregion_suffix:
+            xregion_key = local_key + xregion_suffix
+            manual_key = local_key + actions.CUSTOM_FIELD_MANUAL_SUFFIX
+            local_value = backblast_data.get(local_key)
+            xregion_value = backblast_data.pop(xregion_key, None)
+            manual_value = backblast_data.pop(manual_key, None)
+            manual_value = manual_value.strip() if isinstance(manual_value, str) else manual_value
+
+            if local_value:
+                prefix, suffix = markup
+                backblast_data[local_key] = f"{prefix}{local_value}{suffix}"
+            elif xregion_value:
+                if field_type == "PAX":
+                    record = DbManager.get(User, safe_convert(xregion_value, int))
+                    backblast_data[local_key] = record.f3_name if record else None
+                else:
+                    record = DbManager.get(Org, safe_convert(xregion_value, int))
+                    backblast_data[local_key] = record.name if record else None
+            elif manual_value:
+                backblast_data[local_key] = manual_value
+
+        # Only sync from fields actually rendered on the submitted form (enabled ones —
+        # see add_custom_field_blocks) — a disabled field is simply absent from
+        # backblast_data, which must not be mistaken for "the Q cleared it."
+        if custom_field.get("auto_populate") and custom_field.get("enabled"):
+            submitted_value = backblast_data.get(local_key) or None
+            if submitted_value != custom_field.get("current_value"):
+                custom_field["current_value"] = submitted_value
+                sticky_changed = True
+
+    if sticky_changed:
+        region_record.custom_fields = custom_fields
+        DbManager.update_records(
+            cls=SlackSpace,
+            filters=[SlackSpace.team_id == region_record.team_id],
+            fields={SlackSpace.settings: region_record.__dict__},
+        )
+        update_local_region_records()
+    return backblast_data
 
 
 def backblast_middleware(
@@ -780,6 +919,7 @@ def handle_backblast_post(body: dict, client: WebClient, logger: Logger, context
         backblast_data: dict = backblast_form.get_selected_values(body)
         event_org = DbManager.get(Org, safe_convert(safe_get(backblast_data, actions.BACKBLAST_AO), int))
 
+    backblast_data = resolve_cross_region_custom_fields(backblast_data, region_record)
     logger.debug(f"Backblast data: {backblast_data}")
 
     title = safe_get(backblast_data, actions.BACKBLAST_TITLE)
@@ -917,8 +1057,11 @@ def handle_backblast_post(body: dict, client: WebClient, logger: Logger, context
     custom_fields = {}
     for field, value in backblast_data.items():
         if (field[: len(actions.CUSTOM_FIELD_PREFIX)] == actions.CUSTOM_FIELD_PREFIX) and value:
-            post_msg += f"\n*{field[len(actions.CUSTOM_FIELD_PREFIX) :]}*: {str(value)}"
-            custom_fields[field[len(actions.CUSTOM_FIELD_PREFIX) :]] = value
+            # PAX/Location fields are already resolved to their final display value by
+            # resolve_cross_region_custom_fields (mention markup or a plain cross-region name)
+            field_name = field[len(actions.CUSTOM_FIELD_PREFIX) :]
+            post_msg += f"\n*{field_name}*: {str(value)}"
+            custom_fields[field_name] = value
 
     if file_list:
         custom_fields["files"] = file_list

--- a/apps/slackbot/features/calendar/event_preblast.py
+++ b/apps/slackbot/features/calendar/event_preblast.py
@@ -22,6 +22,7 @@ from typing import Any
 
 from f3_data_models.models import Attendance, AttendanceType, EventInstance, Org
 from slack_sdk.errors import SlackApiError
+from slack_sdk.models import blocks as sdk_blocks
 from slack_sdk.web import WebClient
 from sqlalchemy import or_
 
@@ -59,6 +60,7 @@ from utilities.helper_functions import (
     safe_get,
 )
 from utilities.slack import actions, orm
+from utilities.slack.sdk_orm import SdkBlockView, as_selector_options
 
 DEFAULT_PREBLAST = {
     "type": "rich_text",
@@ -104,6 +106,96 @@ def _build_preblast_service() -> PreblastService:
             attendance_service=_build_attendance_service(),
         )
     return _pb_svc
+
+
+# ---------------------------------------------------------------------------
+# Custom fields (Custom Field Settings) on the preblast form
+# ---------------------------------------------------------------------------
+
+_PREBLAST_CUSTOM_FIELD_ELEMENT_BUILDERS = {
+    "Dropdown": lambda action_id: sdk_blocks.StaticSelectElement(
+        action_id=action_id, options=as_selector_options(names=["(no options set)"], values=[""])
+    ),
+    "Text": lambda action_id: sdk_blocks.PlainTextInputElement(action_id=action_id),
+    "Number": lambda action_id: sdk_blocks.NumberInputElement(action_id=action_id),
+    "PAX": lambda action_id: sdk_blocks.UserSelectElement(action_id=action_id),
+    "Location": lambda action_id: sdk_blocks.ChannelSelectElement(action_id=action_id),
+}
+
+
+def add_custom_field_blocks(form: SdkBlockView, region_record: SlackSettings, initial_values: dict | None = None):
+    """SdkBlockView equivalent of features.backblast.add_custom_field_blocks — same
+    fields/types/cross-region-search/sticky-auto-populate behavior, adapted for the
+    preblast form's newer blocks.*-based architecture. Mutates and returns ``form``."""
+    if initial_values is None:
+        initial_values = {}
+    for custom_field in (region_record.custom_fields or {}).values():
+        if not safe_get(custom_field, "enabled"):
+            continue
+        field_type = safe_get(custom_field, "type")
+        field_action_id = actions.CUSTOM_FIELD_PREFIX + custom_field["name"]
+        build_element = _PREBLAST_CUSTOM_FIELD_ELEMENT_BUILDERS.get(field_type)
+        if not build_element:
+            continue
+
+        form.add_block(
+            sdk_blocks.InputBlock(
+                label=custom_field["name"],
+                element=build_element(field_action_id),
+                optional=True,
+                block_id=field_action_id,
+            )
+        )
+        if field_type == "Dropdown":
+            form.set_options(
+                {field_action_id: as_selector_options(names=custom_field["options"], values=custom_field["options"])}
+            )
+
+        markup = backblast.CUSTOM_FIELD_MENTION_MARKUP.get(field_type)
+        if custom_field["name"] in initial_values:
+            # This event already has a value for this field (editing an existing preblast) —
+            # always respect it over the sticky auto-populate value.
+            raw_value = safe_convert(safe_get(initial_values, custom_field["name"]), str) or ""
+        elif custom_field.get("auto_populate") and custom_field.get("current_value"):
+            # New preblast, no value yet for this event — fall back to the region's sticky
+            # "last submitted value" for this field, if enabled.
+            raw_value = str(custom_field["current_value"])
+        else:
+            raw_value = ""
+        stored_value = backblast.local_picker_initial_value(raw_value, markup)
+        if stored_value:
+            form.set_initial_values({field_action_id: stored_value})
+
+        xregion_suffix = backblast.CUSTOM_FIELD_XREGION_SUFFIX.get(field_type)
+        if xregion_suffix:
+            xregion_action_id = field_action_id + xregion_suffix
+            form.add_block(
+                sdk_blocks.InputBlock(
+                    label=f"{custom_field['name']} (not in this Slack space)",
+                    element=sdk_blocks.ExternalDataSelectElement(
+                        action_id=xregion_action_id,
+                        placeholder="Type to search all regions...",
+                        min_query_length=2,
+                    ),
+                    optional=True,
+                    block_id=xregion_action_id,
+                    hint="To filter by region, include it in parentheses, e.g. 'money (wash)' -> Moneyball (WashMo).",
+                )
+            )
+            manual_action_id = field_action_id + actions.CUSTOM_FIELD_MANUAL_SUFFIX
+            form.add_block(
+                sdk_blocks.InputBlock(
+                    label=f"{custom_field['name']} (not on Slack / not in the system at all)",
+                    element=sdk_blocks.PlainTextInputElement(action_id=manual_action_id, placeholder="Type a name..."),
+                    optional=True,
+                    block_id=manual_action_id,
+                    hint="Only if they're not found by either search above.",
+                )
+            )
+            manual_value = backblast.manual_fallback_initial_value(raw_value, markup)
+            if manual_value:
+                form.set_initial_values({manual_action_id: manual_value})
+    return form
 
 
 # ---------------------------------------------------------------------------
@@ -530,6 +622,7 @@ def _build_and_show_preblast_form(
         initial_coq_slack_ids=initial_coq_slack_ids,
         user_is_q=preblast_info.user_is_q,
     )
+    add_custom_field_blocks(form, region_record, initial_values=record.meta or {})
 
     metadata = {
         "event_instance_id": event_instance_id,
@@ -562,6 +655,10 @@ def handle_event_preblast_edit(
     existing_ts = safe_get(metadata, "preblast_ts")
 
     form_data: dict[str, Any] = extract_state_values(body)
+    # Resolves PAX/Location custom fields (local picker vs. cross-region search) and syncs
+    # each auto-populate field's sticky current_value — same logic as the backblast form,
+    # reused as-is since it only depends on dict keys, not the legacy form framework.
+    form_data = backblast.resolve_cross_region_custom_fields(form_data, region_record)
 
     svc = _build_preblast_service()
     event_svc = _build_event_instance_service()
@@ -593,8 +690,13 @@ def handle_event_preblast_edit(
         preblast_rich = None
         preblast_plain = None
 
-    # Handle image upload
     meta_updates: dict[str, Any] = {}
+    for custom_field_name in region_record.custom_fields or {}:
+        field_key = actions.CUSTOM_FIELD_PREFIX + custom_field_name
+        if field_key in form_data and form_data[field_key]:
+            meta_updates[custom_field_name] = form_data[field_key]
+
+    # Handle image upload
     image_data = form_data.get(actions.EVENT_PREBLAST_IMAGE)
     if image_data:
         file_obj = safe_get(image_data, 0) if isinstance(image_data, list) else image_data

--- a/apps/slackbot/features/custom_fields.py
+++ b/apps/slackbot/features/custom_fields.py
@@ -55,6 +55,9 @@ def build_custom_field_menu(
         label = f"Name: {custom_field['name']}\nType: {custom_field['type']}"
         if custom_field["type"] == "Dropdown":
             label += f"\nOptions: {', '.join(custom_field['options'])}"
+        if custom_field.get("auto_populate"):
+            current_value = custom_field.get("current_value")
+            label += f"\nAuto-populate: Yes (current value: {current_value or '(none set yet)'})"
 
         blocks.extend(
             [
@@ -145,6 +148,7 @@ def build_custom_field_add_edit(
                 actions.CUSTOM_FIELD_ADD_OPTIONS: (
                     ",".join(custom_field["options"]) if custom_field["type"] == "Dropdown" else " "
                 ),
+                actions.CUSTOM_FIELD_ADD_AUTO_POPULATE: "yes" if custom_field.get("auto_populate") else "no",
             }
         )
         action_text = "Edit"
@@ -204,15 +208,20 @@ def handle_custom_field_add(body: dict, client: WebClient, logger: Logger, conte
     custom_field_name = safe_get(config_data, actions.CUSTOM_FIELD_ADD_NAME)
     custom_field_type = safe_get(config_data, actions.CUSTOM_FIELD_ADD_TYPE)
     custom_field_options: str = safe_get(config_data, actions.CUSTOM_FIELD_ADD_OPTIONS)
+    auto_populate = safe_get(config_data, actions.CUSTOM_FIELD_ADD_AUTO_POPULATE) == "yes"
     # trim whitespace from options
     custom_field_options = custom_field_options.strip() if custom_field_options else ""
 
     custom_fields = region_record.custom_fields or {}
+    # Preserve the sticky current_value across edits (rename/retype) of the same field
+    existing_current_value = safe_get(custom_fields, custom_field_name, "current_value")
     custom_fields[custom_field_name] = {
         "name": custom_field_name,
         "type": custom_field_type,
         "options": custom_field_options.split(",") if custom_field_options else [],
         "enabled": True,
+        "auto_populate": auto_populate,
+        "current_value": existing_current_value if auto_populate else None,
     }
 
     if custom_field_type == "Dropdown" and not custom_field_options:

--- a/apps/slackbot/features/reporting.py
+++ b/apps/slackbot/features/reporting.py
@@ -10,10 +10,11 @@ from features.weekly_report_flags import MANAGE_WEEKLY_FLAGS
 from scripts.weekly_reporting import (
     DEFAULT_WEEKLY_DAY,
     DEFAULT_WEEKLY_FREQUENCY,
-    DEFAULT_WEEKLY_HOUR_CST,
+    DEFAULT_WEEKLY_HOUR,
     DEFAULT_WEEKLY_INTRO_TEMPLATE,
     DEFAULT_WEEKLY_SECTIONS,
     DEFAULT_WEEKLY_SUMMARY_METRICS,
+    DEFAULT_WEEKLY_TIMEZONE,
     FLAGS_SECTION_HEADER,
     FNGS_SECTION_HEADER,
     TOP_AO_POSTS_SECTION_HEADER,
@@ -21,6 +22,7 @@ from scripts.weekly_reporting import (
     TOP_QS_SECTION_HEADER,
     WEEKLY_REPORT_FREQUENCY_OPTIONS,
     WEEKLY_REPORT_SECTION_OPTIONS,
+    WEEKLY_REPORT_TIMEZONE_OPTIONS,
     WEEKLY_SECTION_SUMMARY,
     WEEKLY_SUMMARY_METRIC_OPTIONS,
 )
@@ -44,6 +46,7 @@ WEEKLY_REPORT_SUMMARY_ENABLED = "weekly_report_summary_enabled"
 WEEKLY_REPORT_SUMMARY_METRICS = "weekly_report_summary_metrics"
 WEEKLY_REPORT_DAY = "weekly_report_day"
 WEEKLY_REPORT_HOUR = "weekly_report_hour"
+WEEKLY_REPORT_TIMEZONE = "weekly_report_timezone"
 WEEKLY_REPORT_DESTINATION = "weekly_report_destination"
 WEEKLY_REPORT_TEMPLATE = "weekly_report_template"
 WEEKLY_REPORT_FNGS_HEADER = "weekly_report_fngs_header"
@@ -91,7 +94,7 @@ def build_reporting_form(
     weekly_hour = (
         region_record.weekly_report_hour_cst
         if region_record.weekly_report_hour_cst is not None
-        else DEFAULT_WEEKLY_HOUR_CST
+        else DEFAULT_WEEKLY_HOUR
     )
 
     form.set_initial_values(
@@ -105,6 +108,7 @@ def build_reporting_form(
             WEEKLY_REPORT_SUMMARY_METRICS: weekly_summary_metrics,
             WEEKLY_REPORT_DAY: str(weekly_day),
             WEEKLY_REPORT_HOUR: str(weekly_hour),
+            WEEKLY_REPORT_TIMEZONE: region_record.weekly_report_timezone or DEFAULT_WEEKLY_TIMEZONE,
             WEEKLY_REPORT_DESTINATION: region_record.weekly_report_destination
             or region_record.reporting_region_channel,
             WEEKLY_REPORT_TEMPLATE: region_record.weekly_report_intro_template or DEFAULT_WEEKLY_INTRO_TEMPLATE,
@@ -144,8 +148,9 @@ def handle_reporting_edit(body: dict, client: WebClient, logger: Logger, context
     region_record.weekly_report_summary_metrics = form_data.get(WEEKLY_REPORT_SUMMARY_METRICS) or []
     region_record.weekly_report_day = safe_convert(form_data.get(WEEKLY_REPORT_DAY), int, default=DEFAULT_WEEKLY_DAY)
     region_record.weekly_report_hour_cst = safe_convert(
-        form_data.get(WEEKLY_REPORT_HOUR), int, default=DEFAULT_WEEKLY_HOUR_CST
+        form_data.get(WEEKLY_REPORT_HOUR), int, default=DEFAULT_WEEKLY_HOUR
     )
+    region_record.weekly_report_timezone = form_data.get(WEEKLY_REPORT_TIMEZONE) or DEFAULT_WEEKLY_TIMEZONE
     region_record.weekly_report_destination = form_data.get(WEEKLY_REPORT_DESTINATION)
     region_record.weekly_report_intro_template = form_data.get(WEEKLY_REPORT_TEMPLATE)
     region_record.weekly_report_fngs_header = form_data.get(WEEKLY_REPORT_FNGS_HEADER)
@@ -278,13 +283,26 @@ FORM = SdkBlockView(
             block_id=WEEKLY_REPORT_DAY,
         ),
         blocks.InputBlock(
-            label="Send Time (CST)",
+            label="Send Time",
             element=blocks.StaticSelectElement(
                 action_id=WEEKLY_REPORT_HOUR,
                 options=as_selector_options(names=[f"{h}:00" for h in range(24)], values=[str(h) for h in range(24)]),
             ),
             optional=False,
             block_id=WEEKLY_REPORT_HOUR,
+        ),
+        blocks.InputBlock(
+            label="Time Zone",
+            element=blocks.StaticSelectElement(
+                action_id=WEEKLY_REPORT_TIMEZONE,
+                options=as_selector_options(
+                    names=list(WEEKLY_REPORT_TIMEZONE_OPTIONS.values()),
+                    values=list(WEEKLY_REPORT_TIMEZONE_OPTIONS.keys()),
+                ),
+            ),
+            optional=False,
+            block_id=WEEKLY_REPORT_TIMEZONE,
+            hint="'Send Day'/'Send Time' above are interpreted in this time zone.",
         ),
         blocks.InputBlock(
             label="Send To",

--- a/apps/slackbot/features/reporting.py
+++ b/apps/slackbot/features/reporting.py
@@ -6,8 +6,26 @@ from f3_data_models.utils import DbManager
 from slack_sdk.models import blocks
 from slack_sdk.web import WebClient
 
+from features.weekly_report_flags import MANAGE_WEEKLY_FLAGS
+from scripts.weekly_reporting import (
+    DEFAULT_WEEKLY_DAY,
+    DEFAULT_WEEKLY_FREQUENCY,
+    DEFAULT_WEEKLY_HOUR_CST,
+    DEFAULT_WEEKLY_INTRO_TEMPLATE,
+    DEFAULT_WEEKLY_SECTIONS,
+    DEFAULT_WEEKLY_SUMMARY_METRICS,
+    FLAGS_SECTION_HEADER,
+    FNGS_SECTION_HEADER,
+    TOP_AO_POSTS_SECTION_HEADER,
+    TOP_POSTERS_SECTION_HEADER,
+    TOP_QS_SECTION_HEADER,
+    WEEKLY_REPORT_FREQUENCY_OPTIONS,
+    WEEKLY_REPORT_SECTION_OPTIONS,
+    WEEKLY_SECTION_SUMMARY,
+    WEEKLY_SUMMARY_METRIC_OPTIONS,
+)
 from utilities.database.orm import SlackSettings
-from utilities.helper_functions import safe_get
+from utilities.helper_functions import safe_convert, safe_get
 from utilities.slack.sdk_orm import SdkBlockView, as_selector_options
 
 MONTHLY_REPORTS_ENABLED = "monthly_reports_enabled"
@@ -18,6 +36,30 @@ MONTHLY_REPORT_OPTIONS = {
     "ao_monthly_summary": "AO Monthly Summary",
 }
 RUN_MONTHLY_REPORTS_NOW = "run_monthly_reports_now"
+
+WEEKLY_REPORT_ENABLED = "weekly_report_enabled"
+WEEKLY_REPORT_FREQUENCY = "weekly_report_frequency"
+WEEKLY_REPORT_SECTIONS = "weekly_report_sections"
+WEEKLY_REPORT_SUMMARY_ENABLED = "weekly_report_summary_enabled"
+WEEKLY_REPORT_SUMMARY_METRICS = "weekly_report_summary_metrics"
+WEEKLY_REPORT_DAY = "weekly_report_day"
+WEEKLY_REPORT_HOUR = "weekly_report_hour"
+WEEKLY_REPORT_DESTINATION = "weekly_report_destination"
+WEEKLY_REPORT_TEMPLATE = "weekly_report_template"
+WEEKLY_REPORT_FNGS_HEADER = "weekly_report_fngs_header"
+WEEKLY_REPORT_TOP_AO_POSTS_HEADER = "weekly_report_top_ao_posts_header"
+WEEKLY_REPORT_TOP_POSTERS_HEADER = "weekly_report_top_posters_header"
+WEEKLY_REPORT_TOP_QS_HEADER = "weekly_report_top_qs_header"
+WEEKLY_REPORT_FLAGS_HEADER = "weekly_report_flags_header"
+RUN_WEEKLY_REPORT_NOW = "run_weekly_report_now"
+
+# "Summary numbers" is shown as its own Yes/No toggle (not a checkbox in
+# WEEKLY_REPORT_SECTIONS) so it sits directly above the per-metric breakdown it controls.
+NON_SUMMARY_SECTION_OPTIONS = {
+    key: label for key, label in WEEKLY_REPORT_SECTION_OPTIONS.items() if key != WEEKLY_SECTION_SUMMARY
+}
+
+WEEKDAY_NAMES = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"]
 
 
 def build_reporting_form(
@@ -35,10 +77,44 @@ def build_reporting_form(
     if region_record.reporting_ao_monthly_summary_enabled:
         monthly_options.append("ao_monthly_summary")
 
+    weekly_sections = (
+        region_record.weekly_report_sections
+        if region_record.weekly_report_sections is not None
+        else DEFAULT_WEEKLY_SECTIONS
+    )
+    weekly_summary_metrics = (
+        region_record.weekly_report_summary_metrics
+        if region_record.weekly_report_summary_metrics is not None
+        else DEFAULT_WEEKLY_SUMMARY_METRICS
+    )
+    weekly_day = region_record.weekly_report_day if region_record.weekly_report_day is not None else DEFAULT_WEEKLY_DAY
+    weekly_hour = (
+        region_record.weekly_report_hour_cst
+        if region_record.weekly_report_hour_cst is not None
+        else DEFAULT_WEEKLY_HOUR_CST
+    )
+
     form.set_initial_values(
         {
             MONTHLY_REPORTS_ENABLED: monthly_options,
             REGION_REPORTING_CHANNEL: region_record.reporting_region_channel,
+            WEEKLY_REPORT_ENABLED: "yes" if region_record.weekly_report_enabled else "no",
+            WEEKLY_REPORT_FREQUENCY: region_record.weekly_report_frequency or DEFAULT_WEEKLY_FREQUENCY,
+            WEEKLY_REPORT_SECTIONS: weekly_sections,
+            WEEKLY_REPORT_SUMMARY_ENABLED: "yes" if WEEKLY_SECTION_SUMMARY in weekly_sections else "no",
+            WEEKLY_REPORT_SUMMARY_METRICS: weekly_summary_metrics,
+            WEEKLY_REPORT_DAY: str(weekly_day),
+            WEEKLY_REPORT_HOUR: str(weekly_hour),
+            WEEKLY_REPORT_DESTINATION: region_record.weekly_report_destination
+            or region_record.reporting_region_channel,
+            WEEKLY_REPORT_TEMPLATE: region_record.weekly_report_intro_template or DEFAULT_WEEKLY_INTRO_TEMPLATE,
+            WEEKLY_REPORT_FNGS_HEADER: region_record.weekly_report_fngs_header or FNGS_SECTION_HEADER,
+            WEEKLY_REPORT_TOP_AO_POSTS_HEADER: region_record.weekly_report_top_ao_posts_header
+            or TOP_AO_POSTS_SECTION_HEADER,
+            WEEKLY_REPORT_TOP_POSTERS_HEADER: region_record.weekly_report_top_posters_header
+            or TOP_POSTERS_SECTION_HEADER,
+            WEEKLY_REPORT_TOP_QS_HEADER: region_record.weekly_report_top_qs_header or TOP_QS_SECTION_HEADER,
+            WEEKLY_REPORT_FLAGS_HEADER: region_record.weekly_report_flags_header or FLAGS_SECTION_HEADER,
         }
     )
 
@@ -58,6 +134,25 @@ def handle_reporting_edit(body: dict, client: WebClient, logger: Logger, context
     region_record.reporting_region_monthly_summary_enabled = "monthly_summary" in selected_reports
     region_record.reporting_ao_monthly_summary_enabled = "ao_monthly_summary" in selected_reports
     region_record.reporting_region_channel = form_data.get(REGION_REPORTING_CHANNEL)
+
+    region_record.weekly_report_enabled = form_data.get(WEEKLY_REPORT_ENABLED) == "yes"
+    region_record.weekly_report_frequency = form_data.get(WEEKLY_REPORT_FREQUENCY) or DEFAULT_WEEKLY_FREQUENCY
+    selected_sections = form_data.get(WEEKLY_REPORT_SECTIONS) or []
+    if form_data.get(WEEKLY_REPORT_SUMMARY_ENABLED) == "yes":
+        selected_sections = [WEEKLY_SECTION_SUMMARY] + selected_sections
+    region_record.weekly_report_sections = selected_sections
+    region_record.weekly_report_summary_metrics = form_data.get(WEEKLY_REPORT_SUMMARY_METRICS) or []
+    region_record.weekly_report_day = safe_convert(form_data.get(WEEKLY_REPORT_DAY), int, default=DEFAULT_WEEKLY_DAY)
+    region_record.weekly_report_hour_cst = safe_convert(
+        form_data.get(WEEKLY_REPORT_HOUR), int, default=DEFAULT_WEEKLY_HOUR_CST
+    )
+    region_record.weekly_report_destination = form_data.get(WEEKLY_REPORT_DESTINATION)
+    region_record.weekly_report_intro_template = form_data.get(WEEKLY_REPORT_TEMPLATE)
+    region_record.weekly_report_fngs_header = form_data.get(WEEKLY_REPORT_FNGS_HEADER)
+    region_record.weekly_report_top_ao_posts_header = form_data.get(WEEKLY_REPORT_TOP_AO_POSTS_HEADER)
+    region_record.weekly_report_top_posters_header = form_data.get(WEEKLY_REPORT_TOP_POSTERS_HEADER)
+    region_record.weekly_report_top_qs_header = form_data.get(WEEKLY_REPORT_TOP_QS_HEADER)
+    region_record.weekly_report_flags_header = form_data.get(WEEKLY_REPORT_FLAGS_HEADER)
 
     DbManager.update_records(
         cls=SlackSpace,
@@ -94,6 +189,191 @@ FORM = SdkBlockView(
             optional=True,
             block_id=REGION_REPORTING_CHANNEL,
             hint="Must be selected for reports to be sent",
+        ),
+        blocks.DividerBlock(),
+        blocks.HeaderBlock(text="Weekly Report Settings"),
+        blocks.InputBlock(
+            label="Send Weekly Report",
+            element=blocks.RadioButtonsElement(
+                action_id=WEEKLY_REPORT_ENABLED,
+                options=as_selector_options(names=["Yes", "No"], values=["yes", "no"]),
+            ),
+            optional=False,
+            block_id=WEEKLY_REPORT_ENABLED,
+        ),
+        blocks.InputBlock(
+            label="Include Summary Numbers",
+            element=blocks.RadioButtonsElement(
+                action_id=WEEKLY_REPORT_SUMMARY_ENABLED,
+                options=as_selector_options(names=["Yes", "No"], values=["yes", "no"]),
+            ),
+            optional=False,
+            block_id=WEEKLY_REPORT_SUMMARY_ENABLED,
+        ),
+        blocks.InputBlock(
+            label="Summary Numbers",
+            element=blocks.CheckboxesElement(
+                action_id=WEEKLY_REPORT_SUMMARY_METRICS,
+                options=as_selector_options(
+                    names=list(WEEKLY_SUMMARY_METRIC_OPTIONS.values()),
+                    values=list(WEEKLY_SUMMARY_METRIC_OPTIONS.keys()),
+                ),
+            ),
+            optional=True,
+            block_id=WEEKLY_REPORT_SUMMARY_METRICS,
+            hint="Only applies if 'Include Summary Numbers' above is set to Yes. Choose which "
+            "individual numbers appear.",
+        ),
+        blocks.InputBlock(
+            label="Other Weekly Report Sections",
+            element=blocks.CheckboxesElement(
+                action_id=WEEKLY_REPORT_SECTIONS,
+                options=as_selector_options(
+                    names=list(NON_SUMMARY_SECTION_OPTIONS.values()),
+                    values=list(NON_SUMMARY_SECTION_OPTIONS.keys()),
+                ),
+            ),
+            optional=True,
+            block_id=WEEKLY_REPORT_SECTIONS,
+            hint="Only the checked sections will be included in the weekly report.",
+        ),
+        blocks.ActionsBlock(
+            elements=[
+                blocks.ButtonElement(
+                    text="Manage Trophies",
+                    action_id=MANAGE_WEEKLY_FLAGS,
+                    value="manage",
+                )
+            ]
+        ),
+        blocks.ContextBlock(
+            elements=[
+                blocks.MarkdownTextObject(
+                    text="Add, edit, or remove named trophies (Ghost Flag, Pirate Flag, HIM Belt, ...). "
+                    "Only shown in the report if 'Trophies' is checked above."
+                )
+            ]
+        ),
+        blocks.InputBlock(
+            label="Frequency",
+            element=blocks.RadioButtonsElement(
+                action_id=WEEKLY_REPORT_FREQUENCY,
+                options=as_selector_options(
+                    names=list(WEEKLY_REPORT_FREQUENCY_OPTIONS.values()),
+                    values=list(WEEKLY_REPORT_FREQUENCY_OPTIONS.keys()),
+                ),
+            ),
+            optional=False,
+            block_id=WEEKLY_REPORT_FREQUENCY,
+            hint="'Every Other Week' sends on the same calendar weeks region-wide and covers the "
+            "full 14 days since the last report.",
+        ),
+        blocks.InputBlock(
+            label="Send Day",
+            element=blocks.StaticSelectElement(
+                action_id=WEEKLY_REPORT_DAY,
+                options=as_selector_options(names=WEEKDAY_NAMES, values=[str(i) for i in range(7)]),
+            ),
+            optional=False,
+            block_id=WEEKLY_REPORT_DAY,
+        ),
+        blocks.InputBlock(
+            label="Send Time (CST)",
+            element=blocks.StaticSelectElement(
+                action_id=WEEKLY_REPORT_HOUR,
+                options=as_selector_options(names=[f"{h}:00" for h in range(24)], values=[str(h) for h in range(24)]),
+            ),
+            optional=False,
+            block_id=WEEKLY_REPORT_HOUR,
+        ),
+        blocks.InputBlock(
+            label="Send To",
+            element=blocks.ConversationSelectElement(
+                action_id=WEEKLY_REPORT_DESTINATION,
+                placeholder="Select a channel or user",
+            ),
+            optional=True,
+            block_id=WEEKLY_REPORT_DESTINATION,
+            hint="Select a channel to post in, or a user to send as a direct message. "
+            "Falls back to the Region Reporting Channel if not set.",
+        ),
+        blocks.InputBlock(
+            label="Summary Header Text",
+            element=blocks.PlainTextInputElement(
+                action_id=WEEKLY_REPORT_TEMPLATE,
+                multiline=True,
+                placeholder="Intro text shown above the summary numbers",
+            ),
+            optional=True,
+            block_id=WEEKLY_REPORT_TEMPLATE,
+        ),
+        blocks.ContextBlock(
+            elements=[
+                blocks.MarkdownTextObject(
+                    text="Shown above whichever 'Summary Numbers' you checked, each on its own line. "
+                    "Advanced: supports placeholders — `{total_events}`, `{ao_count}`, `{unique_qs}`, "
+                    "`{fng_count}`, `{avg_pax}`, `{avg_pax_record}`, `{unique_pax}`, `{unique_pax_record}` — "
+                    "if you want to reference a number in your own wording instead."
+                )
+            ]
+        ),
+        blocks.InputBlock(
+            label="New Guys Header Text",
+            element=blocks.PlainTextInputElement(action_id=WEEKLY_REPORT_FNGS_HEADER),
+            optional=True,
+            block_id=WEEKLY_REPORT_FNGS_HEADER,
+        ),
+        blocks.InputBlock(
+            label="Top AO Posts Header Text",
+            element=blocks.PlainTextInputElement(action_id=WEEKLY_REPORT_TOP_AO_POSTS_HEADER),
+            optional=True,
+            block_id=WEEKLY_REPORT_TOP_AO_POSTS_HEADER,
+        ),
+        blocks.InputBlock(
+            label="Top Posters Header Text",
+            element=blocks.PlainTextInputElement(action_id=WEEKLY_REPORT_TOP_POSTERS_HEADER),
+            optional=True,
+            block_id=WEEKLY_REPORT_TOP_POSTERS_HEADER,
+        ),
+        blocks.InputBlock(
+            label="Top Qs Header Text",
+            element=blocks.PlainTextInputElement(action_id=WEEKLY_REPORT_TOP_QS_HEADER),
+            optional=True,
+            block_id=WEEKLY_REPORT_TOP_QS_HEADER,
+        ),
+        blocks.InputBlock(
+            label="Trophies Header Text",
+            element=blocks.PlainTextInputElement(action_id=WEEKLY_REPORT_FLAGS_HEADER),
+            optional=True,
+            block_id=WEEKLY_REPORT_FLAGS_HEADER,
+        ),
+        blocks.ContextBlock(
+            elements=[
+                blocks.MarkdownTextObject(
+                    text="Each header above is shown above its section's list (only if that section is "
+                    "checked and has data). Use `*bold*` for bold text. Stick to standard Slack emoji "
+                    "(e.g. `:fire:`) rather than region-specific custom emoji, since not every "
+                    "workspace has the same custom emoji uploaded. The report covers the 7 (or 14, "
+                    "for biweekly) full days ending the day before it is sent."
+                )
+            ]
+        ),
+        blocks.ActionsBlock(
+            elements=[
+                blocks.ButtonElement(
+                    text="Send Weekly Report Now",
+                    action_id=RUN_WEEKLY_REPORT_NOW,
+                    value="run",
+                )
+            ]
+        ),
+        blocks.ContextBlock(
+            elements=[
+                blocks.MarkdownTextObject(
+                    text="'Send Weekly Report Now' uses the last *saved* settings — submit the form first "
+                    "if you have made changes."
+                )
+            ]
         ),
     ]
 )

--- a/apps/slackbot/features/weekly_report_flags.py
+++ b/apps/slackbot/features/weekly_report_flags.py
@@ -1,0 +1,341 @@
+import copy
+import json
+import re
+from logging import Logger
+
+from f3_data_models.models import SlackSpace
+from f3_data_models.utils import DbManager
+from slack_sdk.models import blocks
+from slack_sdk.web import WebClient
+
+from scripts.weekly_reporting import FLAG_HOLDER_LOCATION, FLAG_HOLDER_PAX, FLAG_HOLDER_TYPE_OPTIONS
+from utilities.database.orm import SlackSettings
+from utilities.helper_functions import safe_get
+from utilities.slack.sdk_orm import SdkBlockView, as_selector_options
+
+MANAGE_WEEKLY_FLAGS = "manage_weekly_flags"
+WEEKLY_FLAGS_MENU_CALLBACK_ID = "weekly_flags_menu"
+WEEKLY_FLAG_ADD = "weekly_flag_add"
+WEEKLY_FLAG_EDIT = "weekly_flag_edit"
+WEEKLY_FLAG_DELETE = "weekly_flag_delete"
+WEEKLY_FLAG_ADD_CALLBACK_ID = "weekly_flag_add_edit"
+WEEKLY_FLAG_ENABLED_PREFIX = "weekly_flag_enabled"
+
+WEEKLY_FLAG_NAME = "weekly_flag_name"
+WEEKLY_FLAG_HASHTAG = "weekly_flag_hashtag"
+WEEKLY_FLAG_CUSTOM_FIELD_NAME = "weekly_flag_custom_field_name"
+
+NO_CUSTOM_FIELDS_OPTION = "(No custom fields configured yet)"
+
+
+def _slugify(name: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "-", name.strip().lower()).strip("-") or "trophy"
+
+
+def build_weekly_flags_menu(
+    body: dict,
+    client: WebClient,
+    logger: Logger,
+    context: dict,
+    region_record: SlackSettings,
+    update_view_id: str = None,
+) -> None:
+    trigger_id = safe_get(body, "trigger_id")
+    trophies = region_record.weekly_report_flags or {}
+
+    form_blocks = [
+        blocks.ContextBlock(
+            elements=[
+                blocks.MarkdownTextObject(
+                    text="Named trophies (Ghost Flag, Pirate Flag, HIM Belt, ...). PAX-held and location-held "
+                    "trophies are both best tracked via a Custom Field the Q fills in on the backblast (set "
+                    "one up under Backblast & Preblast Settings -> Custom Field Settings — use the 'PAX' "
+                    "field type for a real person picker, or 'Location' for a real channel picker). "
+                    "Location-held trophies can fall back to hashtag detection (scanning preblast/backblast "
+                    "text) instead if you'd rather not use a Custom Field. Only shown in the weekly report if "
+                    "'Trophies' is checked in Weekly Report Sections."
+                )
+            ]
+        ),
+    ]
+    for key, trophy in trophies.items():
+        holder_type = trophy.get("holder_type", FLAG_HOLDER_LOCATION)
+        holder_label = FLAG_HOLDER_TYPE_OPTIONS.get(holder_type)
+        if trophy.get("custom_field_name"):
+            source_line = f"Custom Field: {trophy['custom_field_name']}"
+        elif holder_type == FLAG_HOLDER_LOCATION:
+            source_line = f"Hashtag: #{trophy.get('hashtag') or '(not set)'}"
+        else:
+            source_line = "Custom Field: (not set)"
+        label = f"Name: {trophy['name']}\n{source_line}\nHeld by: {holder_label}"
+        toggle_block_id = f"{WEEKLY_FLAG_ENABLED_PREFIX}_{key}"
+        form_blocks.extend(
+            [
+                blocks.InputBlock(
+                    label=label,
+                    element=blocks.RadioButtonsElement(
+                        action_id=toggle_block_id,
+                        options=as_selector_options(names=["Enabled", "Disabled"], values=["enable", "disable"]),
+                    ),
+                    optional=False,
+                    block_id=toggle_block_id,
+                ),
+                blocks.ActionsBlock(
+                    elements=[
+                        blocks.ButtonElement(text="Edit", action_id=WEEKLY_FLAG_EDIT, value=key),
+                        blocks.ButtonElement(text="Delete", action_id=WEEKLY_FLAG_DELETE, value=key, style="danger"),
+                    ]
+                ),
+                blocks.DividerBlock(),
+            ]
+        )
+
+    form_blocks.append(
+        blocks.ActionsBlock(elements=[blocks.ButtonElement(text="Add Trophy", action_id=WEEKLY_FLAG_ADD, value="add")])
+    )
+
+    form = SdkBlockView(blocks=form_blocks)
+    form.set_initial_values(
+        {
+            f"{WEEKLY_FLAG_ENABLED_PREFIX}_{key}": "enable" if trophy.get("enabled", True) else "disable"
+            for key, trophy in trophies.items()
+        }
+    )
+
+    if update_view_id:
+        form.update_modal(
+            client=client,
+            view_id=update_view_id,
+            callback_id=WEEKLY_FLAGS_MENU_CALLBACK_ID,
+            title_text="Manage Trophies",
+        )
+    else:
+        form.post_modal(
+            client=client,
+            trigger_id=trigger_id,
+            callback_id=WEEKLY_FLAGS_MENU_CALLBACK_ID,
+            title_text="Manage Trophies",
+            new_or_add="add",
+        )
+
+
+def handle_weekly_flags_menu(
+    body: dict, client: WebClient, logger: Logger, context: dict, region_record: SlackSettings
+):
+    """Saves the Enabled/Disabled toggles from the trophies menu (submitted as one form)."""
+    values = SdkBlockView(blocks=[]).get_selected_values(body)
+    trophies = region_record.weekly_report_flags or {}
+    for block_id, value in values.items():
+        if block_id.startswith(f"{WEEKLY_FLAG_ENABLED_PREFIX}_"):
+            key = block_id[len(WEEKLY_FLAG_ENABLED_PREFIX) + 1 :]
+            if key in trophies:
+                trophies[key]["enabled"] = value == "enable"
+
+    region_record.weekly_report_flags = trophies
+    DbManager.update_records(
+        cls=SlackSpace,
+        filters=[SlackSpace.team_id == region_record.team_id],
+        fields={SlackSpace.settings: region_record.__dict__},
+    )
+
+
+def _set_custom_field_options(form: SdkBlockView, region_record: SlackSettings) -> None:
+    custom_fields = region_record.custom_fields or {}
+    if custom_fields:
+        form.set_options(
+            {
+                WEEKLY_FLAG_CUSTOM_FIELD_NAME: as_selector_options(
+                    names=[f"{f['name']} ({f.get('type', 'Text')})" for f in custom_fields.values()],
+                    values=[f["name"] for f in custom_fields.values()],
+                )
+            }
+        )
+    else:
+        form.set_options(
+            {WEEKLY_FLAG_CUSTOM_FIELD_NAME: as_selector_options(names=[NO_CUSTOM_FIELDS_OPTION], values=[""])}
+        )
+
+
+def build_weekly_flag_add_edit(
+    body: dict, client: WebClient, logger: Logger, context: dict, region_record: SlackSettings
+):
+    # Slack caps modal stacks at 3 views deep (Config -> Reporting Settings -> Manage Trophies
+    # is already at that cap), so this form REPLACES the open Manage Trophies view
+    # (views.update) instead of pushing a 4th view (views.push), which Slack rejects with
+    # push_limit_reached.
+    view_id = safe_get(body, "view", "id")
+    action_id = safe_get(body, "actions", 0, "action_id")
+
+    form = copy.deepcopy(FLAG_ADD_EDIT_FORM)
+    _set_custom_field_options(form, region_record)
+    custom_fields = region_record.custom_fields or {}
+
+    if action_id == WEEKLY_FLAG_NAME:
+        # Re-render triggered by pressing Enter in the Name field (see its
+        # dispatch_action_config below) — preserve whatever's currently typed, and
+        # auto-select a Custom Field whose name exactly matches what was just typed.
+        current_values = SdkBlockView(blocks=[]).get_selected_values(body)
+        typed_name = (current_values.get(WEEKLY_FLAG_NAME) or "").strip()
+        matched_field = next((f for f in custom_fields.values() if f["name"] == typed_name), None)
+        current_custom_field_name = current_values.get(WEEKLY_FLAG_CUSTOM_FIELD_NAME) or ""
+        form.set_initial_values(
+            {
+                WEEKLY_FLAG_NAME: typed_name,
+                WEEKLY_FLAG_HASHTAG: current_values.get(WEEKLY_FLAG_HASHTAG) or "",
+                WEEKLY_FLAG_CUSTOM_FIELD_NAME: matched_field["name"] if matched_field else current_custom_field_name,
+            }
+        )
+        # Recover flag_key (if editing) from the view's already-set private_metadata —
+        # this re-render isn't itself an Add/Edit button click, so body.actions[0].value
+        # doesn't carry it.
+        flag_key = None
+        private_metadata = safe_get(body, "view", "private_metadata")
+        if private_metadata:
+            try:
+                flag_key = json.loads(private_metadata).get("flag_key")
+            except (ValueError, TypeError):
+                flag_key = None
+        action_text = "Edit" if flag_key else "Add"
+    else:
+        flag_key = safe_get(body, "actions", 0, "value") if action_id == WEEKLY_FLAG_EDIT else None
+        trophy = safe_get(region_record.weekly_report_flags, flag_key or "")
+        if trophy:
+            form.set_initial_values(
+                {
+                    WEEKLY_FLAG_NAME: trophy["name"],
+                    WEEKLY_FLAG_HASHTAG: trophy.get("hashtag") or "",
+                    WEEKLY_FLAG_CUSTOM_FIELD_NAME: trophy.get("custom_field_name") or "",
+                }
+            )
+            action_text = "Edit"
+        else:
+            action_text = "Add"
+
+    form.update_modal(
+        client=client,
+        view_id=view_id,
+        callback_id=WEEKLY_FLAG_ADD_CALLBACK_ID,
+        title_text=f"{action_text} Trophy",
+        submit_button_text=f"{action_text} Trophy",
+        parent_metadata={"flag_key": flag_key} if flag_key else None,
+    )
+
+
+def handle_weekly_flag_add(body: dict, client: WebClient, logger: Logger, context: dict, region_record: SlackSettings):
+    form_data = FLAG_ADD_EDIT_FORM.get_selected_values(body)
+    name = (form_data.get(WEEKLY_FLAG_NAME) or "").strip()
+    hashtag = (form_data.get(WEEKLY_FLAG_HASHTAG) or "").strip().lstrip("#")
+    custom_field_name = (form_data.get(WEEKLY_FLAG_CUSTOM_FIELD_NAME) or "").strip()
+
+    # Held-by is derived from the selected Custom Field's own type — the admin already told
+    # us that when they created the field, no need to ask again. A PAX-type field makes a
+    # PAX-held trophy; any other type (Location/Dropdown/Text/Number), or no field at all
+    # (hashtag-only), makes a location-held trophy.
+    selected_field_type = (
+        safe_get(region_record.custom_fields, custom_field_name, "type") if custom_field_name else None
+    )
+    holder_type = FLAG_HOLDER_PAX if selected_field_type == "PAX" else FLAG_HOLDER_LOCATION
+
+    error = None
+    if not name:
+        error = "Please provide a name for the trophy."
+    elif holder_type == FLAG_HOLDER_LOCATION and not hashtag and not custom_field_name:
+        error = "Please provide a hashtag or select a Custom Field."
+    if error:
+        slack_user_id = safe_get(body, "user", "id")
+        if slack_user_id:
+            client.chat_postMessage(channel=slack_user_id, text=error)
+        return
+
+    original_key = None
+    private_metadata = safe_get(body, "view", "private_metadata")
+    if private_metadata:
+        try:
+            original_key = json.loads(private_metadata).get("flag_key")
+        except (ValueError, TypeError):
+            original_key = None
+
+    trophies = region_record.weekly_report_flags or {}
+    previously_enabled = True
+    if original_key and original_key in trophies:
+        previously_enabled = trophies[original_key].get("enabled", True)
+        trophies.pop(original_key)
+
+    trophies[_slugify(name)] = {
+        "name": name,
+        "hashtag": hashtag,
+        "custom_field_name": custom_field_name,
+        "holder_type": holder_type,
+        "enabled": previously_enabled,
+    }
+    region_record.weekly_report_flags = trophies
+    DbManager.update_records(
+        cls=SlackSpace,
+        filters=[SlackSpace.team_id == region_record.team_id],
+        fields={SlackSpace.settings: region_record.__dict__},
+    )
+
+    # This form replaced the Manage Trophies view in place (see build_weekly_flag_add_edit),
+    # so the current view id IS the Manage Trophies slot — update it back to the list.
+    view_id = safe_get(body, "view", "id")
+    build_weekly_flags_menu(body, client, logger, context, region_record, update_view_id=view_id)
+
+
+def handle_weekly_flag_delete(
+    body: dict, client: WebClient, logger: Logger, context: dict, region_record: SlackSettings
+):
+    flag_key = safe_get(body, "actions", 0, "value")
+    view_id = safe_get(body, "container", "view_id")
+
+    trophies = region_record.weekly_report_flags or {}
+    trophies.pop(flag_key, None)
+    region_record.weekly_report_flags = trophies
+    DbManager.update_records(
+        cls=SlackSpace,
+        filters=[SlackSpace.team_id == region_record.team_id],
+        fields={SlackSpace.settings: region_record.__dict__},
+    )
+    build_weekly_flags_menu(body, client, logger, context, region_record, update_view_id=view_id)
+
+
+FLAG_ADD_EDIT_FORM = SdkBlockView(
+    blocks=[
+        blocks.InputBlock(
+            label="Name",
+            element=blocks.PlainTextInputElement(
+                action_id=WEEKLY_FLAG_NAME,
+                placeholder="e.g. Ghost Flag, Pirate Flag, HIM Belt",
+                dispatch_action_config={"trigger_actions_on": ["on_enter_pressed"]},
+            ),
+            optional=False,
+            block_id=WEEKLY_FLAG_NAME,
+            dispatch_action=True,
+            hint="Press Enter after typing to auto-select a Custom Field with a matching name below, if one exists.",
+        ),
+        blocks.InputBlock(
+            label="Custom Field Name",
+            element=blocks.StaticSelectElement(
+                action_id=WEEKLY_FLAG_CUSTOM_FIELD_NAME,
+                options=as_selector_options(names=[NO_CUSTOM_FIELDS_OPTION], values=[""]),
+            ),
+            optional=True,
+            block_id=WEEKLY_FLAG_CUSTOM_FIELD_NAME,
+            hint="Recommended. Pick an existing Custom Field (set one up under Backblast & Preblast Settings "
+            "-> Custom Field Settings) that Qs fill in on the backblast — its most recent value becomes the "
+            "current holder. Whether this trophy is held by a location or a PAX is taken automatically from "
+            "the field's own type ('PAX' or 'Location') — no need to set it separately. Leave this unset "
+            "only if you want a location-held trophy to use hashtag detection instead (below).",
+        ),
+        blocks.InputBlock(
+            label="Hashtag (fallback for location-held trophies only)",
+            element=blocks.PlainTextInputElement(
+                action_id=WEEKLY_FLAG_HASHTAG, placeholder="e.g. ghost flag, pirate flag"
+            ),
+            optional=True,
+            block_id=WEEKLY_FLAG_HASHTAG,
+            hint="Only used when no Custom Field Name is set above. Word(s) to match after '#' in "
+            "preblasts/backblasts (no need to include the '#'). 'ghost flag' matches #ghostflag, "
+            "#nwpghostflag, #ghost-flag, etc.",
+        ),
+    ]
+)

--- a/apps/slackbot/scripts/hourly_runner.py
+++ b/apps/slackbot/scripts/hourly_runner.py
@@ -18,6 +18,7 @@ from scripts import (
     preblast_reminders,
     q_lineups,
     update_slack_users,
+    weekly_reporting,
 )
 
 APP_URL = os.getenv("APP_URL", "http://localhost:8080")
@@ -80,6 +81,12 @@ def run_all_hourly_scripts(force: bool = False, run_reporting: bool = True, repo
             monthly_reporting.cycle_all_orgs(run_org_id=reporting_org_id)
         except Exception as e:
             print(f"Error running monthly reporting: {e}")
+
+        print("Running weekly reporting")
+        try:
+            weekly_reporting.cycle_weekly_reports(force_org_id=reporting_org_id)
+        except Exception as e:
+            print(f"Error running weekly reporting: {e}")
 
     print("Running achievements update")
     try:

--- a/apps/slackbot/scripts/sql/local-expanded-views.sql
+++ b/apps/slackbot/scripts/sql/local-expanded-views.sql
@@ -1,0 +1,138 @@
+-- LOCAL DEV ONLY: creates the `event_instance_expanded` and `attendance_expanded`
+-- materialized views that exist in the cloud databases but are not part of the
+-- local Drizzle migrations. Several slackbot scripts (weekly_reporting,
+-- monthly_reporting, award_achievements) query these views, so apply this once
+-- to your local database to run those scripts against seeded data:
+--
+--   docker exec -i f3-postgres psql -U f3local -d f3nation < apps/slackbot/scripts/sql/local-expanded-views.sql
+--
+-- The definitions here are a best-effort approximation of the cloud views:
+-- close enough for local development, not a source of truth. Re-run after
+-- seeding new data, or refresh with:
+--   REFRESH MATERIALIZED VIEW event_instance_expanded;
+--   REFRESH MATERIALIZED VIEW attendance_expanded;
+
+-- Drop table forms too: SQLAlchemy's create_all can create these as empty tables
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_tables WHERE tablename = 'event_instance_expanded') THEN
+    DROP TABLE event_instance_expanded;
+  END IF;
+  IF EXISTS (SELECT 1 FROM pg_tables WHERE tablename = 'attendance_expanded') THEN
+    DROP TABLE attendance_expanded;
+  END IF;
+END $$;
+
+DROP MATERIALIZED VIEW IF EXISTS event_instance_expanded;
+CREATE MATERIALIZED VIEW event_instance_expanded AS
+WITH org_h AS (
+  SELECT
+    o.id AS org_id,
+    CASE WHEN o.org_type = 'ao' THEN o.id END AS ao_id,
+    CASE
+      WHEN o.org_type = 'region' THEN o.id
+      WHEN o.org_type = 'ao' THEN p.id
+    END AS region_id
+  FROM orgs o
+  LEFT JOIN orgs p ON p.id = o.parent_id
+)
+SELECT
+  ei.id,
+  ei.org_id,
+  ei.location_id,
+  ei.series_id,
+  ei.highlight,
+  ei.start_date,
+  ei.end_date,
+  ei.start_time,
+  ei.end_time,
+  ei.name,
+  ei.description,
+  ei.pax_count,
+  ei.fng_count,
+  ei.preblast,
+  ei.backblast,
+  ei.meta,
+  ei.created,
+  ei.updated,
+  s.name AS series_name,
+  s.description AS series_description,
+  ao.id AS ao_org_id,
+  ao.name AS ao_name,
+  ao.description AS ao_description,
+  ao.logo_url AS ao_logo_url,
+  ao.website AS ao_website,
+  ao.meta AS ao_meta,
+  region.id AS region_org_id,
+  region.name AS region_name,
+  region.description AS region_description,
+  region.logo_url AS region_logo_url,
+  region.website AS region_website,
+  region.meta AS region_meta,
+  area.id AS area_org_id,
+  area.name AS area_name,
+  sector.id AS sector_org_id,
+  sector.name AS sector_name,
+  l.name AS location_name,
+  l.description AS location_description,
+  l.latitude AS location_latitude,
+  l.longitude AS location_longitude,
+  MAX(CASE WHEN et.name ILIKE '%bootcamp%' THEN 1 ELSE 0 END) AS bootcamp_ind,
+  MAX(CASE WHEN et.name ILIKE '%run%' THEN 1 ELSE 0 END) AS run_ind,
+  MAX(CASE WHEN et.name ILIKE '%ruck%' THEN 1 ELSE 0 END) AS ruck_ind,
+  MAX(CASE WHEN et.event_category = 'first_f' THEN 1 ELSE 0 END) AS first_f_ind,
+  MAX(CASE WHEN et.event_category = 'second_f' THEN 1 ELSE 0 END) AS second_f_ind,
+  MAX(CASE WHEN et.event_category = 'third_f' THEN 1 ELSE 0 END) AS third_f_ind,
+  MAX(CASE WHEN tag.name ILIKE '%pre%workout%' THEN 1 ELSE 0 END) AS pre_workout_ind,
+  MAX(CASE WHEN tag.name ILIKE '%off the books%' THEN 1 ELSE 0 END) AS off_the_books_ind,
+  MAX(CASE WHEN tag.name ILIKE '%vq%' THEN 1 ELSE 0 END) AS vq_ind,
+  MAX(CASE WHEN tag.name ILIKE '%convergence%' THEN 1 ELSE 0 END) AS convergence_ind,
+  ARRAY_REMOVE(ARRAY_AGG(DISTINCT et.name), NULL) AS all_types,
+  ARRAY_REMOVE(ARRAY_AGG(DISTINCT tag.name), NULL) AS all_tags
+FROM event_instances ei
+LEFT JOIN events s ON s.id = ei.series_id
+LEFT JOIN org_h ON org_h.org_id = ei.org_id
+LEFT JOIN orgs ao ON ao.id = org_h.ao_id
+LEFT JOIN orgs region ON region.id = org_h.region_id
+LEFT JOIN orgs area ON area.id = region.parent_id AND area.org_type = 'area'
+LEFT JOIN orgs sector ON sector.id = area.parent_id AND sector.org_type = 'sector'
+LEFT JOIN locations l ON l.id = ei.location_id
+LEFT JOIN event_instances_x_event_types eixt ON eixt.event_instance_id = ei.id
+LEFT JOIN event_types et ON et.id = eixt.event_type_id
+LEFT JOIN event_tags_x_event_instances tixt ON tixt.event_instance_id = ei.id
+LEFT JOIN event_tags tag ON tag.id = tixt.event_tag_id
+WHERE ei.is_active
+GROUP BY
+  ei.id, s.id, ao.id, region.id, area.id, sector.id, l.id;
+
+CREATE UNIQUE INDEX ON event_instance_expanded (id);
+
+DROP MATERIALIZED VIEW IF EXISTS attendance_expanded;
+CREATE MATERIALIZED VIEW attendance_expanded AS
+SELECT
+  a.id,
+  a.user_id,
+  a.event_instance_id,
+  a.meta AS attendance_meta,
+  a.created,
+  a.updated,
+  MAX(CASE WHEN axt.attendance_type_id = 2 THEN 1 ELSE 0 END) AS q_ind,
+  MAX(CASE WHEN axt.attendance_type_id = 3 THEN 1 ELSE 0 END) AS coq_ind,
+  u.f3_name,
+  u.first_name,
+  u.last_name,
+  u.email,
+  u.home_region_id,
+  hr.name AS home_region_name,
+  u.avatar_url,
+  u.status AS user_status,
+  ei.start_date
+FROM attendance a
+JOIN users u ON u.id = a.user_id
+JOIN event_instances ei ON ei.id = a.event_instance_id
+LEFT JOIN orgs hr ON hr.id = u.home_region_id
+LEFT JOIN attendance_x_attendance_types axt ON axt.attendance_id = a.id
+WHERE NOT a.is_planned
+GROUP BY a.id, u.id, hr.id, ei.id;
+
+CREATE UNIQUE INDEX ON attendance_expanded (id);

--- a/apps/slackbot/scripts/weekly_reporting.py
+++ b/apps/slackbot/scripts/weekly_reporting.py
@@ -1,0 +1,749 @@
+import os
+import re
+import ssl
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+
+from collections import defaultdict
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta
+from typing import Dict, List, Optional
+
+import pytz
+from f3_data_models.models import Attendance, Attendance_x_AttendanceType, SlackSpace, User
+from f3_data_models.utils import DbManager, get_session
+from slack_sdk import WebClient
+from slack_sdk.errors import SlackApiError
+from sqlalchemy import Date, Integer, case, cast, func, literal, select
+
+from utilities.database.orm import SlackSettings
+from utilities.database.orm.views import EventInstanceExpanded
+from utilities.helper_functions import safe_get
+
+# Attendance type ids (see f3_data_models.models.AttendanceType): 1='PAX', 2='Q', 3='Co-Q'
+Q_ATTENDANCE_TYPE_ID = 2
+
+# "Flags" (Ghost Flag, Pirate Flag, HIM Belt, ...): configurable, multiple, region-defined
+# named items with two ways to track the current holder:
+# - "location": an AO. Preferred detection: a region-defined Custom Field (see
+#   features/custom_fields.py — use the "Location" field type for a real channel picker)
+#   that the Q fills in on the backblast. Falls back to hashtag detection (scanning
+#   preblast/backblast text) if no Custom Field is configured for the flag.
+# - "pax": a person. Always read from a region-defined Custom Field (use the "PAX" field
+#   type for a real person picker) — no hashtag fallback.
+# Both field-based methods reuse the existing backblast Custom Field mechanism instead of
+# adding dedicated flag-assignment UI; the value on an event's most recent match wins.
+# Stored in SlackSettings.weekly_report_flags as
+# {flag_key: {"name": str, "hashtag": str, "custom_field_name": str, "holder_type": ..., "enabled": bool}}.
+FLAG_HOLDER_LOCATION = "location"
+FLAG_HOLDER_PAX = "pax"
+FLAG_HOLDER_TYPE_OPTIONS = {
+    FLAG_HOLDER_LOCATION: "A Location (AO)",
+    FLAG_HOLDER_PAX: "PAX",
+}
+FLAG_LOOKBACK_DAYS = 90
+FLAG_HOLDER_FALLBACK = "not currently held"
+
+# Section keys — these are stored in SlackSettings.weekly_report_sections
+WEEKLY_SECTION_SUMMARY = "summary"
+WEEKLY_SECTION_FNGS = "fngs"
+WEEKLY_SECTION_TOP_AO_POSTS = "top_ao_posts"
+WEEKLY_SECTION_TOP_POSTERS = "top_posters"
+WEEKLY_SECTION_TOP_QS = "top_qs"
+WEEKLY_SECTION_FLAGS = "flags"
+
+WEEKLY_REPORT_SECTION_OPTIONS = {
+    WEEKLY_SECTION_SUMMARY: "Summary numbers (events, AOs, Qs, FNGs, average / unique PAX)",
+    WEEKLY_SECTION_FNGS: "FNGs by AO",
+    WEEKLY_SECTION_TOP_AO_POSTS: "Highest attended workout at each AO",
+    WEEKLY_SECTION_TOP_POSTERS: "Top posters",
+    WEEKLY_SECTION_TOP_QS: "Top Qs",
+    WEEKLY_SECTION_FLAGS: "Trophies (Ghost Flag, HIM Belt, etc. — configured below)",
+}
+DEFAULT_WEEKLY_SECTIONS = list(WEEKLY_REPORT_SECTION_OPTIONS.keys())
+
+# Individual summary numbers — stored in SlackSettings.weekly_report_summary_metrics.
+# Each maps to one fixed-format line in WEEKLY_SUMMARY_METRIC_LINES, rendered in this order.
+SUMMARY_METRIC_TOTAL_EVENTS = "total_events"
+SUMMARY_METRIC_AO_COUNT = "ao_count"
+SUMMARY_METRIC_UNIQUE_QS = "unique_qs"
+SUMMARY_METRIC_FNG_COUNT = "fng_count"
+SUMMARY_METRIC_AVG_PAX = "avg_pax"
+SUMMARY_METRIC_UNIQUE_PAX = "unique_pax"
+
+WEEKLY_SUMMARY_METRIC_OPTIONS = {
+    SUMMARY_METRIC_TOTAL_EVENTS: "Total Events",
+    SUMMARY_METRIC_AO_COUNT: "AO Count",
+    SUMMARY_METRIC_UNIQUE_QS: "Unique Qs",
+    SUMMARY_METRIC_FNG_COUNT: "FNGs",
+    SUMMARY_METRIC_AVG_PAX: "Average PAX (with all-time record)",
+    SUMMARY_METRIC_UNIQUE_PAX: "Unique PAX participating (with all-time record)",
+}
+DEFAULT_WEEKLY_SUMMARY_METRICS = list(WEEKLY_SUMMARY_METRIC_OPTIONS.keys())
+
+WEEKLY_SUMMARY_METRIC_LINES = {
+    SUMMARY_METRIC_TOTAL_EVENTS: "• Total Events: {total_events} Workouts",
+    SUMMARY_METRIC_AO_COUNT: "• AO Count: {ao_count} AOs",
+    SUMMARY_METRIC_UNIQUE_QS: "• Unique Qs: {unique_qs} Qs",
+    SUMMARY_METRIC_FNG_COUNT: "• FNGs: {fng_count} FNGs :fire:",
+    SUMMARY_METRIC_AVG_PAX: "• Average PAX: {avg_pax} PAX (current record: {avg_pax_record})",
+    SUMMARY_METRIC_UNIQUE_PAX: "• Unique PAX: {unique_pax} PAX (current record: {unique_pax_record})",
+}
+
+DEFAULT_WEEKLY_DAY = 0  # Monday
+DEFAULT_WEEKLY_HOUR_CST = 8
+
+# "weekly" sends every week on weekly_report_day; "biweekly" sends every other week,
+# in sync across all regions (see is_biweekly_send_week)
+FREQUENCY_WEEKLY = "weekly"
+FREQUENCY_BIWEEKLY = "biweekly"
+WEEKLY_REPORT_FREQUENCY_OPTIONS = {
+    FREQUENCY_WEEKLY: "Every Week",
+    FREQUENCY_BIWEEKLY: "Every Other Week",
+}
+DEFAULT_WEEKLY_FREQUENCY = FREQUENCY_WEEKLY
+# Reference Monday used to compute biweekly parity; arbitrary but fixed so all
+# regions on "every other week" send on the same calendar weeks.
+BIWEEKLY_EPOCH_MONDAY = date(2024, 1, 1)
+
+# The header/intro is the only free-text part of the summary section; the numbers
+# below it are individually toggleable fixed-format lines (WEEKLY_SUMMARY_METRIC_LINES)
+DEFAULT_WEEKLY_INTRO_TEMPLATE = "Here goes the numbers from last week :point_down:"
+
+WEEKLY_REPORT_TITLE = "*Weekly Region Report*"
+
+# Bold section headers (Slack mrkdwn *text*) plus standard Unicode emoji only — no
+# workspace-specific custom emoji (like Slack's own :slack: logo glyph), since not every
+# region's workspace is guaranteed to have every custom emoji available.
+FNGS_SECTION_HEADER = "*New Guys — welcome them to Slack!*"
+TOP_AO_POSTS_SECTION_HEADER = "*Highest Attended Workout by AO* :muscle:"
+TOP_POSTERS_SECTION_HEADER = "*Top Posters* :fire:"
+TOP_QS_SECTION_HEADER = "*Top Qs* :muscle:"
+FLAGS_SECTION_HEADER = "*Trophies* :triangular_flag_on_post:"
+
+
+@dataclass
+class WeeklyEvent:
+    event_id: int
+    name: str
+    start_date: date
+    ao_org_id: Optional[int]
+    ao_name: Optional[str]
+    ao_channel_id: Optional[str]
+    pax_count: Optional[int]
+    fng_count: Optional[int]
+    backblast: Optional[str]
+
+
+@dataclass
+class WeeklyAttendanceRecord:
+    event_id: int
+    user_id: int
+    f3_name: Optional[str]
+    q_ind: int
+
+
+@dataclass
+class FlagCandidate:
+    start_date: date
+    ao_name: Optional[str]
+    ao_channel_id: Optional[str]
+    preblast: Optional[str]
+    backblast: Optional[str]
+    meta: Optional[dict]  # event custom-field values, used when a flag's holder_type is "pax"
+
+
+@dataclass
+class WeeklyRegionStats:
+    total_events: int = 0
+    ao_count: int = 0
+    unique_qs: int = 0
+    fng_count: int = 0
+    avg_pax: float = 0.0
+    unique_pax: int = 0
+    avg_pax_record: float = 0.0  # best 7-day-window average PAX in region history
+    unique_pax_record: int = 0  # best 7-day-window unique PAX in region history
+    flags: List[tuple] = None  # (flag_name, holder_or_fallback)
+    fngs_by_ao: List[tuple] = None  # (count, ao_label, names_csv)
+    top_ao_events: List[tuple] = None  # (attendance, ao_label, q_name, title)
+    top_posters: List[tuple] = None  # (post_count, f3_name)
+    top_qs: List[tuple] = None  # (q_count, f3_name)
+
+
+class _SafeFormatDict(dict):
+    """Leaves unknown placeholders in place instead of raising KeyError."""
+
+    def __missing__(self, key):
+        return "{" + key + "}"
+
+
+def is_biweekly_send_week(current_date: date) -> bool:
+    """True on send-eligible weeks for 'every other week' regions, synced across all regions."""
+    weeks_since_epoch = (current_date - BIWEEKLY_EPOCH_MONDAY).days // 7
+    return weeks_since_epoch % 2 == 0
+
+
+def report_window_days(frequency: Optional[str]) -> int:
+    """Number of days the report covers: 7 for weekly, 14 for biweekly."""
+    return 14 if frequency == FREQUENCY_BIWEEKLY else 7
+
+
+def ao_label(ao_name: Optional[str], ao_channel_id: Optional[str]) -> str:
+    """Renders an AO as a real Slack channel mention when we know its channel, otherwise a #-slug of its name."""
+    if ao_channel_id:
+        return f"<#{ao_channel_id}>"
+    if not ao_name:
+        return "#unknown"
+    return "#" + re.sub(r"[^a-z0-9]+", "-", ao_name.lower()).strip("-")
+
+
+def build_flag_pattern(hashtag: str) -> re.Pattern:
+    """Builds a regex matching hashtag variations of a flag's name/hashtag words.
+
+    E.g. hashtag="ghost flag" matches #ghostflag, #ghost-flag, #nwpghostflag, #f3ghostflag, etc.
+    """
+    words = [re.escape(w) for w in re.split(r"[\s_-]+", (hashtag or "").strip().lower()) if w]
+    if not words:
+        return re.compile(r"(?!)")  # never matches
+    core = r"[\s_-]?".join(words)
+    return re.compile(rf"#[a-z0-9_-]*{core}[a-z0-9_-]*", re.IGNORECASE)
+
+
+def resolve_location_holder(candidates: List[FlagCandidate], pattern: re.Pattern) -> Optional[str]:
+    """Returns the AO of the most recent event whose preblast/backblast matches the flag's
+    hashtag pattern, or None."""
+    for c in sorted(candidates, key=lambda c: c.start_date, reverse=True):
+        text = "\n".join(t for t in (c.preblast, c.backblast) if t)
+        if text and pattern.search(text):
+            return ao_label(c.ao_name, c.ao_channel_id)
+    return None
+
+
+def resolve_custom_field_holder(
+    candidates: List[FlagCandidate], custom_field_name: str, holder_type: str
+) -> Optional[str]:
+    """Returns the value of a region-defined Custom Field (filled in by the Q on the
+    backblast) from the most recent event that has one set, or None. Reuses the existing
+    backblast Custom Field mechanism rather than a dedicated flag-assignment UI.
+
+    The "PAX" and "Location" field types store a ready-to-render Slack mention (<@U0123456>
+    or <#C0123456>, auto-resolved to a name/channel by Slack when displayed); other field
+    types (Dropdown/Text) store a plain typed value, which gets formatted to match — "@name"
+    for PAX-held flags, "#slug" for location-held flags."""
+    if not custom_field_name:
+        return None
+    for c in sorted(candidates, key=lambda c: c.start_date, reverse=True):
+        value = safe_get(c.meta, custom_field_name)
+        if value:
+            value = str(value)
+            if value.startswith("<") or value.startswith("@") or value.startswith("#"):
+                return value
+            if holder_type == FLAG_HOLDER_LOCATION:
+                return "#" + re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
+            return f"@{value}"
+    return None
+
+
+def resolve_org_flags(flags_config: Optional[dict], candidates: List[FlagCandidate]) -> List[tuple]:
+    """Resolves every enabled flag in a region's config to its (name, current holder) pair,
+    in configured order. A configured Custom Field always wins over hashtag detection for
+    location-held flags; PAX-held flags require a Custom Field (no hashtag fallback)."""
+    if not flags_config:
+        return []
+    resolved = []
+    for flag in flags_config.values():
+        if not flag.get("enabled", True):
+            continue
+        holder_type = flag.get("holder_type") or FLAG_HOLDER_LOCATION
+        custom_field_name = flag.get("custom_field_name") or ""
+        if custom_field_name:
+            holder = resolve_custom_field_holder(candidates, custom_field_name, holder_type)
+        elif holder_type == FLAG_HOLDER_LOCATION:
+            pattern = build_flag_pattern(flag.get("hashtag") or flag.get("name") or "")
+            holder = resolve_location_holder(candidates, pattern)
+        else:
+            holder = None
+        resolved.append((flag.get("name", "Trophy"), holder or FLAG_HOLDER_FALLBACK))
+    return resolved
+
+
+def extract_fng_names(backblast: Optional[str]) -> List[str]:
+    if not backblast:
+        return []
+    match = re.search(r"FNGs?:\s*\d*[\s:,-]*([^\n]*)", backblast, re.IGNORECASE)
+    if not match:
+        return []
+    names = [n.strip() for n in match.group(1).split(",")]
+    return [n for n in names if n and n.lower() not in {"none", "0", "n/a", "na"}]
+
+
+def compute_weekly_stats(events: List[WeeklyEvent], attendance: List[WeeklyAttendanceRecord]) -> WeeklyRegionStats:
+    stats = WeeklyRegionStats(fngs_by_ao=[], top_ao_events=[], top_posters=[], top_qs=[])
+    if not events:
+        return stats
+
+    # Dedupe attendance per (event, user)
+    seen = set()
+    attendance_unique: List[WeeklyAttendanceRecord] = []
+    for a in attendance:
+        key = (a.event_id, a.user_id)
+        if key not in seen:
+            seen.add(key)
+            attendance_unique.append(a)
+        elif a.q_ind:
+            # keep the Q indicator if any of the user's rows for the event carried it
+            for existing in attendance_unique:
+                if (existing.event_id, existing.user_id) == key:
+                    existing.q_ind = 1
+                    break
+
+    tagged_by_event: Dict[int, int] = defaultdict(int)
+    for a in attendance_unique:
+        tagged_by_event[a.event_id] += 1
+
+    def event_attendance(event: WeeklyEvent) -> int:
+        # Prefer the backblast COUNT (pax_count); fall back to tagged attendance
+        return event.pax_count if event.pax_count else tagged_by_event.get(event.event_id, 0)
+
+    ao_keys = {e.ao_org_id or e.ao_name for e in events}
+    stats.total_events = len(events)
+    stats.ao_count = len(ao_keys)
+    stats.unique_qs = len({a.user_id for a in attendance_unique if a.q_ind})
+    stats.fng_count = sum(e.fng_count or 0 for e in events)
+    stats.unique_pax = len({a.user_id for a in attendance_unique})
+    # Average PAX mirrors pax-vault's AVG(pax_count): average the recorded pax_count
+    # over events that have one; fall back to tagged attendance only if none do
+    recorded_counts = [e.pax_count for e in events if e.pax_count is not None]
+    if recorded_counts:
+        stats.avg_pax = round(sum(recorded_counts) / len(recorded_counts), 2)
+    else:
+        stats.avg_pax = round(sum(event_attendance(e) for e in events) / len(events), 2)
+
+    # FNGs by AO
+    fng_counts: Dict[str, int] = defaultdict(int)
+    fng_names: Dict[str, List[str]] = defaultdict(list)
+    for e in events:
+        names = extract_fng_names(e.backblast)
+        count = e.fng_count if e.fng_count else len(names)
+        if count > 0 or names:
+            label = ao_label(e.ao_name, e.ao_channel_id)
+            fng_counts[label] += max(count, len(names))
+            for name in names:
+                if name not in fng_names[label]:
+                    fng_names[label].append(name)
+    stats.fngs_by_ao = sorted(
+        [(count, label, ", ".join(f"@{n}" for n in sorted(fng_names[label]))) for label, count in fng_counts.items()],
+        key=lambda row: (-row[0], row[1]),
+    )
+
+    # Highest attended workout at each AO
+    events_by_ao: Dict[str, List[WeeklyEvent]] = defaultdict(list)
+    for e in events:
+        events_by_ao[e.ao_org_id or e.ao_name].append(e)
+    q_by_event: Dict[int, str] = {}
+    for a in attendance_unique:
+        if a.q_ind and a.f3_name and a.event_id not in q_by_event:
+            q_by_event[a.event_id] = a.f3_name
+    top_rows = []
+    for ao_events in events_by_ao.values():
+        top = max(ao_events, key=event_attendance)
+        q_name = f"@{q_by_event[top.event_id]}" if top.event_id in q_by_event else ""
+        title = f"{top.name} ({top.start_date.strftime('%a %m/%d/%y')})"
+        top_rows.append((event_attendance(top), ao_label(top.ao_name, top.ao_channel_id), q_name, title))
+    stats.top_ao_events = sorted(top_rows, key=lambda row: (-row[0], row[1]))
+
+    # Top posters (dense rank <= 3 by post count)
+    post_counts: Dict[str, int] = defaultdict(int)
+    for a in attendance_unique:
+        if a.f3_name:
+            post_counts[a.f3_name] += 1
+    distinct_counts = sorted(set(post_counts.values()), reverse=True)[:3]
+    stats.top_posters = sorted(
+        [(count, name) for name, count in post_counts.items() if count in distinct_counts],
+        key=lambda row: (-row[0], row[1].lower()),
+    )
+
+    # Top Qs
+    q_counts: Dict[str, int] = defaultdict(int)
+    for a in attendance_unique:
+        if a.q_ind and a.f3_name:
+            q_counts[a.f3_name] += 1
+    stats.top_qs = sorted(
+        [(count, name) for name, count in q_counts.items()],
+        key=lambda row: (-row[0], row[1].lower()),
+    )[:10]
+
+    return stats
+
+
+def build_weekly_report_text(region_record: SlackSettings, stats: WeeklyRegionStats) -> str:
+    sections = region_record.weekly_report_sections or DEFAULT_WEEKLY_SECTIONS
+    parts: List[str] = [WEEKLY_REPORT_TITLE]
+
+    if WEEKLY_SECTION_SUMMARY in sections:
+        header = region_record.weekly_report_intro_template or DEFAULT_WEEKLY_INTRO_TEMPLATE
+        values = _SafeFormatDict(
+            total_events=stats.total_events,
+            ao_count=stats.ao_count,
+            unique_qs=stats.unique_qs,
+            fng_count=stats.fng_count,
+            avg_pax=stats.avg_pax,
+            unique_pax=stats.unique_pax,
+            avg_pax_record=stats.avg_pax_record,
+            unique_pax_record=stats.unique_pax_record,
+        )
+        try:
+            summary_lines = [header.format_map(values)] if header else []
+        except (ValueError, IndexError):
+            # a malformed user header (e.g. stray braces) should not kill the report
+            summary_lines = [DEFAULT_WEEKLY_INTRO_TEMPLATE]
+
+        metrics = region_record.weekly_report_summary_metrics
+        if metrics is None:
+            metrics = DEFAULT_WEEKLY_SUMMARY_METRICS
+        for metric in DEFAULT_WEEKLY_SUMMARY_METRICS:
+            if metric in metrics:
+                summary_lines.append(WEEKLY_SUMMARY_METRIC_LINES[metric].format_map(values))
+        if summary_lines:
+            parts.append("\n".join(summary_lines))
+
+    # Row lines below use "• " bullets rather than padded multi-space columns — Slack's
+    # mrkdwn renderer collapses consecutive spaces outside of code blocks, so a manually
+    # spaced-out "column" layout doesn't actually stay aligned once posted.
+    #
+    # Each section's header text is admin-overridable (see reporting.py's Reporting
+    # Settings form) — a blank/unset override falls back to the built-in default here.
+    if WEEKLY_SECTION_FNGS in sections and stats.fngs_by_ao:
+        lines = [region_record.weekly_report_fngs_header or FNGS_SECTION_HEADER, ""]
+        for count, label, names in stats.fngs_by_ao:
+            lines.append(f"• {label} — {names}" if names else f"• {label} — {count}")
+        parts.append("\n".join(lines))
+
+    if WEEKLY_SECTION_TOP_AO_POSTS in sections and stats.top_ao_events:
+        lines = [region_record.weekly_report_top_ao_posts_header or TOP_AO_POSTS_SECTION_HEADER, ""]
+        for attendance, label, q_name, title in stats.top_ao_events:
+            q_part = f", Q: {q_name}" if q_name else ""
+            lines.append(f"• {label} — {attendance} PAX{q_part} — {title}")
+        parts.append("\n".join(lines))
+
+    if WEEKLY_SECTION_TOP_POSTERS in sections and stats.top_posters:
+        lines = [region_record.weekly_report_top_posters_header or TOP_POSTERS_SECTION_HEADER, ""]
+        lines += [f"• @{name} — {count}" for count, name in stats.top_posters]
+        parts.append("\n".join(lines))
+
+    if WEEKLY_SECTION_TOP_QS in sections and stats.top_qs:
+        lines = [region_record.weekly_report_top_qs_header or TOP_QS_SECTION_HEADER, ""]
+        lines += [f"• @{name} — {count}" for count, name in stats.top_qs]
+        parts.append("\n".join(lines))
+
+    if WEEKLY_SECTION_FLAGS in sections and stats.flags:
+        lines = [region_record.weekly_report_flags_header or FLAGS_SECTION_HEADER, ""]
+        lines += [f"• {name} — {holder}" for name, holder in stats.flags]
+        parts.append("\n".join(lines))
+
+    return "\n\n".join(parts)
+
+
+def pull_weekly_data(
+    org_ids: List[int], window_start: date, window_end: date
+) -> Dict[int, tuple[List[WeeklyEvent], List[WeeklyAttendanceRecord]]]:
+    """Pulls first-F events + attendance for the window, grouped by region org id."""
+    if not org_ids:
+        return {}
+    session = get_session()
+    try:
+        event_rows = session.execute(
+            select(
+                EventInstanceExpanded.id,
+                EventInstanceExpanded.name,
+                EventInstanceExpanded.start_date,
+                EventInstanceExpanded.ao_org_id,
+                EventInstanceExpanded.ao_name,
+                EventInstanceExpanded.ao_meta,
+                EventInstanceExpanded.pax_count,
+                EventInstanceExpanded.fng_count,
+                EventInstanceExpanded.backblast,
+                EventInstanceExpanded.region_org_id,
+            ).where(
+                EventInstanceExpanded.region_org_id.in_(org_ids),
+                EventInstanceExpanded.start_date >= window_start,
+                EventInstanceExpanded.start_date <= window_end,
+                EventInstanceExpanded.first_f_ind == 1,
+            )
+        ).all()
+
+        region_by_event: Dict[int, int] = {row.id: row.region_org_id for row in event_rows}
+        attendance_rows = []
+        if region_by_event:
+            # Actual attendance only (is_planned=False) — mirrors pax-vault, which strips
+            # "fartsack" rows (signed up but no-showed) from all counts
+            q_case = case((Attendance_x_AttendanceType.attendance_type_id == Q_ATTENDANCE_TYPE_ID, 1), else_=0)
+            attendance_rows = session.execute(
+                select(
+                    Attendance.event_instance_id,
+                    Attendance.user_id,
+                    User.f3_name,
+                    func.max(q_case).label("q_ind"),
+                )
+                .join(User, User.id == Attendance.user_id)
+                .outerjoin(Attendance_x_AttendanceType, Attendance_x_AttendanceType.attendance_id == Attendance.id)
+                .where(
+                    Attendance.event_instance_id.in_(list(region_by_event.keys())),
+                    Attendance.is_planned.is_(False),
+                )
+                .group_by(Attendance.event_instance_id, Attendance.user_id, User.f3_name)
+            ).all()
+    finally:
+        session.close()
+
+    data: Dict[int, tuple[List[WeeklyEvent], List[WeeklyAttendanceRecord]]] = {org_id: ([], []) for org_id in org_ids}
+    for row in event_rows:
+        data[row.region_org_id][0].append(
+            WeeklyEvent(
+                event_id=row.id,
+                name=row.name,
+                start_date=row.start_date,
+                ao_org_id=row.ao_org_id,
+                ao_name=row.ao_name,
+                ao_channel_id=safe_get(row.ao_meta or {}, "slack_channel_id"),
+                pax_count=row.pax_count,
+                fng_count=row.fng_count,
+                backblast=row.backblast,
+            )
+        )
+    for row in attendance_rows:
+        region_org_id = region_by_event.get(row.event_instance_id)
+        if region_org_id in data:
+            data[region_org_id][1].append(
+                WeeklyAttendanceRecord(
+                    event_id=row.event_instance_id,
+                    user_id=row.user_id,
+                    f3_name=row.f3_name,
+                    q_ind=row.q_ind or 0,
+                )
+            )
+    return data
+
+
+def pull_flag_candidates(org_ids: List[int], window_end: date) -> Dict[int, List[FlagCandidate]]:
+    """Pulls events with preblast/backblast text or custom-field data within the lookback
+    window, grouped by region, for resolving each region's configured flags' current holders.
+    Since each region can configure different flag hashtags/custom fields, the per-flag match
+    happens in Python (resolve_org_flags), not in SQL — this just gathers the raw candidate
+    pool once per region."""
+    if not org_ids:
+        return {}
+    session = get_session()
+    try:
+        event_rows = session.execute(
+            select(
+                EventInstanceExpanded.region_org_id,
+                EventInstanceExpanded.start_date,
+                EventInstanceExpanded.ao_name,
+                EventInstanceExpanded.ao_meta,
+                EventInstanceExpanded.preblast,
+                EventInstanceExpanded.backblast,
+                EventInstanceExpanded.meta,
+            ).where(
+                EventInstanceExpanded.region_org_id.in_(org_ids),
+                EventInstanceExpanded.start_date > window_end - timedelta(days=FLAG_LOOKBACK_DAYS),
+                EventInstanceExpanded.start_date <= window_end,
+                (EventInstanceExpanded.preblast.is_not(None))
+                | (EventInstanceExpanded.backblast.is_not(None))
+                | (EventInstanceExpanded.meta.is_not(None)),
+            )
+        ).all()
+    finally:
+        session.close()
+
+    candidates_by_region: Dict[int, List[FlagCandidate]] = defaultdict(list)
+    for row in event_rows:
+        candidates_by_region[row.region_org_id].append(
+            FlagCandidate(
+                start_date=row.start_date,
+                ao_name=row.ao_name,
+                ao_channel_id=safe_get(row.ao_meta or {}, "slack_channel_id"),
+                preblast=row.preblast,
+                backblast=row.backblast,
+                meta=row.meta,
+            )
+        )
+    return {org_id: candidates_by_region.get(org_id, []) for org_id in org_ids}
+
+
+def pull_weekly_records(org_ids: List[int], window_end: date) -> Dict[int, tuple[float, int]]:
+    """Computes each region's all-time weekly records: (best average PAX, best unique PAX).
+
+    History is split into 7-day buckets aligned to window_end so the current report
+    window is one of the buckets and the numbers stay directly comparable.
+    """
+    if not org_ids:
+        return {}
+    session = get_session()
+    try:
+        # In Postgres, date - date yields integer days; integer / 7 floors to the bucket
+        days_ago = cast(literal(window_end, Date) - EventInstanceExpanded.start_date, Integer)
+        bucket = days_ago.op("/")(7)
+
+        avg_rows = session.execute(
+            select(
+                EventInstanceExpanded.region_org_id,
+                bucket.label("bucket"),
+                func.avg(EventInstanceExpanded.pax_count).label("avg_pax"),
+            )
+            .where(
+                EventInstanceExpanded.region_org_id.in_(org_ids),
+                EventInstanceExpanded.start_date <= window_end,
+                EventInstanceExpanded.first_f_ind == 1,
+            )
+            .group_by(EventInstanceExpanded.region_org_id, bucket)
+        ).all()
+
+        unique_rows = session.execute(
+            select(
+                EventInstanceExpanded.region_org_id,
+                bucket.label("bucket"),
+                func.count(func.distinct(Attendance.user_id)).label("unique_pax"),
+            )
+            .select_from(EventInstanceExpanded)
+            .join(Attendance, Attendance.event_instance_id == EventInstanceExpanded.id)
+            .where(
+                EventInstanceExpanded.region_org_id.in_(org_ids),
+                EventInstanceExpanded.start_date <= window_end,
+                EventInstanceExpanded.first_f_ind == 1,
+                Attendance.is_planned.is_(False),
+            )
+            .group_by(EventInstanceExpanded.region_org_id, bucket)
+        ).all()
+    finally:
+        session.close()
+
+    records: Dict[int, tuple[float, int]] = {}
+    best_avg: Dict[int, float] = defaultdict(float)
+    best_unique: Dict[int, int] = defaultdict(int)
+    for row in avg_rows:
+        if row.avg_pax is not None:
+            best_avg[row.region_org_id] = max(best_avg[row.region_org_id], round(float(row.avg_pax), 2))
+    for row in unique_rows:
+        best_unique[row.region_org_id] = max(best_unique[row.region_org_id], int(row.unique_pax))
+    for org_id in org_ids:
+        records[org_id] = (best_avg.get(org_id, 0.0), best_unique.get(org_id, 0))
+    return records
+
+
+def send_weekly_report(region_record: SlackSettings, text: str, channel: str):
+    if not region_record.bot_token or not channel or not text:
+        print("Slack bot token, weekly report destination, or report text missing; skipping send")
+        return
+
+    ssl_context = ssl.create_default_context()
+    ssl_context.check_hostname = False
+    ssl_context.verify_mode = ssl.CERT_NONE
+    client = WebClient(token=region_record.bot_token, ssl=ssl_context)
+    try:
+        client.chat_postMessage(channel=channel, text=text)
+    except SlackApiError as e:
+        if e.response["error"] == "not_in_channel":
+            try:
+                client.conversations_join(channel=channel)
+                client.chat_postMessage(channel=channel, text=text)
+            except SlackApiError as e2:
+                print(f"Error joining channel or sending weekly report: {e2.response['error']}")
+        else:
+            print(f"Error sending weekly report: {e.response['error']}")
+
+
+def run_weekly_report_for_region(
+    region_record: SlackSettings, window_end: Optional[date] = None, dry_run: bool = False
+):
+    # The report covers the N full days ending yesterday (CST): 7 for weekly, 14 for
+    # biweekly, so a Monday send covers the prior week(s) through Sunday
+    window_end = window_end or (datetime.now(pytz.timezone("US/Central")).date() - timedelta(days=1))
+    window_start = window_end - timedelta(days=report_window_days(region_record.weekly_report_frequency) - 1)
+    data = pull_weekly_data([region_record.org_id], window_start, window_end)
+    records = pull_weekly_records([region_record.org_id], window_end)
+    flag_candidates = pull_flag_candidates([region_record.org_id], window_end)
+    events, attendance = data.get(region_record.org_id, ([], []))
+    stats = compute_weekly_stats(events, attendance)
+    stats.avg_pax_record, stats.unique_pax_record = records.get(region_record.org_id, (0.0, 0))
+    stats.flags = resolve_org_flags(region_record.weekly_report_flags, flag_candidates.get(region_record.org_id, []))
+    text = build_weekly_report_text(region_record, stats)
+    if dry_run:
+        print(f"--- weekly report for org {region_record.org_id} ({window_start} to {window_end}) ---")
+        print(text)
+        return
+    channel = region_record.weekly_report_destination or region_record.reporting_region_channel
+    send_weekly_report(region_record, text, channel)
+
+
+def run_weekly_report_single_org(
+    body: dict, client: WebClient, logger: any, context: dict, region_record: SlackSettings
+):
+    """Handler for the 'Send Weekly Report Now' button in the reporting settings modal."""
+    run_weekly_report_for_region(region_record)
+
+
+def cycle_weekly_reports(force_org_id: int = None, dry_run: bool = False):
+    current_time = datetime.now(pytz.timezone("US/Central"))
+    slack_spaces = DbManager.find_records(SlackSpace, filters=[True])
+    settings_list: List[SlackSettings] = [
+        SlackSettings(**s.settings) for s in slack_spaces if safe_get(s.settings, "org_id")
+    ]
+
+    def is_due(s: SlackSettings) -> bool:
+        day = s.weekly_report_day if s.weekly_report_day is not None else DEFAULT_WEEKLY_DAY
+        hour = s.weekly_report_hour_cst if s.weekly_report_hour_cst is not None else DEFAULT_WEEKLY_HOUR_CST
+        if not (bool(s.weekly_report_enabled) and day == current_time.weekday() and hour == current_time.hour):
+            return False
+        frequency = s.weekly_report_frequency or DEFAULT_WEEKLY_FREQUENCY
+        if frequency == FREQUENCY_BIWEEKLY and not is_biweekly_send_week(current_time.date()):
+            return False
+        return True
+
+    due_settings = [s for s in settings_list if is_due(s) or s.org_id == force_org_id]
+    if not due_settings and force_org_id and dry_run:
+        # allow local/dry-run testing for a region that has no Slack space connected yet
+        due_settings = [SlackSettings(team_id="dry-run", org_id=force_org_id)]
+    if not due_settings:
+        return
+
+    window_end = current_time.date() - timedelta(days=1)
+
+    # group by window length (weekly vs biweekly) so each group's data is pulled in one batch
+    settings_by_window_days: Dict[int, List[SlackSettings]] = defaultdict(list)
+    for s in due_settings:
+        settings_by_window_days[report_window_days(s.weekly_report_frequency)].append(s)
+
+    for window_days, group in settings_by_window_days.items():
+        window_start = window_end - timedelta(days=window_days - 1)
+        org_ids = [s.org_id for s in group]
+        data = pull_weekly_data(org_ids, window_start, window_end)
+        records = pull_weekly_records(org_ids, window_end)
+        flag_candidates = pull_flag_candidates(org_ids, window_end)
+        for settings in group:
+            try:
+                events, attendance = data.get(settings.org_id, ([], []))
+                stats = compute_weekly_stats(events, attendance)
+                stats.avg_pax_record, stats.unique_pax_record = records.get(settings.org_id, (0.0, 0))
+                stats.flags = resolve_org_flags(settings.weekly_report_flags, flag_candidates.get(settings.org_id, []))
+                text = build_weekly_report_text(settings, stats)
+                if dry_run:
+                    print(f"--- weekly report for org {settings.org_id} ({window_start} to {window_end}) ---")
+                    print(text)
+                    continue
+                channel = settings.weekly_report_destination or settings.reporting_region_channel
+                send_weekly_report(settings, text, channel)
+            except Exception as e:
+                print(f"Error sending weekly report for org {settings.org_id}: {e}")
+                continue
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Run weekly reporting")
+    parser.add_argument("--org-id", type=int, default=None, help="Force-run for a single org, ignoring schedules")
+    parser.add_argument("--dry-run", action="store_true", help="Print the report(s) instead of sending to Slack")
+    args = parser.parse_args()
+    cycle_weekly_reports(force_org_id=args.org_id, dry_run=args.dry_run)

--- a/apps/slackbot/scripts/weekly_reporting.py
+++ b/apps/slackbot/scripts/weekly_reporting.py
@@ -92,7 +92,21 @@ WEEKLY_SUMMARY_METRIC_LINES = {
 }
 
 DEFAULT_WEEKLY_DAY = 0  # Monday
-DEFAULT_WEEKLY_HOUR_CST = 8
+DEFAULT_WEEKLY_HOUR = 8
+
+# Regions can be anywhere in the US (or beyond) — weekly_report_day/_hour are interpreted in
+# whichever of these the region picks (SlackSettings.weekly_report_timezone), not a fixed
+# server timezone. Defaults to Central to match this report's original fixed-CST behavior.
+DEFAULT_WEEKLY_TIMEZONE = "America/Chicago"
+WEEKLY_REPORT_TIMEZONE_OPTIONS = {
+    "America/New_York": "Eastern",
+    "America/Chicago": "Central",
+    "America/Denver": "Mountain",
+    "America/Phoenix": "Arizona (no DST)",
+    "America/Los_Angeles": "Pacific",
+    "America/Anchorage": "Alaska",
+    "Pacific/Honolulu": "Hawaii",
+}
 
 # "weekly" sends every week on weekly_report_day; "biweekly" sends every other week,
 # in sync across all regions (see is_biweekly_send_week)
@@ -654,12 +668,21 @@ def send_weekly_report(region_record: SlackSettings, text: str, channel: str):
             print(f"Error sending weekly report: {e.response['error']}")
 
 
+def region_timezone(region_record: SlackSettings) -> pytz.BaseTzInfo:
+    return pytz.timezone(region_record.weekly_report_timezone or DEFAULT_WEEKLY_TIMEZONE)
+
+
+def region_local_window_end(region_record: SlackSettings) -> date:
+    """Yesterday, in the region's own configured timezone (defaults to Central)."""
+    return datetime.now(region_timezone(region_record)).date() - timedelta(days=1)
+
+
 def run_weekly_report_for_region(
     region_record: SlackSettings, window_end: Optional[date] = None, dry_run: bool = False
 ):
-    # The report covers the N full days ending yesterday (CST): 7 for weekly, 14 for
-    # biweekly, so a Monday send covers the prior week(s) through Sunday
-    window_end = window_end or (datetime.now(pytz.timezone("US/Central")).date() - timedelta(days=1))
+    # The report covers the N full days ending yesterday, in the region's own timezone:
+    # 7 for weekly, 14 for biweekly, so a Monday send covers the prior week(s) through Sunday
+    window_end = window_end or region_local_window_end(region_record)
     window_start = window_end - timedelta(days=report_window_days(region_record.weekly_report_frequency) - 1)
     data = pull_weekly_data([region_record.org_id], window_start, window_end)
     records = pull_weekly_records([region_record.org_id], window_end)
@@ -685,19 +708,22 @@ def run_weekly_report_single_org(
 
 
 def cycle_weekly_reports(force_org_id: int = None, dry_run: bool = False):
-    current_time = datetime.now(pytz.timezone("US/Central"))
     slack_spaces = DbManager.find_records(SlackSpace, filters=[True])
     settings_list: List[SlackSettings] = [
         SlackSettings(**s.settings) for s in slack_spaces if safe_get(s.settings, "org_id")
     ]
 
     def is_due(s: SlackSettings) -> bool:
+        # weekly_report_day/_hour are in the region's own configured timezone, not a fixed
+        # server timezone — this cron runs hourly, so only the regions whose local clock
+        # currently matches their configured send day/hour are due on this particular tick.
+        local_now = datetime.now(region_timezone(s))
         day = s.weekly_report_day if s.weekly_report_day is not None else DEFAULT_WEEKLY_DAY
-        hour = s.weekly_report_hour_cst if s.weekly_report_hour_cst is not None else DEFAULT_WEEKLY_HOUR_CST
-        if not (bool(s.weekly_report_enabled) and day == current_time.weekday() and hour == current_time.hour):
+        hour = s.weekly_report_hour_cst if s.weekly_report_hour_cst is not None else DEFAULT_WEEKLY_HOUR
+        if not (bool(s.weekly_report_enabled) and day == local_now.weekday() and hour == local_now.hour):
             return False
         frequency = s.weekly_report_frequency or DEFAULT_WEEKLY_FREQUENCY
-        if frequency == FREQUENCY_BIWEEKLY and not is_biweekly_send_week(current_time.date()):
+        if frequency == FREQUENCY_BIWEEKLY and not is_biweekly_send_week(local_now.date()):
             return False
         return True
 
@@ -708,14 +734,16 @@ def cycle_weekly_reports(force_org_id: int = None, dry_run: bool = False):
     if not due_settings:
         return
 
-    window_end = current_time.date() - timedelta(days=1)
-
-    # group by window length (weekly vs biweekly) so each group's data is pulled in one batch
-    settings_by_window_days: Dict[int, List[SlackSettings]] = defaultdict(list)
+    # Group by (window length, window end) rather than just window length — due regions can
+    # span multiple timezones, and each one's "yesterday" is computed in its own timezone
+    # (see region_local_window_end), so window_end isn't necessarily the same across all of
+    # them even within a single cron tick.
+    settings_by_window: Dict[tuple, List[SlackSettings]] = defaultdict(list)
     for s in due_settings:
-        settings_by_window_days[report_window_days(s.weekly_report_frequency)].append(s)
+        window_key = (report_window_days(s.weekly_report_frequency), region_local_window_end(s))
+        settings_by_window[window_key].append(s)
 
-    for window_days, group in settings_by_window_days.items():
+    for (window_days, window_end), group in settings_by_window.items():
         window_start = window_end - timedelta(days=window_days - 1)
         org_ids = [s.org_id for s in group]
         data = pull_weekly_data(org_ids, window_start, window_end)

--- a/apps/slackbot/tests/scripts/test_weekly_reporting.py
+++ b/apps/slackbot/tests/scripts/test_weekly_reporting.py
@@ -1,0 +1,530 @@
+import os
+import sys
+import unittest
+from datetime import date, timedelta
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+
+from scripts.weekly_reporting import (
+    BIWEEKLY_EPOCH_MONDAY,
+    DEFAULT_WEEKLY_SECTIONS,
+    DEFAULT_WEEKLY_SUMMARY_METRICS,
+    FLAG_HOLDER_FALLBACK,
+    FLAG_HOLDER_LOCATION,
+    FLAG_HOLDER_PAX,
+    SUMMARY_METRIC_AVG_PAX,
+    SUMMARY_METRIC_TOTAL_EVENTS,
+    SUMMARY_METRIC_UNIQUE_PAX,
+    WEEKLY_SECTION_FLAGS,
+    WEEKLY_SECTION_FNGS,
+    WEEKLY_SECTION_SUMMARY,
+    WEEKLY_SECTION_TOP_QS,
+    FlagCandidate,
+    WeeklyAttendanceRecord,
+    WeeklyEvent,
+    ao_label,
+    build_flag_pattern,
+    build_weekly_report_text,
+    compute_weekly_stats,
+    extract_fng_names,
+    is_biweekly_send_week,
+    report_window_days,
+    resolve_custom_field_holder,
+    resolve_location_holder,
+    resolve_org_flags,
+)
+from utilities.database.orm import SlackSettings
+
+
+def _make_event(
+    event_id=1,
+    name="Beatdown",
+    start_date=date(2026, 7, 20),
+    ao_org_id=100,
+    ao_name="The Landing",
+    ao_channel_id=None,
+    pax_count=None,
+    fng_count=None,
+    backblast=None,
+):
+    return WeeklyEvent(
+        event_id=event_id,
+        name=name,
+        start_date=start_date,
+        ao_org_id=ao_org_id,
+        ao_name=ao_name,
+        ao_channel_id=ao_channel_id,
+        pax_count=pax_count,
+        fng_count=fng_count,
+        backblast=backblast,
+    )
+
+
+def _make_attendance(event_id=1, user_id=1, f3_name="Roma", q_ind=0):
+    return WeeklyAttendanceRecord(event_id=event_id, user_id=user_id, f3_name=f3_name, q_ind=q_ind)
+
+
+def _make_region_record(**kwargs):
+    return SlackSettings(team_id="T123", org_id=50049, **kwargs)
+
+
+class TestAoLabel(unittest.TestCase):
+    def test_uses_channel_mention_when_channel_known(self):
+        self.assertEqual(ao_label("The Landing", "C12345"), "<#C12345>")
+
+    def test_slugifies_ao_name_without_channel(self):
+        self.assertEqual(ao_label("Field of Dreams!", None), "#field-of-dreams")
+
+    def test_handles_missing_name(self):
+        self.assertEqual(ao_label(None, None), "#unknown")
+
+
+class TestExtractFngNames(unittest.TestCase):
+    def test_extracts_names_after_count(self):
+        backblast = "Q: Roma\nFNGs: 2 Apollo, Beaker\nCOUNT: 10"
+        self.assertEqual(extract_fng_names(backblast), ["Apollo", "Beaker"])
+
+    def test_filters_none_placeholders(self):
+        self.assertEqual(extract_fng_names("FNGs: 0 None\nCOUNT: 5"), [])
+
+    def test_no_fng_line(self):
+        self.assertEqual(extract_fng_names("COUNT: 5"), [])
+        self.assertEqual(extract_fng_names(None), [])
+
+
+class TestBuildFlagPattern(unittest.TestCase):
+    def test_matches_hashtag_variations_for_multiword_core(self):
+        pattern = build_flag_pattern("ghost flag")
+        for tag in ("#ghostflag", "#GhostFlag", "#ghost-flag", "#f3ghostflag", "#nwpghostflag", "#nwp-ghost-flag"):
+            self.assertTrue(pattern.search(f"Great beatdown! {tag} was planted"), tag)
+
+    def test_matches_single_word_core(self):
+        pattern = build_flag_pattern("pirateflag")
+        self.assertTrue(pattern.search("The #pirateflag was defended!"))
+
+    def test_does_not_match_unrelated_text(self):
+        pattern = build_flag_pattern("him belt")
+        self.assertFalse(pattern.search("we saw a ghost out there, no flag though"))
+
+    def test_empty_hashtag_never_matches(self):
+        pattern = build_flag_pattern("")
+        self.assertFalse(pattern.search("#anything"))
+
+
+class TestResolveLocationHolder(unittest.TestCase):
+    def _candidate(self, start_date, text, ao_name="Field of Dreams", ao_channel_id=None, in_preblast=False):
+        return FlagCandidate(
+            start_date=start_date,
+            ao_name=ao_name,
+            ao_channel_id=ao_channel_id,
+            preblast=text if in_preblast else None,
+            backblast=None if in_preblast else text,
+            meta=None,
+        )
+
+    def test_uses_ao_label(self):
+        pattern = build_flag_pattern("ghost flag")
+        candidates = [self._candidate(date(2026, 7, 20), "#ghostflag was planted")]
+        self.assertEqual(resolve_location_holder(candidates, pattern), "#field-of-dreams")
+
+    def test_matches_in_preblast(self):
+        pattern = build_flag_pattern("ghost flag")
+        candidates = [self._candidate(date(2026, 7, 20), "Bring the #ghostflag!", in_preblast=True)]
+        self.assertEqual(resolve_location_holder(candidates, pattern), "#field-of-dreams")
+
+    def test_most_recent_event_wins(self):
+        pattern = build_flag_pattern("ghost flag")
+        candidates = [
+            self._candidate(date(2026, 7, 1), "#ghostflag", ao_name="The Landing"),
+            self._candidate(date(2026, 7, 20), "#ghostflag", ao_name="The Hub", ao_channel_id="CHUB"),
+        ]
+        self.assertEqual(resolve_location_holder(candidates, pattern), "<#CHUB>")
+
+    def test_empty_candidates(self):
+        pattern = build_flag_pattern("ghost flag")
+        self.assertIsNone(resolve_location_holder([], pattern))
+
+
+class TestResolveCustomFieldHolder(unittest.TestCase):
+    def _candidate(self, start_date, meta=None):
+        return FlagCandidate(
+            start_date=start_date,
+            ao_name="Field of Dreams",
+            ao_channel_id=None,
+            preblast=None,
+            backblast=None,
+            meta=meta,
+        )
+
+    def test_pax_reads_custom_field_value_from_most_recent_event(self):
+        candidates = [
+            self._candidate(date(2026, 7, 1), meta={"HIM Belt Holder": "Zubat"}),
+            self._candidate(date(2026, 7, 20), meta={"HIM Belt Holder": "Roma"}),
+        ]
+        self.assertEqual(resolve_custom_field_holder(candidates, "HIM Belt Holder", FLAG_HOLDER_PAX), "@Roma")
+
+    def test_pax_already_at_mentioned_value_not_double_prefixed(self):
+        candidates = [self._candidate(date(2026, 7, 20), meta={"HIM Belt Holder": "@Roma"})]
+        self.assertEqual(resolve_custom_field_holder(candidates, "HIM Belt Holder", FLAG_HOLDER_PAX), "@Roma")
+
+    def test_pax_slack_mention_value_not_double_prefixed(self):
+        candidates = [self._candidate(date(2026, 7, 20), meta={"HIM Belt Holder": "<@U0123456>"})]
+        self.assertEqual(resolve_custom_field_holder(candidates, "HIM Belt Holder", FLAG_HOLDER_PAX), "<@U0123456>")
+
+    def test_location_channel_mention_value_not_double_formatted(self):
+        candidates = [self._candidate(date(2026, 7, 20), meta={"Ghost Flag AO": "<#C0123456>"})]
+        self.assertEqual(resolve_custom_field_holder(candidates, "Ghost Flag AO", FLAG_HOLDER_LOCATION), "<#C0123456>")
+
+    def test_location_plain_typed_value_gets_slugified(self):
+        candidates = [self._candidate(date(2026, 7, 20), meta={"Ghost Flag AO": "South End Station"})]
+        self.assertEqual(
+            resolve_custom_field_holder(candidates, "Ghost Flag AO", FLAG_HOLDER_LOCATION),
+            "#south-end-station",
+        )
+
+    def test_skips_events_missing_the_field_to_find_most_recent_set_value(self):
+        candidates = [
+            self._candidate(date(2026, 7, 20), meta={"Other Field": "x"}),
+            self._candidate(date(2026, 7, 10), meta={"HIM Belt Holder": "Bramble"}),
+        ]
+        self.assertEqual(resolve_custom_field_holder(candidates, "HIM Belt Holder", FLAG_HOLDER_PAX), "@Bramble")
+
+    def test_no_custom_field_name_returns_none(self):
+        candidates = [self._candidate(date(2026, 7, 20), meta={"HIM Belt Holder": "Roma"})]
+        self.assertIsNone(resolve_custom_field_holder(candidates, "", FLAG_HOLDER_PAX))
+
+    def test_never_set_returns_none(self):
+        candidates = [self._candidate(date(2026, 7, 20), meta={})]
+        self.assertIsNone(resolve_custom_field_holder(candidates, "HIM Belt Holder", FLAG_HOLDER_PAX))
+
+
+class TestResolveOrgFlags(unittest.TestCase):
+    def _candidate(self, start_date, text=None, ao_name="Field of Dreams", meta=None):
+        return FlagCandidate(
+            start_date=start_date, ao_name=ao_name, ao_channel_id=None, preblast=None, backblast=text, meta=meta
+        )
+
+    def test_resolves_multiple_flags_in_configured_order(self):
+        flags_config = {
+            "ghost-flag": {
+                "name": "Ghost Flag",
+                "hashtag": "ghost flag",
+                "holder_type": FLAG_HOLDER_LOCATION,
+                "enabled": True,
+            },
+            "him-belt": {
+                "name": "HIM Belt",
+                "custom_field_name": "HIM Belt Holder",
+                "holder_type": FLAG_HOLDER_PAX,
+                "enabled": True,
+            },
+        }
+        candidates = [
+            self._candidate(date(2026, 7, 20), text="#ghostflag planted"),
+            self._candidate(date(2026, 7, 21), meta={"HIM Belt Holder": "Bramble"}),
+        ]
+        resolved = resolve_org_flags(flags_config, candidates)
+        self.assertEqual(resolved, [("Ghost Flag", "#field-of-dreams"), ("HIM Belt", "@Bramble")])
+
+    def test_disabled_flags_are_skipped(self):
+        flags_config = {
+            "ghost-flag": {
+                "name": "Ghost Flag",
+                "hashtag": "ghost flag",
+                "holder_type": FLAG_HOLDER_LOCATION,
+                "enabled": False,
+            },
+        }
+        candidates = [self._candidate(date(2026, 7, 20), text="#ghostflag planted")]
+        self.assertEqual(resolve_org_flags(flags_config, candidates), [])
+
+    def test_unmatched_flag_uses_fallback(self):
+        flags_config = {
+            "ghost-flag": {
+                "name": "Ghost Flag",
+                "hashtag": "ghost flag",
+                "holder_type": FLAG_HOLDER_LOCATION,
+                "enabled": True,
+            },
+        }
+        self.assertEqual(resolve_org_flags(flags_config, []), [("Ghost Flag", FLAG_HOLDER_FALLBACK)])
+
+    def test_pax_flag_without_custom_field_name_uses_fallback(self):
+        flags_config = {
+            "him-belt": {"name": "HIM Belt", "holder_type": FLAG_HOLDER_PAX, "enabled": True},
+        }
+        candidates = [self._candidate(date(2026, 7, 20), meta={"HIM Belt Holder": "Roma"})]
+        self.assertEqual(resolve_org_flags(flags_config, candidates), [("HIM Belt", FLAG_HOLDER_FALLBACK)])
+
+    def test_location_flag_prefers_custom_field_over_hashtag_when_both_set(self):
+        flags_config = {
+            "ghost-flag": {
+                "name": "Ghost Flag",
+                "hashtag": "ghost flag",
+                "custom_field_name": "Ghost Flag AO",
+                "holder_type": FLAG_HOLDER_LOCATION,
+                "enabled": True,
+            },
+        }
+        # only the custom field is populated on this candidate; the hashtag never appears in
+        # the text, proving the custom field path is used rather than falling through to text
+        candidates = [self._candidate(date(2026, 7, 20), text="no hashtag here", meta={"Ghost Flag AO": "<#CFOD>"})]
+        self.assertEqual(resolve_org_flags(flags_config, candidates), [("Ghost Flag", "<#CFOD>")])
+
+    def test_location_flag_falls_back_to_hashtag_without_custom_field(self):
+        flags_config = {
+            "ghost-flag": {
+                "name": "Ghost Flag",
+                "hashtag": "ghost flag",
+                "holder_type": FLAG_HOLDER_LOCATION,
+                "enabled": True,
+            },
+        }
+        candidates = [self._candidate(date(2026, 7, 20), text="#ghostflag planted")]
+        self.assertEqual(resolve_org_flags(flags_config, candidates), [("Ghost Flag", "#field-of-dreams")])
+
+    def test_none_config_returns_empty(self):
+        self.assertEqual(resolve_org_flags(None, []), [])
+
+
+class TestComputeWeeklyStats(unittest.TestCase):
+    def _fixture(self):
+        events = [
+            _make_event(
+                event_id=1,
+                ao_org_id=100,
+                ao_name="The Landing",
+                pax_count=25,
+                fng_count=1,
+                backblast="FNGs: 1 Dumpster Fire\nCOUNT: 25",
+            ),
+            _make_event(event_id=2, ao_org_id=100, ao_name="The Landing", pax_count=10),
+            _make_event(
+                event_id=3, ao_org_id=200, ao_name="The Hub", ao_channel_id="CHUB", pax_count=None
+            ),  # falls back to tagged attendance
+        ]
+        attendance = [
+            _make_attendance(event_id=1, user_id=1, f3_name="Bramble", q_ind=1),
+            _make_attendance(event_id=1, user_id=2, f3_name="Roma"),
+            _make_attendance(event_id=2, user_id=1, f3_name="Bramble", q_ind=1),
+            _make_attendance(event_id=3, user_id=3, f3_name="Zubat", q_ind=1),
+            _make_attendance(event_id=3, user_id=2, f3_name="Roma"),
+            _make_attendance(event_id=3, user_id=2, f3_name="Roma"),  # duplicate row is deduped
+        ]
+        return events, attendance
+
+    def test_summary_numbers(self):
+        stats = compute_weekly_stats(*self._fixture())
+        self.assertEqual(stats.total_events, 3)
+        self.assertEqual(stats.ao_count, 2)
+        self.assertEqual(stats.unique_qs, 2)  # Bramble + Zubat
+        self.assertEqual(stats.fng_count, 1)
+        self.assertEqual(stats.unique_pax, 3)
+        # avg mirrors pax-vault's AVG(pax_count): only events with a recorded count
+        self.assertEqual(stats.avg_pax, round((25 + 10) / 2, 2))
+
+    def test_avg_pax_falls_back_to_tagged_when_no_recorded_counts(self):
+        events = [_make_event(event_id=1, pax_count=None)]
+        attendance = [
+            _make_attendance(event_id=1, user_id=1, f3_name="Bramble"),
+            _make_attendance(event_id=1, user_id=2, f3_name="Roma"),
+        ]
+        stats = compute_weekly_stats(events, attendance)
+        self.assertEqual(stats.avg_pax, 2.0)
+
+    def test_fngs_by_ao(self):
+        stats = compute_weekly_stats(*self._fixture())
+        self.assertEqual(stats.fngs_by_ao, [(1, "#the-landing", "@Dumpster Fire")])
+
+    def test_top_ao_events(self):
+        stats = compute_weekly_stats(*self._fixture())
+        self.assertEqual(len(stats.top_ao_events), 2)
+        attendance_count, label, q_name, title = stats.top_ao_events[0]
+        self.assertEqual(attendance_count, 25)
+        self.assertEqual(label, "#the-landing")
+        self.assertEqual(q_name, "@Bramble")
+        self.assertIn("Beatdown (", title)
+        self.assertEqual(stats.top_ao_events[1][1], "<#CHUB>")
+
+    def test_top_posters_and_qs(self):
+        stats = compute_weekly_stats(*self._fixture())
+        self.assertEqual(stats.top_posters, [(2, "Bramble"), (2, "Roma"), (1, "Zubat")])
+        self.assertEqual(stats.top_qs, [(2, "Bramble"), (1, "Zubat")])
+
+    def test_empty_events(self):
+        stats = compute_weekly_stats([], [])
+        self.assertEqual(stats.total_events, 0)
+        self.assertEqual(stats.fngs_by_ao, [])
+
+
+class TestBuildWeeklyReportText(unittest.TestCase):
+    def _stats(self):
+        events = [
+            _make_event(event_id=1, pax_count=10, fng_count=1, backblast="FNGs: 1 Apollo\nCOUNT: 10"),
+        ]
+        attendance = [_make_attendance(event_id=1, user_id=1, f3_name="Bramble", q_ind=1)]
+        return compute_weekly_stats(events, attendance)
+
+    def test_default_template_renders_placeholders(self):
+        record = _make_region_record()
+        text = build_weekly_report_text(record, self._stats())
+        self.assertIn("• Total Events: 1 Workouts", text)
+        self.assertIn("• FNGs: 1 FNGs :fire:", text)
+
+    def test_title_always_present(self):
+        record = _make_region_record()
+        text = build_weekly_report_text(record, self._stats())
+        self.assertTrue(text.startswith("*Weekly Region Report*"))
+
+    def test_no_slack_custom_emoji(self):
+        # :slack: is Slack's own bundled logo glyph, not a standard Unicode emoji — some
+        # regions' workspaces may not reliably render it, so it must never appear.
+        record = _make_region_record(weekly_report_sections=None)
+        stats = self._stats()
+        stats.flags = [("Ghost Flag", "#field-of-dreams")]
+        text = build_weekly_report_text(record, stats)
+        self.assertNotIn(":slack:", text)
+
+    def test_flags_section_renders_configured_flags(self):
+        record = _make_region_record(
+            weekly_report_sections=[WEEKLY_SECTION_FLAGS],
+        )
+        stats = self._stats()
+        stats.flags = [("Ghost Flag", "#field-of-dreams"), ("HIM Belt", FLAG_HOLDER_FALLBACK)]
+        text = build_weekly_report_text(record, stats)
+        self.assertIn("• Ghost Flag — #field-of-dreams", text)
+        self.assertIn(f"• HIM Belt — {FLAG_HOLDER_FALLBACK}", text)
+
+    def test_flags_section_omitted_when_no_flags_configured(self):
+        record = _make_region_record(weekly_report_sections=[WEEKLY_SECTION_FLAGS])
+        stats = self._stats()
+        stats.flags = []
+        text = build_weekly_report_text(record, stats)
+        self.assertNotIn("*Trophies*", text)
+
+    def test_section_header_override_replaces_default(self):
+        record = _make_region_record(
+            weekly_report_sections=[WEEKLY_SECTION_FLAGS], weekly_report_flags_header="*Custom Trophy Header* :wave:"
+        )
+        stats = self._stats()
+        stats.flags = [("Ghost Flag", "#field-of-dreams")]
+        text = build_weekly_report_text(record, stats)
+        self.assertIn("*Custom Trophy Header* :wave:", text)
+        self.assertNotIn("*Trophies*", text)
+
+    def test_blank_section_header_override_falls_back_to_default(self):
+        record = _make_region_record(weekly_report_sections=[WEEKLY_SECTION_FLAGS], weekly_report_flags_header="")
+        stats = self._stats()
+        stats.flags = [("Ghost Flag", "#field-of-dreams")]
+        text = build_weekly_report_text(record, stats)
+        self.assertIn("*Trophies*", text)
+
+    def test_records_render_in_default_template(self):
+        record = _make_region_record()
+        stats = self._stats()
+        stats.avg_pax_record = 12.16
+        stats.unique_pax_record = 188
+        text = build_weekly_report_text(record, stats)
+        self.assertIn("(current record: 12.16)", text)
+        self.assertIn("(current record: 188)", text)
+
+    def test_custom_template(self):
+        record = _make_region_record(
+            weekly_report_intro_template="We had {total_events} events and {unknown_placeholder}!"
+        )
+        text = build_weekly_report_text(record, self._stats())
+        self.assertIn("We had 1 events and {unknown_placeholder}!", text)
+
+    def test_malformed_template_falls_back_to_default(self):
+        record = _make_region_record(weekly_report_intro_template="Broken {")
+        text = build_weekly_report_text(record, self._stats())
+        self.assertIn("• Total Events: 1 Workouts", text)
+
+    def test_sections_are_respected(self):
+        record = _make_region_record(weekly_report_sections=[WEEKLY_SECTION_TOP_QS])
+        text = build_weekly_report_text(record, self._stats())
+        self.assertNotIn("Total Events", text)
+        self.assertIn("@Bramble", text)
+
+    def test_none_sections_defaults_to_all(self):
+        record = _make_region_record(weekly_report_sections=None)
+        text = build_weekly_report_text(record, self._stats())
+        for marker in ("Total Events", "New Guys", "Highest Attended Workout", "Top Posters", "Top Qs"):
+            self.assertIn(marker, text)
+
+    def test_empty_fngs_section_omitted(self):
+        record = _make_region_record(weekly_report_sections=[WEEKLY_SECTION_SUMMARY, WEEKLY_SECTION_FNGS])
+        events = [_make_event(event_id=1, pax_count=5)]
+        stats = compute_weekly_stats(events, [])
+        text = build_weekly_report_text(record, stats)
+        self.assertNotIn("New Guys", text)
+
+    def test_default_sections_constant_covers_all_options(self):
+        self.assertEqual(len(DEFAULT_WEEKLY_SECTIONS), 6)
+
+    def test_default_summary_metrics_constant_covers_all_options(self):
+        self.assertEqual(len(DEFAULT_WEEKLY_SUMMARY_METRICS), 6)
+
+    def test_summary_metrics_are_individually_toggleable(self):
+        record = _make_region_record(
+            weekly_report_summary_metrics=[SUMMARY_METRIC_TOTAL_EVENTS, SUMMARY_METRIC_AVG_PAX]
+        )
+        text = build_weekly_report_text(record, self._stats())
+        self.assertIn("Total Events: 1 Workouts", text)
+        self.assertIn("Average PAX:", text)
+        self.assertNotIn("AO Count:", text)
+        self.assertNotIn("Unique Qs:", text)
+        self.assertNotIn("FNGs: 1 FNGs", text)
+        self.assertNotIn("Unique PAX:", text)
+
+    def test_summary_metrics_none_defaults_to_all(self):
+        record = _make_region_record(weekly_report_summary_metrics=None)
+        text = build_weekly_report_text(record, self._stats())
+        for marker in ("Total Events:", "AO Count:", "Unique Qs:", "FNGs:", "Average PAX:"):
+            self.assertIn(marker, text)
+
+    def test_summary_metrics_empty_list_shows_only_header(self):
+        record = _make_region_record(weekly_report_summary_metrics=[])
+        text = build_weekly_report_text(record, self._stats())
+        self.assertIn("Here goes the numbers from last week", text)
+        self.assertNotIn("Total Events:", text)
+
+    def test_single_metric_order_is_fixed_regardless_of_list_order(self):
+        record = _make_region_record(
+            weekly_report_summary_metrics=[SUMMARY_METRIC_UNIQUE_PAX, SUMMARY_METRIC_TOTAL_EVENTS]
+        )
+        text = build_weekly_report_text(record, self._stats())
+        self.assertLess(text.index("Total Events:"), text.index("Unique PAX:"))
+
+    def test_unique_pax_metric_alone_still_renders(self):
+        record = _make_region_record(weekly_report_summary_metrics=[SUMMARY_METRIC_UNIQUE_PAX])
+        text = build_weekly_report_text(record, self._stats())
+        self.assertIn("Unique PAX:", text)
+        self.assertNotIn("Total Events:", text)
+
+
+class TestBiweeklyScheduling(unittest.TestCase):
+    def test_epoch_monday_itself_is_a_send_week(self):
+        self.assertTrue(is_biweekly_send_week(BIWEEKLY_EPOCH_MONDAY))
+
+    def test_one_week_after_epoch_is_not_a_send_week(self):
+        self.assertFalse(is_biweekly_send_week(BIWEEKLY_EPOCH_MONDAY + timedelta(days=7)))
+
+    def test_two_weeks_after_epoch_is_a_send_week(self):
+        self.assertTrue(is_biweekly_send_week(BIWEEKLY_EPOCH_MONDAY + timedelta(days=14)))
+
+    def test_any_day_within_the_send_week_matches(self):
+        # parity is based on whole weeks elapsed, not weekday, so day 3 of an "off" week
+        # should still read as not-due same as day 0 of that week
+        self.assertFalse(is_biweekly_send_week(BIWEEKLY_EPOCH_MONDAY + timedelta(days=10)))
+
+    def test_report_window_days_weekly_default(self):
+        self.assertEqual(report_window_days(None), 7)
+        self.assertEqual(report_window_days("weekly"), 7)
+
+    def test_report_window_days_biweekly(self):
+        self.assertEqual(report_window_days("biweekly"), 14)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/apps/slackbot/tests/scripts/test_weekly_reporting.py
+++ b/apps/slackbot/tests/scripts/test_weekly_reporting.py
@@ -1,7 +1,9 @@
 import os
 import sys
 import unittest
-from datetime import date, timedelta
+from datetime import date, datetime, timedelta
+
+import pytz
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
 
@@ -9,6 +11,7 @@ from scripts.weekly_reporting import (
     BIWEEKLY_EPOCH_MONDAY,
     DEFAULT_WEEKLY_SECTIONS,
     DEFAULT_WEEKLY_SUMMARY_METRICS,
+    DEFAULT_WEEKLY_TIMEZONE,
     FLAG_HOLDER_FALLBACK,
     FLAG_HOLDER_LOCATION,
     FLAG_HOLDER_PAX,
@@ -28,6 +31,8 @@ from scripts.weekly_reporting import (
     compute_weekly_stats,
     extract_fng_names,
     is_biweekly_send_week,
+    region_local_window_end,
+    region_timezone,
     report_window_days,
     resolve_custom_field_holder,
     resolve_location_holder,
@@ -524,6 +529,21 @@ class TestBiweeklyScheduling(unittest.TestCase):
 
     def test_report_window_days_biweekly(self):
         self.assertEqual(report_window_days("biweekly"), 14)
+
+
+class TestRegionTimezone(unittest.TestCase):
+    def test_defaults_to_central_when_unset(self):
+        record = _make_region_record(weekly_report_timezone=None)
+        self.assertEqual(region_timezone(record), pytz.timezone(DEFAULT_WEEKLY_TIMEZONE))
+
+    def test_uses_configured_timezone(self):
+        record = _make_region_record(weekly_report_timezone="America/Los_Angeles")
+        self.assertEqual(region_timezone(record), pytz.timezone("America/Los_Angeles"))
+
+    def test_region_local_window_end_is_yesterday_in_that_timezone(self):
+        record = _make_region_record(weekly_report_timezone="Pacific/Honolulu")
+        expected = datetime.now(pytz.timezone("Pacific/Honolulu")).date() - timedelta(days=1)
+        self.assertEqual(region_local_window_end(record), expected)
 
 
 if __name__ == "__main__":

--- a/apps/slackbot/utilities/database/orm/__init__.py
+++ b/apps/slackbot/utilities/database/orm/__init__.py
@@ -79,3 +79,21 @@ class SlackSettings:
     open_event_color: Optional[str] = None
     bot_log_channel: Optional[str] = None
     calendar_config_special_days_out: Optional[int] = None
+    weekly_report_enabled: Optional[bool] = None
+    weekly_report_sections: Optional[list[str]] = None
+    weekly_report_day: Optional[int] = None  # 0 = Monday ... 6 = Sunday
+    weekly_report_hour_cst: Optional[int] = None
+    weekly_report_destination: Optional[str] = None  # conversation id: channel or user (DM)
+    weekly_report_intro_template: Optional[str] = None
+    weekly_report_summary_metrics: Optional[list[str]] = None
+    weekly_report_frequency: Optional[str] = None  # "weekly" (default) or "biweekly"
+    # {flag_key: {"name": str, "hashtag": str, "custom_field_name": str,
+    #              "holder_type": "location"|"pax", "enabled": bool}}
+    weekly_report_flags: Optional[dict[str, dict]] = None
+    # Optional per-section header text overrides — blank/unset falls back to the built-in
+    # default header for that section (see scripts/weekly_reporting.py).
+    weekly_report_fngs_header: Optional[str] = None
+    weekly_report_top_ao_posts_header: Optional[str] = None
+    weekly_report_top_posters_header: Optional[str] = None
+    weekly_report_top_qs_header: Optional[str] = None
+    weekly_report_flags_header: Optional[str] = None

--- a/apps/slackbot/utilities/database/orm/__init__.py
+++ b/apps/slackbot/utilities/database/orm/__init__.py
@@ -82,7 +82,12 @@ class SlackSettings:
     weekly_report_enabled: Optional[bool] = None
     weekly_report_sections: Optional[list[str]] = None
     weekly_report_day: Optional[int] = None  # 0 = Monday ... 6 = Sunday
+    # NOTE: keeps the "_cst" suffix from this field's original hardcoded-Central-time design
+    # (even though it's now interpreted per weekly_report_timezone below) — renaming this key
+    # would break loading for any region whose SlackSpace.settings JSON already has it saved,
+    # since SlackSettings(**settings) rejects unknown kwargs.
     weekly_report_hour_cst: Optional[int] = None
+    weekly_report_timezone: Optional[str] = None  # IANA tz name, e.g. "America/Chicago"
     weekly_report_destination: Optional[str] = None  # conversation id: channel or user (DM)
     weekly_report_intro_template: Optional[str] = None
     weekly_report_summary_metrics: Optional[list[str]] = None

--- a/apps/slackbot/utilities/helper_functions.py
+++ b/apps/slackbot/utilities/helper_functions.py
@@ -477,7 +477,11 @@ def get_request_type(body: dict) -> Tuple[str]:
     elif request_type == "view_closed":
         return ("view_closed", safe_get(body, "view", "callback_id"))
     elif request_type == "block_suggestion":
-        return ("block_suggestion", safe_get(body, "action_id"))
+        suggestion_action = safe_get(body, "action_id")
+        for suffix in routing.OPTIONS_SUFFIXES:
+            if suggestion_action and suggestion_action.endswith(suffix):
+                return ("block_suggestion", suffix)
+        return ("block_suggestion", suggestion_action)
     elif request_type == "shortcut":
         return ("shortcut", safe_get(body, "callback_id"))
     else:
@@ -920,6 +924,7 @@ def sort_by_name(extractor):
 
     return key
 
+
 def extract_state_values(body: dict) -> dict[str, Any]:
     """Extracts the state values from a Slack view submission payload.
 
@@ -937,27 +942,25 @@ def extract_state_values(body: dict) -> dict[str, Any]:
         for _, state in block_values.items():
             element_type = state.get("type")
             if element_type in (
-                "plain_text_input", "email_text_input", "url_text_input",
-                "number_input", "datepicker", "timepicker",
+                "plain_text_input",
+                "email_text_input",
+                "url_text_input",
+                "number_input",
+                "datepicker",
+                "timepicker",
             ):
                 form_data[block_id] = state.get("value")
             elif element_type in ("users_select", "conversations_select", "channels_select"):
                 form_data[block_id] = (
-                    state.get("selected_user")
-                    or state.get("selected_conversation")
-                    or state.get("selected_channel")
+                    state.get("selected_user") or state.get("selected_conversation") or state.get("selected_channel")
                 )
             elif element_type in ("multi_users_select", "multi_conversations_select", "multi_channels_select"):
                 form_data[block_id] = (
-                    state.get("selected_users")
-                    or state.get("selected_conversations")
-                    or state.get("selected_channels")
+                    state.get("selected_users") or state.get("selected_conversations") or state.get("selected_channels")
                 )
             elif element_type in ("static_select", "external_select", "radio_buttons"):
                 form_data[block_id] = (
-                    (state.get("selected_option") or {}).get("value")
-                    if state.get("selected_option")
-                    else None
+                    (state.get("selected_option") or {}).get("value") if state.get("selected_option") else None
                 )
             elif element_type in ("multi_static_select", "multi_external_select", "checkboxes"):
                 form_data[block_id] = [o.get("value") for o in state.get("selected_options", [])]

--- a/apps/slackbot/utilities/options.py
+++ b/apps/slackbot/utilities/options.py
@@ -75,6 +75,42 @@ def _search_users(value: str, limit: int = USER_SEARCH_LIMIT) -> list[dict]:
     return options
 
 
+def _search_locations(value: str, limit: int = USER_SEARCH_LIMIT) -> list[dict]:
+    """Search AOs by name with optional region filter via '(' syntax, across all regions.
+
+    Supports search terms like 'the hub (wash)' to filter by both AO name and region.
+    Results are sorted by relevance (exact > starts-with > contains), then alphabetically.
+    """
+    name_query, region_query = _parse_search_value(value)
+    if not name_query:
+        return []
+
+    org_records = DbManager.find_records(
+        cls=Org,
+        filters=[and_(Org.name.ilike(f"%{name_query}%"), Org.org_type == Org_Type.ao)],
+        joinedloads=[Org.parent_org],
+    )
+
+    if region_query:
+        region_lower = region_query.lower()
+        org_records = [o for o in org_records if o.parent_org and region_lower in o.parent_org.name.lower()]
+
+    org_records.sort(key=lambda o: _relevance_score(o.name or "", name_query))
+
+    options = []
+    for org in org_records[:limit]:
+        display_name = org.name
+        if org.parent_org:
+            display_name += f" ({org.parent_org.name})"
+        options.append(
+            {
+                "text": {"type": "plain_text", "text": display_name},
+                "value": str(org.id),
+            }
+        )
+    return options
+
+
 def handle_request(
     body: dict,
     client: WebClient,
@@ -89,6 +125,14 @@ def handle_request(
         return _search_users(value)
     elif action_id == user_form.USER_FORM_BROUGHT_BY:
         return _search_users(value)
+    elif action_id.endswith(actions.CUSTOM_FIELD_PAX_XREGION_SUFFIX):
+        # Cross-region search for a PAX-type custom field's secondary
+        # "not in this Slack space" picker (action id is per-field, dynamically named)
+        return _search_users(value)
+    elif action_id.endswith(actions.CUSTOM_FIELD_LOCATION_XREGION_SUFFIX):
+        # Cross-region search for a Location-type custom field's secondary
+        # "not in this Slack space" picker
+        return _search_locations(value)
     elif action_id in [
         user_form.USER_FORM_HOME_REGION,
         connect_form.SELECT_REGION,

--- a/apps/slackbot/utilities/routing.py
+++ b/apps/slackbot/utilities/routing.py
@@ -17,6 +17,7 @@ from features import (
     strava,
     user,
     weaselbot,
+    weekly_report_flags,
     welcome,
 )
 from features.calendar import (
@@ -35,6 +36,7 @@ from scripts.backblast_reminders import handle_backblast_reminder_dismiss
 from scripts.home_region_nudge import handle_home_region_dismiss, handle_home_region_opt_out, handle_home_region_switch
 from scripts.monthly_reporting import run_reporting_single_org
 from scripts.q_lineups import handle_lineup_signup
+from scripts.weekly_reporting import run_weekly_report_single_org
 from utilities import builders, options
 from utilities.slack import actions
 
@@ -90,6 +92,8 @@ VIEW_MAPPER = {
     actions.HOME_ASSIGN_Q_CALLBACK_ID: (home.handle_assign_q_form, False, False),
     actions.DB_ADMIN_CALLBACK_ID: (db_admin.handle_send_admin_announcement, False, False),
     reporting.REPORTING_CALLBACK_ID: (reporting.handle_reporting_edit, False, False),
+    weekly_report_flags.WEEKLY_FLAGS_MENU_CALLBACK_ID: (weekly_report_flags.handle_weekly_flags_menu, False, False),
+    weekly_report_flags.WEEKLY_FLAG_ADD_CALLBACK_ID: (weekly_report_flags.handle_weekly_flag_add, False, False),
     actions.DB_ADMIN_LONG_RUN_CALLBACK_ID: (db_admin.handle_long_run_task, False, False),
     paxminer_mapping.PAXMINER_MAPPING_ID: (paxminer_mapping.handle_paxminer_mapping_post, False, False),
     event_instance.EVENT_CLOSE_CALLBACK_ID: (event_instance.handle_event_instance_close, False, False),
@@ -187,6 +191,12 @@ ACTION_MAPPER = {
     user.IGNORE_EVENT: (builders.ignore_event, False, False),
     actions.CONFIG_REPORTING: (reporting.build_reporting_form, False, False),
     reporting.RUN_MONTHLY_REPORTS_NOW: (run_reporting_single_org, False, False),
+    reporting.RUN_WEEKLY_REPORT_NOW: (run_weekly_report_single_org, False, False),
+    weekly_report_flags.MANAGE_WEEKLY_FLAGS: (weekly_report_flags.build_weekly_flags_menu, False, False),
+    weekly_report_flags.WEEKLY_FLAG_ADD: (weekly_report_flags.build_weekly_flag_add_edit, False, False),
+    weekly_report_flags.WEEKLY_FLAG_EDIT: (weekly_report_flags.build_weekly_flag_add_edit, False, False),
+    weekly_report_flags.WEEKLY_FLAG_NAME: (weekly_report_flags.build_weekly_flag_add_edit, False, False),
+    weekly_report_flags.WEEKLY_FLAG_DELETE: (weekly_report_flags.handle_weekly_flag_delete, False, False),
     actions.CONFIG_HELP_MENU: (help.build_help_menu, False, False),
     actions.CALENDAR_MANAGE_SERIES_AO: (series.build_series_list_form, False, False),
     actions.SETTINGS_BUTTON: (config.build_config_form, True, False),
@@ -261,7 +271,17 @@ OPTIONS_MAPPER = {
     connect.SELECT_REGION: (options.handle_request, False, False),
     actions.EMERGENCY_DR_USER_SELECT: (options.handle_request, False, False),
     actions.DOWNRANGE_REGION_SELECT: (options.handle_request, False, False),
+    actions.CUSTOM_FIELD_PAX_XREGION_SUFFIX: (options.handle_request, False, False),
+    actions.CUSTOM_FIELD_LOCATION_XREGION_SUFFIX: (options.handle_request, False, False),
 }
+
+# Per-field custom field cross-region search action ids are dynamically named
+# (custom_field_<admin-defined name><suffix>), so they're matched by suffix here —
+# mirrors ACTION_PREFIXES' prefix-matching for the same reason (see get_request_type).
+OPTIONS_SUFFIXES = [
+    actions.CUSTOM_FIELD_PAX_XREGION_SUFFIX,
+    actions.CUSTOM_FIELD_LOCATION_XREGION_SUFFIX,
+]
 
 SHORTCUT_MAPPER = {
     actions.BACKBLAST_SHORTCUT: (backblast.backblast_middleware, True, False),

--- a/apps/slackbot/utilities/slack/actions.py
+++ b/apps/slackbot/utilities/slack/actions.py
@@ -189,10 +189,18 @@ CUSTOM_FIELD_DELETE = "custom_field_delete"
 CUSTOM_FIELD_ADD_NAME = "custom_field_add_name"
 CUSTOM_FIELD_ADD_TYPE = "custom_field_add_type"
 CUSTOM_FIELD_ADD_OPTIONS = "custom_field_add_options"
+CUSTOM_FIELD_ADD_AUTO_POPULATE = "custom_field_add_auto_populate"
 CUSTOM_FIELD_ADD_CALLBACK_ID = "custom_field_add_id"
 CUSTOM_FIELD_MENU_CALLBACK_ID = "custom_field_menu_id"
 CUSTOM_FIELD_PREFIX = "custom_field_"
 CUSTOM_FIELD_ADD_FORM = "custom_field_add_id"
+# Suffixes for the secondary "not in this Slack space" cross-region search field rendered
+# alongside a PAX/Location-type custom field's primary (local workspace) picker.
+CUSTOM_FIELD_PAX_XREGION_SUFFIX = "__xregion_pax"
+CUSTOM_FIELD_LOCATION_XREGION_SUFFIX = "__xregion_location"
+# Third-tier plain-text fallback for PAX/Location custom fields: covers someone/somewhere not
+# found by either picker above because they're not in the F3 database at all.
+CUSTOM_FIELD_MANUAL_SUFFIX = "__manual"
 
 ERROR_FORM_MESSAGE = "error_form_message"
 LOADING_ID = "loading_id"

--- a/apps/slackbot/utilities/slack/forms.py
+++ b/apps/slackbot/utilities/slack/forms.py
@@ -653,6 +653,8 @@ CUSTOM_FIELD_TYPE_MAP = {
     "Dropdown": orm.StaticSelectElement(),
     "Text": orm.PlainTextInputElement(),
     "Number": orm.NumberInputElement(),
+    "PAX": orm.UsersSelectElement(),
+    "Location": orm.ChannelsSelectElement(),
 }
 
 CUSTOM_FIELD_ADD_EDIT_FORM = orm.BlockView(
@@ -691,6 +693,18 @@ CUSTOM_FIELD_ADD_EDIT_FORM = orm.BlockView(
             label="Dropdown options (only required if 'Dropdown' is selected above)",
             optional=True,
             hint="Separate options with commas",
+        ),
+        orm.InputBlock(
+            element=orm.RadioButtonsElement(
+                options=orm.as_selector_options(names=["Yes", "No"], values=["yes", "no"]),
+                initial_value="no",
+            ),
+            action=actions.CUSTOM_FIELD_ADD_AUTO_POPULATE,
+            label="Auto-populate with last value",
+            optional=False,
+            hint="If Yes, this field pre-fills on every new backblast/preblast with whatever was last "
+            "submitted for it, until a Q changes it — useful for things like 'who currently holds the HIM "
+            "Belt' that don't change every post.",
         ),
     ]
 )


### PR DESCRIPTION
## Summary

Replaces the manual BigQuery weekly-stats workflow (5 separate scripts producing Slack-postable text) with a fully Slack-native, admin-configurable weekly region report, built through the existing Reporting Settings modal (`/f3-nation-settings` → Reporting Settings).

- **Configurable weekly report**: individually toggleable sections (Summary numbers, FNGs by AO, Highest Attended Workout, Top Posters, Top Qs, Trophies) and summary metrics, schedule (day/hour, weekly or biweekly, in a per-region time zone — see below), destination (a channel or a DM), and per-section free-text header overrides (including the original summary header) with placeholder support (`{total_events}`, `{avg_pax}`, etc.).
- **Per-region time zone**: the "Send Day"/"Send Time" schedule is evaluated against each region's own configured time zone (Eastern/Central/Mountain/Arizona/Pacific/Alaska/Hawaii, defaulting to Central to match the original fixed-CST behavior) instead of a single hardcoded US/Central for every region.
- **Trophies** (e.g. Ghost Flag, HIM Belt): admin-defined, multi-instance named items, each held by either a PAX or a location, resolved via a region-defined Custom Field (preferred) or hashtag detection scanning preblast/backblast text. Managed from a new "Manage Trophies" screen off Reporting Settings.
- **Custom Fields** gain new `PAX` and `Location` types with real Slack pickers, cross-region search (for PAX/AOs outside the current workspace, reusing the app's existing backblast cross-region search infrastructure), and a plain-text "not on Slack at all" fallback for people/locations that aren't in F3's database anywhere — three-tier resolution priority: local picker → cross-region search → manual text.
- **Sticky auto-populate**: an opt-in toggle on any Custom Field that pre-fills it on every new backblast/preblast with whatever was last submitted, until a Q changes it — shared logic between the backblast and preblast forms.
- **Report formatting cleanup**: bold section headers, bullet rows instead of hand-padded multi-space "columns" (which Slack's mrkdwn renderer actually collapses to single spaces, so the old layout never rendered aligned in production), and removed the one workspace-dependent emoji (`:slack:`, Slack's own logo glyph) in favor of standard Unicode emoji that render on every workspace regardless of custom emoji configuration.

## Test plan

- [x] `uv run ruff check .` / `uv run ruff format --check .` — clean on all touched files
- [x] `uv run pytest -q` — 390 passed (`tests/scripts/test_weekly_reporting.py` covers stats computation, flag/trophy resolution, biweekly scheduling, per-region time zone helpers, and report text rendering including the new per-section header overrides)
- [x] Manual smoke tests (isolated `uv run python -c "..."` scripts, since `weekly_report_flags.py`, `backblast.py`'s custom-field resolution, and `reporting.py`'s form handlers have no automated coverage yet) against a seeded local Postgres (Docker, org_id=6 / F3 Charlotte):
  - Custom Field auto-select from a matching Trophy name, including the dispatch-on-Enter round-trip and edit-flag-key recovery
  - Sticky auto-populate: enabled field syncs correctly; **disabled field's `current_value` is preserved** (this was a real bug caught during self-review — a disabled auto-populate field was previously getting silently wiped on the next unrelated backblast/preblast submission, since disabled fields aren't rendered on the form)
  - Three-tier PAX/Location resolution (local picker → cross-region search → manual text fallback), including priority ordering and sticky pre-fill of the manual field
  - Per-section header override save/render round-trip, including blank-falls-back-to-default
  - Per-region scheduling: two regions configured with the same numeric send hour but different time zones correctly diverge (only the one whose actual local clock matches fires)
  - Full rendered weekly report output, visually reviewed against the intended bold-header/bullet format
- [x] Caught and fixed live via the local dev server: an early version of this change renamed `SlackSettings.weekly_report_hour_cst` → `weekly_report_hour`, which broke loading for any region whose `SlackSpace.settings` JSON already had the old key saved (`SlackSettings` is a plain dataclass built via `SlackSettings(**settings)`, which rejects unknown kwargs — `main.py` swallows that error and silently falls back to blank settings for the request). Reverted the field name; the time zone is a separate new `weekly_report_timezone` field instead.
- [ ] Not yet tested against a live Slack workspace end-to-end (would need a connected region's bot token)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018p6ChZMzmWcx37GYcYgvJt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable weekly and biweekly Slack region reports, including section/metric selection, scheduling, destinations, and custom headings.
  * Added weekly trophy (flag) management via Slack modals (create/edit/enable/disable/delete) and quick “send now”.
  * Enhanced PAX and Location custom fields with Slack pickers, cross-region search, manual fallback, and auto-populate behavior.
  * Added preblast-form custom field blocks and submission handling for cross-region custom fields.
* **Bug Fixes**
  * Improved background supervisor process liveness checking during restarts.
* **Documentation**
  * Added local setup/testing instructions for weekly reporting scripts.
* **Tests**
  * Added a full test suite for weekly reporting logic and scheduling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
