### PR TITLE
ci(ci): file GitHub issues from code scanning alerts

### DIFF
--- a/.github/scripts/code-scanning-issue.cjs
+++ b/.github/scripts/code-scanning-issue.cjs
@@ -22,7 +22,9 @@ function permalink(alert) {
   const instance = alert.most_recent_instance ?? {};
   const path = instance.location?.path;
   const sha = instance.commit_sha;
-  const repoUrl = (alert.html_url ?? "").split("/security/code-scanning/")[0];
+  const marker = "/security/code-scanning/";
+  const markerAt = (alert.html_url ?? "").indexOf(marker);
+  const repoUrl = markerAt < 0 ? null : alert.html_url.slice(0, markerAt);
   if (!path || !sha || !repoUrl) return null;
   const start = instance.location.start_line;
   const end = instance.location.end_line ?? start;
@@ -69,7 +71,9 @@ function renderIssue(alert, issueNumber = null) {
           : "")
       : "_The tool did not report a file location._",
     "",
-    instance.message?.text ? `> ${instance.message.text}` : "",
+    instance.message?.text
+      ? `> ${instance.message.text.replace(/\r?\n/g, "\n> ")}`
+      : "",
     "",
     "## Recommendation",
     "",
@@ -92,23 +96,67 @@ function renderIssue(alert, issueNumber = null) {
   return { title: issueTitle(alert), body: lines.join("\n") };
 }
 
-/**
- * Lists issues and matches the title prefix exactly.
- * Deliberately not the search API: the search index is eventually consistent,
- * and its fuzzy matching would let "Alert #4:" match "Alert #42:".
- */
-async function findExistingIssue(github, owner, repo, alertNumber) {
-  const marker = `${TITLE_PREFIX}${alertNumber}:`;
-  const issues = await github.paginate(github.rest.issues.listForRepo, {
+async function listRepoIssues(github, owner, repo) {
+  return github.paginate(github.rest.issues.listForRepo, {
     owner,
     repo,
     state: "all",
     per_page: 100,
   });
-  const hit = issues.find(
+}
+
+/**
+ * Lists issues and matches the title prefix exactly.
+ * Deliberately not the search API: the search index is eventually consistent,
+ * and its fuzzy matching would let "Alert #4:" match "Alert #42:".
+ * Callers looking up many alerts in one run should pass a `listRepoIssues`
+ * result as `issues` so the repo is paginated once rather than once per alert.
+ */
+async function findExistingIssue(github, owner, repo, alertNumber, issues) {
+  const marker = `${TITLE_PREFIX}${alertNumber}:`;
+  const list = issues ?? (await listRepoIssues(github, owner, repo));
+  const hit = list.find(
     (issue) => !issue.pull_request && (issue.title ?? "").startsWith(marker),
   );
   return hit ? { number: hit.number, state: hit.state } : null;
 }
 
-module.exports = { renderIssue, findExistingIssue, TITLE_PREFIX };
+/**
+ * Creates the tracking issue, then rewrites the body with the concrete
+ * "Fixes #N" line — the issue cannot know its own number until it exists.
+ * Shared so both workflows file byte-identical issues.
+ */
+async function createIssueForAlert(github, owner, repo, alert, core) {
+  const created = await github.rest.issues.create({
+    owner,
+    repo,
+    ...renderIssue(alert),
+  });
+  const number = created.data.number;
+
+  try {
+    await github.rest.issues.update({
+      owner,
+      repo,
+      issue_number: number,
+      body: renderIssue(alert, number).body,
+    });
+    return { number, injected: true };
+  } catch (error) {
+    core.warning(
+      `#${number} was created successfully for alert #${alert.number}, ` +
+        'but injecting the concrete "Fixes #N" line into its body failed; it keeps the ' +
+        "generic fallback wording. A maintainer can edit the body, or simply reference " +
+        `#${number} manually in the fix PR. Error: ${error.status ?? "no status"} ${error.message}`,
+    );
+    return { number, injected: false };
+  }
+}
+
+module.exports = {
+  renderIssue,
+  findExistingIssue,
+  listRepoIssues,
+  createIssueForAlert,
+  TITLE_PREFIX,
+};

--- a/.github/scripts/code-scanning-issue.cjs
+++ b/.github/scripts/code-scanning-issue.cjs
@@ -1,0 +1,114 @@
+"use strict";
+
+/**
+ * Shared by .github/workflows/code-scanning-issue.yml and
+ * code-scanning-backfill.yml so both render identical issues.
+ * CommonJS because actions/github-script loads it with require().
+ */
+
+const TITLE_PREFIX = "[code scanning] Alert #";
+
+function issueTitle(alert) {
+  return `${TITLE_PREFIX}${alert.number}: ${alert.rule?.id ?? "unknown rule"}`;
+}
+
+/**
+ * Absolute permalink to the flagged lines, pinned to the alert's commit.
+ * Relative links are not resolved reliably in issue bodies, so the repo URL is
+ * recovered from the alert's own html_url
+ * (https://github.com/OWNER/REPO/security/code-scanning/N).
+ */
+function permalink(alert) {
+  const instance = alert.most_recent_instance ?? {};
+  const path = instance.location?.path;
+  const sha = instance.commit_sha;
+  const repoUrl = (alert.html_url ?? "").split("/security/code-scanning/")[0];
+  if (!path || !sha || !repoUrl) return null;
+  const start = instance.location.start_line;
+  const end = instance.location.end_line ?? start;
+  const anchor = start
+    ? `#L${start}${end && end !== start ? `-L${end}` : ""}`
+    : "";
+  return `${repoUrl}/blob/${sha}/${path}${anchor}`;
+}
+
+function renderIssue(alert, issueNumber = null) {
+  const rule = alert.rule ?? {};
+  const instance = alert.most_recent_instance ?? {};
+  const location = instance.location ?? {};
+  const link = permalink(alert);
+
+  const lines = [
+    `> Filed automatically from [code scanning alert #${alert.number}](${alert.html_url ?? ""}).`,
+    "",
+    "## Summary",
+    "",
+    rule.full_description ??
+      rule.description ??
+      "_No description provided by the scanning tool._",
+    "",
+    "## Alert details",
+    "",
+    "| | |",
+    "| --- | --- |",
+    `| Rule | \`${rule.id ?? "unknown"}\` |`,
+    `| Severity | ${rule.severity ?? "unknown"} |`,
+    `| Security severity | ${rule.security_severity_level ?? "not classified"} |`,
+    `| Tool | ${alert.tool?.name ?? "unknown"} ${alert.tool?.version ?? ""} |`,
+    `| Tags | ${(rule.tags ?? []).map((t) => `\`${t}\``).join(", ") || "none"} |`,
+    `| State | ${alert.state ?? "unknown"} |`,
+    `| First detected | ${alert.created_at ?? "unknown"} |`,
+    `| Last updated | ${alert.updated_at ?? "unknown"} |`,
+    "",
+    "## Location",
+    "",
+    location.path
+      ? `\`${location.path}\`${location.start_line ? `, line ${location.start_line}` : ""}` +
+        (link
+          ? `\n\n[View the flagged code at the time of the alert](${link})`
+          : "")
+      : "_The tool did not report a file location._",
+    "",
+    instance.message?.text ? `> ${instance.message.text}` : "",
+    "",
+    "## Recommendation",
+    "",
+    rule.help ??
+      "_The scanning tool did not ship remediation guidance. See the alert page._",
+    "",
+    "## How this issue closes",
+    "",
+    issueNumber
+      ? `Put \`Fixes #${issueNumber}\` in your pull request description. When the PR merges, this issue closes.`
+      : "Reference this issue with a `Fixes` keyword and this issue's number in your pull request description.",
+    "",
+    "The alert itself is **not** closed by this issue. Once the fix lands on `main`," +
+      " the scanner re-runs and marks the alert fixed on its own; if this issue is still" +
+      " open at that point, automation closes it.",
+    "",
+    `[Open the alert](${alert.html_url ?? ""})`,
+  ];
+
+  return { title: issueTitle(alert), body: lines.join("\n") };
+}
+
+/**
+ * Lists issues and matches the title prefix exactly.
+ * Deliberately not the search API: the search index is eventually consistent,
+ * and its fuzzy matching would let "Alert #4:" match "Alert #42:".
+ */
+async function findExistingIssue(github, owner, repo, alertNumber) {
+  const marker = `${TITLE_PREFIX}${alertNumber}:`;
+  const issues = await github.paginate(github.rest.issues.listForRepo, {
+    owner,
+    repo,
+    state: "all",
+    per_page: 100,
+  });
+  const hit = issues.find(
+    (issue) => !issue.pull_request && (issue.title ?? "").startsWith(marker),
+  );
+  return hit ? { number: hit.number, state: hit.state } : null;
+}
+
+module.exports = { renderIssue, findExistingIssue, TITLE_PREFIX };

--- a/.github/workflows/code-scanning-backfill.yml
+++ b/.github/workflows/code-scanning-backfill.yml
@@ -1,0 +1,100 @@
+name: Backfill code scanning alert issues
+
+# One-shot. Run it, then delete this file in a follow-up PR.
+# .github/scripts/code-scanning-issue.cjs stays — the reactive workflow needs it.
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "List what would be filed without creating anything"
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+  issues: write
+  security-events: read
+
+jobs:
+  backfill:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the shared renderer
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: File issues for existing open alerts
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          DRY_RUN: ${{ inputs.dry_run }}
+        with:
+          script: |
+            const { renderIssue, findExistingIssue } = require(
+              './.github/scripts/code-scanning-issue.cjs',
+            );
+
+            // Anything other than an explicit "false" stays a dry run.
+            const dryRun = process.env.DRY_RUN !== 'false';
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            const listed = await github.paginate(
+              github.rest.codeScanning.listAlertsForRepo,
+              { owner, repo, state: 'open', per_page: 100 },
+            );
+            core.info(`${listed.length} open alert(s); dry run: ${dryRun}`);
+
+            const rows = [
+              [
+                { data: 'Alert', header: true },
+                { data: 'Rule', header: true },
+                { data: 'Severity', header: true },
+                { data: 'Location', header: true },
+                { data: 'Result', header: true },
+              ],
+            ];
+
+            for (const summary of listed) {
+              // Re-fetch each alert: the list endpoint returns a trimmed rule
+              // object, and the body must match the reactive workflow's exactly.
+              const { data: alert } = await github.rest.codeScanning.getAlert({
+                owner, repo, alert_number: summary.number,
+              });
+
+              const location = alert.most_recent_instance?.location ?? {};
+              const where = location.path
+                ? `${location.path}:${location.start_line ?? '?'}`
+                : 'n/a';
+
+              const existing = await findExistingIssue(github, owner, repo, alert.number);
+              let result;
+
+              if (existing) {
+                result = `skipped — already #${existing.number}`;
+              } else if (dryRun) {
+                result = `would create — "${renderIssue(alert).title}"`;
+              } else {
+                const created = await github.rest.issues.create({
+                  owner, repo, ...renderIssue(alert),
+                });
+                await github.rest.issues.update({
+                  owner, repo, issue_number: created.data.number,
+                  body: renderIssue(alert, created.data.number).body,
+                });
+                result = `created #${created.data.number}`;
+              }
+
+              core.info(`Alert #${alert.number}: ${result}`);
+              rows.push([
+                `#${alert.number}`,
+                alert.rule?.id ?? 'unknown',
+                alert.rule?.security_severity_level ?? 'unclassified',
+                where,
+                result,
+              ]);
+            }
+
+            await core.summary
+              .addHeading(dryRun ? 'Backfill dry run' : 'Backfill results')
+              .addTable(rows)
+              .write();

--- a/.github/workflows/code-scanning-backfill.yml
+++ b/.github/workflows/code-scanning-backfill.yml
@@ -15,17 +15,20 @@ concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: false
 
-permissions:
-  contents: read
-  issues: write
-  security-events: read
+permissions: {}
 
 jobs:
   backfill:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # check out the shared renderer
+      issues: write # file and reopen tracking issues
+      security-events: read # list the open code scanning alerts
     steps:
       - name: Check out the shared renderer
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: File issues for existing open alerts
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -33,20 +36,26 @@ jobs:
           DRY_RUN: ${{ inputs.dry_run }}
         with:
           script: |
-            const { renderIssue, findExistingIssue } = require(
-              './.github/scripts/code-scanning-issue.cjs',
-            );
+            const {
+              renderIssue, findExistingIssue, listRepoIssues, createIssueForAlert,
+            } = require('./.github/scripts/code-scanning-issue.cjs');
 
             // Anything other than an explicit "false" stays a dry run.
             const dryRun = process.env.DRY_RUN !== 'false';
             const owner = context.repo.owner;
             const repo = context.repo.repo;
 
+            // Match the reactive workflow, which tracks default-branch alerts only.
+            const defaultBranch = context.payload.repository?.default_branch ?? 'main';
             const listed = await github.paginate(
               github.rest.codeScanning.listAlertsForRepo,
-              { owner, repo, state: 'open', per_page: 100 },
+              { owner, repo, state: 'open', ref: `refs/heads/${defaultBranch}`, per_page: 100 },
             );
             core.info(`${listed.length} open alert(s); dry run: ${dryRun}`);
+
+            // Paginated once and reused: findExistingIssue would otherwise
+            // re-list every issue in the repo on each of the N iterations.
+            const issues = await listRepoIssues(github, owner, repo);
 
             const rows = [
               [
@@ -58,60 +67,88 @@ jobs:
               ],
             ];
 
-            for (const summary of listed) {
-              // Re-fetch each alert: the list endpoint returns a trimmed rule
-              // object, and the body must match the reactive workflow's exactly.
-              const { data: alert } = await github.rest.codeScanning.getAlert({
-                owner, repo, alert_number: summary.number,
-              });
+            let failures = 0;
 
-              const location = alert.most_recent_instance?.location ?? {};
-              const where = location.path
-                ? `${location.path}:${location.start_line ?? '?'}`
-                : 'n/a';
+            try {
+              for (const summary of listed) {
+                let where = 'n/a';
+                let ruleId = 'unknown';
+                let severity = 'unclassified';
+                let result;
 
-              const existing = await findExistingIssue(github, owner, repo, alert.number);
-              let result;
-
-              if (existing) {
-                result = `skipped — already #${existing.number}`;
-              } else if (dryRun) {
-                result = `would create — "${renderIssue(alert).title}"`;
-              } else {
-                const created = await github.rest.issues.create({
-                  owner, repo, ...renderIssue(alert),
-                });
-
-                // The issue cannot know its own number until it exists, so the
-                // concrete "Fixes #N" line is written in a second pass.
+                // A throw here must not cost the whole table: this loop creates
+                // issues in bulk, which is the canonical way to trip GitHub's
+                // secondary rate limit, and the summary is the job's whole output.
                 try {
-                  await github.rest.issues.update({
-                    owner, repo, issue_number: created.data.number,
-                    body: renderIssue(alert, created.data.number).body,
+                  // Re-fetch each alert: the list endpoint returns a trimmed rule
+                  // object, and the body must match the reactive workflow's exactly.
+                  const { data: alert } = await github.rest.codeScanning.getAlert({
+                    owner, repo, alert_number: summary.number,
                   });
-                  result = `created #${created.data.number}`;
-                } catch (error) {
-                  core.warning(
-                    `#${created.data.number} was created successfully for alert #${alert.number}, ` +
-                      'but injecting the concrete "Fixes #N" line into its body failed; it keeps the ' +
-                      'generic fallback wording. A maintainer can edit the body, or simply reference ' +
-                      `#${created.data.number} manually in the fix PR. Error: ${error.message}`,
-                  );
-                  result = `created #${created.data.number} — body injection FAILED, see warning`;
-                }
-              }
 
-              core.info(`Alert #${alert.number}: ${result}`);
-              rows.push([
-                `#${alert.number}`,
-                alert.rule?.id ?? 'unknown',
-                alert.rule?.security_severity_level ?? 'unclassified',
-                where,
-                result,
-              ]);
+                  const location = alert.most_recent_instance?.location ?? {};
+                  where = location.path
+                    ? `${location.path}:${location.start_line ?? '?'}`
+                    : 'n/a';
+                  ruleId = alert.rule?.id ?? 'unknown';
+                  severity = alert.rule?.security_severity_level ?? 'unclassified';
+
+                  const existing = await findExistingIssue(
+                    github, owner, repo, alert.number, issues,
+                  );
+
+                  if (existing?.state === 'open') {
+                    result = `skipped — already #${existing.number}`;
+                  } else if (existing && dryRun) {
+                    result = `would reopen — #${existing.number} (closed)`;
+                  } else if (existing) {
+                    // Closed by hand, or by a `fixed` event on a feature branch,
+                    // while the alert is still open. Nothing else would reopen it.
+                    await github.rest.issues.update({
+                      owner, repo, issue_number: existing.number, state: 'open',
+                    });
+                    await github.rest.issues.createComment({
+                      owner, repo, issue_number: existing.number,
+                      body: `Reopening: code scanning alert #${alert.number} is still open.\n\n${alert.html_url}`,
+                    });
+                    result = `reopened #${existing.number}`;
+                  } else if (dryRun) {
+                    result = `would create — "${renderIssue(alert).title}"`;
+                  } else {
+                    const { number, injected } = await createIssueForAlert(
+                      github, owner, repo, alert, core,
+                    );
+                    result = injected
+                      ? `created #${number}`
+                      : `created #${number} — body injection FAILED, see warning`;
+                    // Stay under the secondary rate limit on bulk creation.
+                    await new Promise((resolve) => setTimeout(resolve, 1000));
+                  }
+                } catch (error) {
+                  failures += 1;
+                  result = `FAILED — ${error.status ?? 'no status'} ${error.message}`;
+                  core.warning(`Alert #${summary.number}: ${result}`);
+                }
+
+                core.info(`Alert #${summary.number}: ${result}`);
+                rows.push([
+                  `#${summary.number}`,
+                  ruleId,
+                  severity,
+                  where,
+                  result,
+                ]);
+              }
+            } finally {
+              await core.summary
+                .addHeading(dryRun ? 'Backfill dry run' : 'Backfill results')
+                .addTable(rows)
+                .write();
             }
 
-            await core.summary
-              .addHeading(dryRun ? 'Backfill dry run' : 'Backfill results')
-              .addTable(rows)
-              .write();
+            if (failures > 0) {
+              core.setFailed(
+                `${failures} of ${listed.length} alert(s) failed; see the job summary. ` +
+                  'Re-running is idempotent.',
+              );
+            }

--- a/.github/workflows/code-scanning-backfill.yml
+++ b/.github/workflows/code-scanning-backfill.yml
@@ -11,6 +11,10 @@ on:
         type: boolean
         default: true
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
   issues: write

--- a/.github/workflows/code-scanning-backfill.yml
+++ b/.github/workflows/code-scanning-backfill.yml
@@ -77,11 +77,24 @@ jobs:
                 const created = await github.rest.issues.create({
                   owner, repo, ...renderIssue(alert),
                 });
-                await github.rest.issues.update({
-                  owner, repo, issue_number: created.data.number,
-                  body: renderIssue(alert, created.data.number).body,
-                });
-                result = `created #${created.data.number}`;
+
+                // The issue cannot know its own number until it exists, so the
+                // concrete "Fixes #N" line is written in a second pass.
+                try {
+                  await github.rest.issues.update({
+                    owner, repo, issue_number: created.data.number,
+                    body: renderIssue(alert, created.data.number).body,
+                  });
+                  result = `created #${created.data.number}`;
+                } catch (error) {
+                  core.warning(
+                    `#${created.data.number} was created successfully for alert #${alert.number}, ` +
+                      'but injecting the concrete "Fixes #N" line into its body failed; it keeps the ' +
+                      'generic fallback wording. A maintainer can edit the body, or simply reference ' +
+                      `#${created.data.number} manually in the fix PR. Error: ${error.message}`,
+                  );
+                  result = `created #${created.data.number} — body injection FAILED, see warning`;
+                }
               }
 
               core.info(`Alert #${alert.number}: ${result}`);

--- a/.github/workflows/code-scanning-issue.yml
+++ b/.github/workflows/code-scanning-issue.yml
@@ -42,6 +42,22 @@ jobs:
             const existing = await findExistingIssue(github, owner, repo, alert.number);
 
             if (OPENING.has(action)) {
+              const ref = context.payload.ref ?? alert.most_recent_instance?.ref;
+              const defaultBranch = context.payload.repository?.default_branch ?? 'main';
+              const defaultRef = `refs/heads/${defaultBranch}`;
+
+              if (!ref) {
+                core.info(
+                  `Could not determine ref for alert #${alert.number}; treating as default branch.`,
+                );
+              } else if (ref !== defaultRef) {
+                core.info(
+                  `Alert #${alert.number} is on ref \`${ref}\`, not the default branch ` +
+                    `(\`${defaultRef}\`); alerts on non-default branches are not tracked as issues.`,
+                );
+                return;
+              }
+
               if (existing?.state === 'open') {
                 core.info(`Alert #${alert.number} already tracked by #${existing.number}.`);
                 return;

--- a/.github/workflows/code-scanning-issue.yml
+++ b/.github/workflows/code-scanning-issue.yml
@@ -8,22 +8,25 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.alert.number }}
   cancel-in-progress: false
 
-permissions:
-  contents: read
-  issues: write
+permissions: {}
 
 jobs:
   sync:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # check out the shared renderer
+      issues: write # file, reopen, comment on and close tracking issues
     steps:
       - name: Check out the shared renderer
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Sync issue with alert state
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
-            const { renderIssue, findExistingIssue } = require(
+            const { renderIssue, findExistingIssue, createIssueForAlert } = require(
               './.github/scripts/code-scanning-issue.cjs',
             );
 
@@ -41,16 +44,20 @@ jobs:
             const CLOSING = new Set(['fixed', 'closed_by_user']);
             const existing = await findExistingIssue(github, owner, repo, alert.number);
 
-            if (OPENING.has(action)) {
-              const ref = context.payload.ref ?? alert.most_recent_instance?.ref;
-              const defaultBranch = context.payload.repository?.default_branch ?? 'main';
-              const defaultRef = `refs/heads/${defaultBranch}`;
+            // `||` not `??`: ref is an empty string (not absent) on the
+            // *_by_user actions, which carry no ref of their own.
+            const ref = context.payload.ref || alert.most_recent_instance?.ref;
+            const defaultBranch = context.payload.repository?.default_branch ?? 'main';
+            const defaultRef = `refs/heads/${defaultBranch}`;
+            if (!ref) {
+              core.info(
+                `Could not determine ref for alert #${alert.number}; treating as default branch.`,
+              );
+            }
+            const onDefaultRef = !ref || ref === defaultRef;
 
-              if (!ref) {
-                core.info(
-                  `Could not determine ref for alert #${alert.number}; treating as default branch.`,
-                );
-              } else if (ref !== defaultRef) {
+            if (OPENING.has(action)) {
+              if (!onDefaultRef) {
                 core.info(
                   `Alert #${alert.number} is on ref \`${ref}\`, not the default branch ` +
                     `(\`${defaultRef}\`); alerts on non-default branches are not tracked as issues.`,
@@ -64,8 +71,12 @@ jobs:
               }
 
               if (existing) {
+                // Refresh the body too: the permalink is pinned to the alert's
+                // commit, and alerts reopen precisely because the code moved.
                 await github.rest.issues.update({
-                  owner, repo, issue_number: existing.number, state: 'open',
+                  owner, repo, issue_number: existing.number,
+                  state: 'open',
+                  body: renderIssue(alert, existing.number).body,
                 });
                 await github.rest.issues.createComment({
                   owner, repo, issue_number: existing.number,
@@ -75,25 +86,8 @@ jobs:
                 return;
               }
 
-              const { title, body } = renderIssue(alert);
-              const created = await github.rest.issues.create({ owner, repo, title, body });
-
-              // The issue cannot know its own number until it exists, so the
-              // concrete "Fixes #N" line is written in a second pass.
-              try {
-                await github.rest.issues.update({
-                  owner, repo, issue_number: created.data.number,
-                  body: renderIssue(alert, created.data.number).body,
-                });
-              } catch (error) {
-                core.warning(
-                  `#${created.data.number} was created successfully for alert #${alert.number}, ` +
-                    'but injecting the concrete "Fixes #N" line into its body failed; it keeps the ' +
-                    'generic fallback wording. A maintainer can edit the body, or simply reference ' +
-                    `#${created.data.number} manually in the fix PR. Error: ${error.message}`,
-                );
-              }
-              core.info(`Created #${created.data.number} for alert #${alert.number}.`);
+              const { number } = await createIssueForAlert(github, owner, repo, alert, core);
+              core.info(`Created #${number} for alert #${alert.number}.`);
               return;
             }
 
@@ -107,10 +101,27 @@ jobs:
                 return;
               }
 
+              // Closing on a non-default ref is unrecoverable: the alert never
+              // changed state on the default branch, so no further event fires.
+              if (!onDefaultRef) {
+                await github.rest.issues.createComment({
+                  owner, repo, issue_number: existing.number,
+                  body:
+                    `Code scanning alert #${alert.number} was \`${action}\` on \`${ref}\`, not the ` +
+                    `default branch (\`${defaultRef}\`), so this issue stays open — the alert is ` +
+                    `still open on \`${defaultBranch}\`.\n\n${alert.html_url}`,
+                });
+                core.info(
+                  `Alert #${alert.number} was ${action} on ref \`${ref}\`, not the default ` +
+                    `branch (\`${defaultRef}\`); left #${existing.number} open.`,
+                );
+                return;
+              }
+
               const reason =
                 action === 'fixed'
-                  ? `The scanner reports it fixed on \`${alert.most_recent_instance?.ref ?? 'the default branch'}\`.`
-                  : `It was dismissed by @${alert.dismissed_by?.login ?? 'a maintainer'} ` +
+                  ? `The scanner reports it fixed on \`${ref || defaultRef}\`.`
+                  : `It was dismissed by ${alert.dismissed_by?.login ? `@${alert.dismissed_by.login}` : 'a maintainer'} ` +
                     `(reason: ${alert.dismissed_reason ?? 'none given'}` +
                     `${alert.dismissed_comment ? ` — ${alert.dismissed_comment}` : ''}).`;
 

--- a/.github/workflows/code-scanning-issue.yml
+++ b/.github/workflows/code-scanning-issue.yml
@@ -1,0 +1,105 @@
+name: Code scanning alert issues
+
+on:
+  code_scanning_alert:
+    types: [created, reopened, reopened_by_user, fixed, closed_by_user]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.alert.number }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the shared renderer
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Sync issue with alert state
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const { renderIssue, findExistingIssue } = require(
+              './.github/scripts/code-scanning-issue.cjs',
+            );
+
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const alert = context.payload.alert;
+            const action = context.payload.action;
+
+            if (!alert) {
+              core.warning('No alert in the event payload; nothing to do.');
+              return;
+            }
+
+            const OPENING = new Set(['created', 'reopened', 'reopened_by_user']);
+            const CLOSING = new Set(['fixed', 'closed_by_user']);
+            const existing = await findExistingIssue(github, owner, repo, alert.number);
+
+            if (OPENING.has(action)) {
+              if (existing?.state === 'open') {
+                core.info(`Alert #${alert.number} already tracked by #${existing.number}.`);
+                return;
+              }
+
+              if (existing) {
+                await github.rest.issues.update({
+                  owner, repo, issue_number: existing.number, state: 'open',
+                });
+                await github.rest.issues.createComment({
+                  owner, repo, issue_number: existing.number,
+                  body: `Reopening: code scanning alert #${alert.number} is active again (\`${action}\`).\n\n${alert.html_url}`,
+                });
+                core.info(`Reopened #${existing.number} for alert #${alert.number}.`);
+                return;
+              }
+
+              const { title, body } = renderIssue(alert);
+              const created = await github.rest.issues.create({ owner, repo, title, body });
+
+              // The issue cannot know its own number until it exists, so the
+              // concrete "Fixes #N" line is written in a second pass.
+              await github.rest.issues.update({
+                owner, repo, issue_number: created.data.number,
+                body: renderIssue(alert, created.data.number).body,
+              });
+              core.info(`Created #${created.data.number} for alert #${alert.number}.`);
+              return;
+            }
+
+            if (CLOSING.has(action)) {
+              if (!existing) {
+                core.info(`No issue tracks alert #${alert.number}; nothing to close.`);
+                return;
+              }
+              if (existing.state === 'closed') {
+                core.info(`#${existing.number} is already closed.`);
+                return;
+              }
+
+              const reason =
+                action === 'fixed'
+                  ? `The scanner reports it fixed on \`${alert.most_recent_instance?.ref ?? 'the default branch'}\`.`
+                  : `It was dismissed by @${alert.dismissed_by?.login ?? 'a maintainer'} ` +
+                    `(reason: ${alert.dismissed_reason ?? 'none given'}` +
+                    `${alert.dismissed_comment ? ` — ${alert.dismissed_comment}` : ''}).`;
+
+              await github.rest.issues.createComment({
+                owner, repo, issue_number: existing.number,
+                body: `Closing automatically: code scanning alert #${alert.number} is no longer open.\n\n${reason}\n\n${alert.html_url}`,
+              });
+              await github.rest.issues.update({
+                owner, repo, issue_number: existing.number,
+                state: 'closed',
+                state_reason: action === 'fixed' ? 'completed' : 'not_planned',
+              });
+              core.info(`Closed #${existing.number} for alert #${alert.number}.`);
+              return;
+            }
+
+            core.info(`Action "${action}" needs no issue change.`);

--- a/.github/workflows/code-scanning-issue.yml
+++ b/.github/workflows/code-scanning-issue.yml
@@ -64,10 +64,19 @@ jobs:
 
               // The issue cannot know its own number until it exists, so the
               // concrete "Fixes #N" line is written in a second pass.
-              await github.rest.issues.update({
-                owner, repo, issue_number: created.data.number,
-                body: renderIssue(alert, created.data.number).body,
-              });
+              try {
+                await github.rest.issues.update({
+                  owner, repo, issue_number: created.data.number,
+                  body: renderIssue(alert, created.data.number).body,
+                });
+              } catch (error) {
+                core.warning(
+                  `#${created.data.number} was created successfully for alert #${alert.number}, ` +
+                    'but injecting the concrete "Fixes #N" line into its body failed; it keeps the ' +
+                    'generic fallback wording. A maintainer can edit the body, or simply reference ' +
+                    `#${created.data.number} manually in the fix PR. Error: ${error.message}`,
+                );
+              }
               core.info(`Created #${created.data.number} for alert #${alert.number}.`);
               return;
             }

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -10,6 +10,7 @@ const config: KnipConfig = {
     "packages/db/src/**",
     "packages/shared/src/app/constants.ts",
     ".claude/scripts/sync-agent-skills.mjs",
+    ".github/scripts/code-scanning-issue.cjs",
     "tooling/typescript/type-extensions.d.ts",
     "turbo/generators/config.ts",
   ],

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "engines": {
     "node": ">=24.18.0 <25"
   },
-  "packageManager": "pnpm@11.17.0+sha512.cca3cea332ad254bb84145f966d19f4879615210346fc92c79a047f23a0d7b3cca3c3792f0076ba1f1831d277efbcf0a9119b31a9a60eca7fb3d6231f331ef72",
+  "packageManager": "pnpm@11.18.0+sha512.33d83c77da82f49fba836925c6f1b841181ec3132b670639bd012f7075f5c7cf634c5f870147c19aae7478fac01df09d8892e880454896edd23ee9b33757563c",
   "scripts": {
     "build": "turbo build",
     "ci:local": "pnpm format && pnpm lint && pnpm lint:unused && pnpm typecheck && pnpm build && pnpm test",


### PR DESCRIPTION
## Overview

Security scanning finds problems in our code, but today those findings only appear in the repository's Security tab, which most contributors never open. This adds two automations that turn each finding into a normal GitHub Issue, so the work shows up where we actually track work.

The first automation runs by itself whenever a new finding appears. The second is a one-time cleanup that files issues for the 6 findings we already have; it is run once by hand and deleted afterwards.

Issues also close themselves once the underlying finding is resolved.

## What's here

- `.github/scripts/code-scanning-issue.cjs` — the shared code that formats an issue from an alert and finds an alert's existing issue. Both workflows use it, so both produce identical issues.
- `.github/workflows/code-scanning-issue.yml` — reacts to alerts being opened, reopened, fixed, or dismissed.
- `.github/workflows/code-scanning-backfill.yml` — the one-shot, manually dispatched backfill. Defaults to a dry run.
- `knip.config.ts` — one-line ignore entry, explained below.

## A note on how closing works

The original request was for closing an issue to close its alert. GitHub does not support that: the only way to close an alert through the API is to *dismiss* it, and the available dismissal reasons are "false positive", "won't fix", and "used in tests" — none of which mean "we fixed it". Marking a genuinely fixed alert as dismissed would misrepresent it and hide it from future scans.

So this works the other way round, which reaches the same end state: merge the fix, the scanner re-runs on `main` and marks the alert fixed on its own, and the workflow then closes the issue. No automation ever dismisses an alert.

## Pull-request branches are not tracked

Code scanning here runs through GitHub's default setup, which analyzes pull requests as well as `main`. Without a guard, a contributor opening a PR that introduced a new finding would get an issue filed for a problem that only ever existed on their branch — and if the PR were abandoned, that issue would linger forever pointing at an alert that no longer exists.

So issue creation is skipped for alerts on any branch other than the default one. Closing is deliberately **not** filtered this way: closing an issue is harmless and idempotent, and gating it would risk issues silently never closing.

## Why knip.config.ts changed

Both workflows load the shared module with `require()` from inside an `actions/github-script` YAML block. knip only follows static imports, so it cannot see that call and reported the file as dead code, failing the `lint` job. The file is added to knip's `ignore` list, directly alongside the existing `.claude/scripts/sync-agent-skills.mjs` entry, which is there for exactly the same reason.

## Not included, on purpose

No labels, project board membership, or Priority/Effort values are applied — issues are filed bare and triaged by hand. (Priority and Effort are organization-level project fields whose options the API does not expose, so they cannot be set from a workflow regardless.)

## Testing

Honest summary: **none of this can be verified before merge.** GitHub only dispatches the `code_scanning_alert` event against the default branch's copy of a workflow file, so the reactive workflow cannot run from this branch. The issue-rendering logic was developed against a local test harness that was intentionally not committed.

After merge, verification is:

1. Dispatch the backfill with **dry run checked** — it should list 6 alerts and create nothing.
2. Dispatch again unchecked — it should create 6 issues.
3. Dispatch a third time — it should create 0, proving duplicates are prevented.

Then delete `.github/workflows/code-scanning-backfill.yml` in a follow-up PR.

## Also in this PR

A one-line bump of the pinned pnpm version in `package.json` (11.17.0 → 11.18.0), riding along in its own commit. Unrelated to the workflows.

## Impact

No database changes, no environment variables, no new secrets. Uses the built-in `GITHUB_TOKEN`.
