### PR TITLE
test(api): fix flaky cold-start timeout in dispatch characterization test

### DIFF
--- a/apps/api/characterization/wire/dispatch.char.test.ts
+++ b/apps/api/characterization/wire/dispatch.char.test.ts
@@ -15,6 +15,10 @@ import { req, target } from "../transport";
  * silently break SSG and the map client, so pin the rule itself.
  */
 describe("handler dispatch", () => {
+  // First test in the file: it builds a real oRPC client and pays the suite's
+  // one-time cold-start cost (module init + transport wiring), which lands
+  // this case right at the 5s default and flakes on a loaded CI runner
+  // (observed ~5019ms). Give it headroom without masking a genuine hang.
   it("returns the RPC body shape for a real oRPC client", async () => {
     const res = await rpcResponse((client) => client.ping(), {
       "x-forwarded-for": "10.90.0.1",
@@ -25,7 +29,7 @@ describe("handler dispatch", () => {
         await normalize(res, { paths: { "json.timestamp": "<TIMESTAMP>" } }),
       ),
     ).toMatchFileSnapshot("../__snapshots__/dispatch-rpc-ping.golden.json");
-  });
+  }, 20_000);
 
   it("returns the OpenAPI body shape for the same procedure over REST", async () => {
     const res = await target.invoke(


### PR DESCRIPTION
## Problem
`apps/api/characterization/wire/dispatch.char.test.ts` → **"returns the RPC body shape for a real oRPC client"** flakes on CI with `Test timed out in 5000ms`.

It's the **first test in the file** and builds a real oRPC client, so it pays the suite's one-time cold-start cost (module init + transport wiring). On a loaded runner that lands it right at the 5s Vitest default — observed **~5019ms**, 19ms over. It passes on re-run, but has timed out twice.

## Fix
Give **that one case** a 20s timeout (`it(name, fn, 20_000)`) so cold-start variance can't fail the run, while still bounding a genuine hang. No behavior change — assertions untouched, and only the first/heaviest test gets extra headroom; everything else keeps the 5s default.

## Verification
- Ran the file locally with CI-equivalent env: the target test passes; 13/14 green (the 1 failure is a local missing-DB `role "f3" does not exist`, not this change).
- prettier + eslint + typecheck (23 pkgs) + commitlint clean.

Split out of #685 (AI-native SDLC) — pre-existing flake, unrelated to that PR's changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Increased the timeout for a handler dispatch test to accommodate occasional delays during initial startup.
  * No test behavior or assertions were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->