### PR TITLE
fix(slackbot): acknowledging requests prior to sending loading modal

### DIFF
--- a/apps/slackbot/main.py
+++ b/apps/slackbot/main.py
@@ -79,16 +79,48 @@ else:
     handler = StructuredLogHandler()
     setup_logging(handler, log_level=logging_level)
 
-try:
-    app = App(
-        process_before_response=process_before_response,
-        oauth_settings=get_oauth_settings(),
-    )
-except Exception as exc:
-    raise RuntimeError(
-        "Error initializing Slackbot: you may need to set up your .env file with the appropriate Slack credentials. "
-        f"Exception: {exc}"
-    ) from exc
+_app = None
+_app_lock = threading.Lock()
+
+
+def create_slack_app() -> App:
+    try:
+        slack_app = App(
+            process_before_response=process_before_response,
+            oauth_settings=get_oauth_settings(),
+        )
+    except Exception as exc:
+        raise RuntimeError(
+            "Error initializing Slackbot: you may need to set up your .env file with the appropriate Slack "
+            "credentials. "
+            f"Exception: {exc}"
+        ) from exc
+
+    try:
+        args = [main_response]
+        lazy_kwargs = {}
+
+        match_all_pattern = re.compile(".*")
+        slack_app.action(match_all_pattern)(*args, **lazy_kwargs)
+        slack_app.view(match_all_pattern)(*args, **lazy_kwargs)
+        slack_app.command(match_all_pattern)(*args, **lazy_kwargs)
+        slack_app.view_closed(match_all_pattern)(*args, **lazy_kwargs)
+        slack_app.event(match_all_pattern)(*args, **lazy_kwargs)
+        slack_app.options(match_all_pattern)(*args, **lazy_kwargs)
+        slack_app.shortcut(match_all_pattern)(*args, **lazy_kwargs)
+    except Exception:
+        pass
+
+    return slack_app
+
+
+def get_slack_app() -> App:
+    global _app
+    if _app is None:
+        with _app_lock:
+            if _app is None:
+                _app = create_slack_app()
+    return _app
 
 # ----------------------------------------
 # Production Mode: Google Cloud Function HTTP Handler
@@ -110,7 +142,7 @@ if not LOCAL_DEVELOPMENT:
             logging.info(f"Request body: {request.get_data(as_text=True)}")
             return strava.strava_exchange_token(request)
         elif request.path[:6] == "/slack":
-            slack_handler = SlackRequestHandler(app=app)
+            slack_handler = SlackRequestHandler(app=get_slack_app())
             return slack_handler.handle(request)
         elif request.path == "/hourly-runner-complete":
             update_local_region_records()
@@ -196,23 +228,6 @@ def main_response(body: dict, logger: logging.Logger, client: WebClient, ack: Ac
             f"{safe_get(safe_get(MAIN_MAPPER, request_type), request_id) or request_type + ', ' + request_id}"
         )
 
-
-try:
-    ARGS = [main_response]
-    LAZY_KWARGS = {}
-
-    MATCH_ALL_PATTERN = re.compile(".*")
-    app.action(MATCH_ALL_PATTERN)(*ARGS, **LAZY_KWARGS)
-    app.view(MATCH_ALL_PATTERN)(*ARGS, **LAZY_KWARGS)
-    app.command(MATCH_ALL_PATTERN)(*ARGS, **LAZY_KWARGS)
-    app.view_closed(MATCH_ALL_PATTERN)(*ARGS, **LAZY_KWARGS)
-    app.event(MATCH_ALL_PATTERN)(*ARGS, **LAZY_KWARGS)
-    app.options(MATCH_ALL_PATTERN)(*ARGS, **LAZY_KWARGS)
-    app.shortcut(MATCH_ALL_PATTERN)(*ARGS, **LAZY_KWARGS)
-except Exception:
-    pass
-
-
 def start_local_health_server(port: int):
     class HealthHandler(BaseHTTPRequestHandler):
         def do_GET(self):
@@ -246,7 +261,7 @@ if __name__ == "__main__":
 
     if not SOCKET_MODE:
         try:
-            app.start(port=port)
+            get_slack_app().start(port=port)
             update_local_region_records()
         except KeyboardInterrupt:
             # graceful shutdown during auto-reload
@@ -258,5 +273,5 @@ if __name__ == "__main__":
 
         logging.getLogger().info("Running in local Socket Mode.")
 
-        handler = SocketModeHandler(app, app_token)
+        handler = SocketModeHandler(get_slack_app(), app_token)
         handler.start()

--- a/apps/slackbot/main.py
+++ b/apps/slackbot/main.py
@@ -133,6 +133,9 @@ def main_response(body: dict, logger: logging.Logger, client: WebClient, ack: Ac
 
     if lookup:
         run_function, add_loading, has_submission_ack = lookup
+        if request_type not in ("block_suggestion", "view_submission"):
+            ack()
+
         if ENABLE_DEBUGGING and request_type != "view_submission":
             body[LOADING_ID] = add_debug_form(body=body, client=client)
             # NOTE: do not put debugging breakpoints above this line
@@ -152,9 +155,6 @@ def main_response(body: dict, logger: logging.Logger, client: WebClient, ack: Ac
                 )
             else:
                 ack()
-
-        if request_type not in ("block_suggestion", "view_submission"):
-            ack()
 
         try:
             try:

--- a/apps/slackbot/main.py
+++ b/apps/slackbot/main.py
@@ -122,6 +122,7 @@ def get_slack_app() -> App:
                 _app = create_slack_app()
     return _app
 
+
 # ----------------------------------------
 # Production Mode: Google Cloud Function HTTP Handler
 # (DISABLED in local development)
@@ -227,6 +228,7 @@ def main_response(body: dict, logger: logging.Logger, client: WebClient, ack: Ac
             f"no handler for path: "
             f"{safe_get(safe_get(MAIN_MAPPER, request_type), request_id) or request_type + ', ' + request_id}"
         )
+
 
 def start_local_health_server(port: int):
     class HealthHandler(BaseHTTPRequestHandler):

--- a/apps/slackbot/tests/conftest.py
+++ b/apps/slackbot/tests/conftest.py
@@ -4,5 +4,3 @@ import os
 # (e.g. utilities.constants) loads the developer's local .env, so test outcomes
 # don't depend on ambient dev settings like ENABLE_DEBUGGING=true.
 os.environ["ENABLE_DEBUGGING"] = "false"
-os.environ["LOCAL_DEVELOPMENT"] = "true"
-os.environ["SLACK_BOT_TOKEN"] = "test-token"

--- a/apps/slackbot/tests/conftest.py
+++ b/apps/slackbot/tests/conftest.py
@@ -4,3 +4,4 @@ import os
 # (e.g. utilities.constants) loads the developer's local .env, so test outcomes
 # don't depend on ambient dev settings like ENABLE_DEBUGGING=true.
 os.environ["ENABLE_DEBUGGING"] = "false"
+os.environ["LOCAL_DEVELOPMENT"] = "true"

--- a/apps/slackbot/tests/conftest.py
+++ b/apps/slackbot/tests/conftest.py
@@ -5,3 +5,4 @@ import os
 # don't depend on ambient dev settings like ENABLE_DEBUGGING=true.
 os.environ["ENABLE_DEBUGGING"] = "false"
 os.environ["LOCAL_DEVELOPMENT"] = "true"
+os.environ["SLACK_BOT_TOKEN"] = "test-token"

--- a/apps/slackbot/tests/test_main_app.py
+++ b/apps/slackbot/tests/test_main_app.py
@@ -19,9 +19,7 @@ def test_import_does_not_create_slack_app():
 def test_get_slack_app_is_a_singleton_and_registers_listeners():
     slack_app = MagicMock()
 
-    with patch.object(main, "App", return_value=slack_app), patch.object(
-        main, "get_oauth_settings", return_value={}
-    ):
+    with patch.object(main, "App", return_value=slack_app), patch.object(main, "get_oauth_settings", return_value={}):
         first = main.get_slack_app()
         second = main.get_slack_app()
 

--- a/apps/slackbot/tests/test_main_app.py
+++ b/apps/slackbot/tests/test_main_app.py
@@ -1,0 +1,36 @@
+import importlib
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import main
+
+
+def test_import_does_not_create_slack_app():
+    with patch.object(main, "create_slack_app") as create_slack_app:
+        importlib.reload(main)
+
+    create_slack_app.assert_not_called()
+    assert main._app is None
+
+
+def test_get_slack_app_is_a_singleton_and_registers_listeners():
+    slack_app = MagicMock()
+
+    with patch.object(main, "App", return_value=slack_app), patch.object(
+        main, "get_oauth_settings", return_value={}
+    ):
+        first = main.get_slack_app()
+        second = main.get_slack_app()
+
+    assert first is slack_app
+    assert second is slack_app
+    assert slack_app.action.call_count == 1
+    assert slack_app.view.call_count == 1
+    assert slack_app.command.call_count == 1
+    assert slack_app.view_closed.call_count == 1
+    assert slack_app.event.call_count == 1
+    assert slack_app.options.call_count == 1
+    assert slack_app.shortcut.call_count == 1

--- a/apps/slackbot/tests/test_main_response.py
+++ b/apps/slackbot/tests/test_main_response.py
@@ -1,0 +1,25 @@
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from main import main_response
+
+
+def test_calendar_shortcut_acknowledges_before_loading_form_and_handler():
+    events = []
+    ack = MagicMock(side_effect=lambda: events.append("ack"))
+    add_loading_form = MagicMock(side_effect=lambda **_: events.append("loading"))
+    handler = MagicMock(side_effect=lambda **_: events.append("handler"))
+    body = {"type": "shortcut", "callback_id": "calendar_shortcut", "team": {"id": "T123"}}
+
+    with (
+        patch("main.MAIN_MAPPER", {"shortcut": {"calendar_shortcut": (handler, True, False)}}),
+        patch("main.add_loading_form", add_loading_form),
+        patch("main.get_region_record", return_value=MagicMock()),
+    ):
+        main_response(body, MagicMock(), MagicMock(), ack, {})
+
+    assert events == ["ack", "loading", "handler"]
+    ack.assert_called_once_with()

--- a/apps/slackbot/utilities/builders.py
+++ b/apps/slackbot/utilities/builders.py
@@ -160,8 +160,8 @@ def add_loading_form(body: dict, client: WebClient, new_or_add: str = "new") -> 
             callback_id="loading-id",
             new_or_add=new_or_add,
         )
-    # wait 0.1 seconds
-    time.sleep(0.1)
+    # wait 0.3 seconds
+    time.sleep(0.3)
     return safe_get(loading_form_response, "view", "id")
 
 

--- a/apps/slackbot/utilities/builders.py
+++ b/apps/slackbot/utilities/builders.py
@@ -161,7 +161,7 @@ def add_loading_form(body: dict, client: WebClient, new_or_add: str = "new") -> 
             new_or_add=new_or_add,
         )
     # wait 0.1 seconds
-    time.sleep(0.3)
+    time.sleep(0.1)
     return safe_get(loading_form_response, "view", "id")
 
 


### PR DESCRIPTION
This is a small hotfix to address an issue some users are seeing. We were applying Slack's required acknowledgement (`ack()`) after sending the loading modal where required. For reasons not fully clear to me, this can lead to the loading modal not being updated after the response function is run, if the response function is too fast.

I now apply `ack()` before sending the loading modal, which I think should fix it... it's hard to say for sure, because Slack stuff can be flaky and this sort of thing can behave very differently on a local machine than our Cloud Run environments, so we'll definitely want to test things in staging before deploying to prod.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of calendar shortcuts so requests are acknowledged promptly before loading content appears.
  * Prevented duplicate or delayed acknowledgments during form submissions.

* **Performance**
  * Reduced the delay before loading forms are displayed, making calendar interactions feel more responsive.

* **Tests**
  * Added coverage to verify the expected acknowledgment, loading, and processing sequence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->