### PR TITLE
chore(slackbot): add non-root user to slackbot dockerfile

### DIFF
--- a/apps/slackbot/Dockerfile
+++ b/apps/slackbot/Dockerfile
@@ -11,19 +11,20 @@ ENV PYTHONUNBUFFERED=1 \
 
 WORKDIR /app
 
-# Create non-root user for security (must exist before uv sync so --chown works)
+# Create non-root user for security
 RUN groupadd --gid 1000 slackbot && \
     useradd --uid 1000 --gid slackbot --shell /bin/bash --create-home slackbot
 
-COPY pyproject.toml uv.lock ./
-COPY packages/db-python ./packages/db-python
-COPY apps/slackbot ./apps/slackbot
+# Copy source files owned by slackbot (BuildKit --chown is valid on COPY)
+COPY --chown=slackbot:slackbot pyproject.toml uv.lock ./
+COPY --chown=slackbot:slackbot packages/db-python ./packages/db-python
+COPY --chown=slackbot:slackbot apps/slackbot ./apps/slackbot
 
-# Run uv sync as slackbot so the venv is created with correct ownership;
-# no post-install chown -R needed, avoiding metadata rewrites on the venv tree.
+# uv sync runs as root (build-time); fix venv ownership afterward.
+# Only /app/.venv needs to be writable by slackbot at runtime.
 RUN --mount=type=cache,target=/root/.cache/uv \
-    --chown=slackbot:slackbot \
-    uv sync --locked --package f3-nation-slack-bot --no-dev --no-editable
+    uv sync --locked --package f3-nation-slack-bot --no-dev --no-editable && \
+    chown -R slackbot:slackbot /app/.venv
 
 WORKDIR $APP_HOME
 USER slackbot

--- a/apps/slackbot/Dockerfile
+++ b/apps/slackbot/Dockerfile
@@ -11,21 +11,21 @@ ENV PYTHONUNBUFFERED=1 \
 
 WORKDIR /app
 
+# Create non-root user for security (must exist before uv sync so --chown works)
+RUN groupadd --gid 1000 slackbot && \
+    useradd --uid 1000 --gid slackbot --shell /bin/bash --create-home slackbot
+
 COPY pyproject.toml uv.lock ./
 COPY packages/db-python ./packages/db-python
 COPY apps/slackbot ./apps/slackbot
 
+# Run uv sync as slackbot so the venv is created with correct ownership;
+# no post-install chown -R needed, avoiding metadata rewrites on the venv tree.
 RUN --mount=type=cache,target=/root/.cache/uv \
+    --chown=slackbot:slackbot \
     uv sync --locked --package f3-nation-slack-bot --no-dev --no-editable
 
 WORKDIR $APP_HOME
-
-# Create non-root user for security
-RUN groupadd --gid 1000 slackbot && \
-    useradd --uid 1000 --gid slackbot --shell /bin/bash --create-home slackbot && \
-    mkdir -p /app/.venv /app/packages /app/apps/slackbot && \
-    chown -R slackbot:slackbot /app
-
 USER slackbot
 EXPOSE 8080
 CMD ["functions-framework", "--target", "handler", "--port", "8080"]

--- a/apps/slackbot/Dockerfile
+++ b/apps/slackbot/Dockerfile
@@ -19,5 +19,13 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --locked --package f3-nation-slack-bot --no-dev --no-editable
 
 WORKDIR $APP_HOME
+
+# Create non-root user for security
+RUN groupadd --gid 1000 slackbot && \
+    useradd --uid 1000 --gid slackbot --shell /bin/bash --create-home slackbot && \
+    mkdir -p /app/.venv /app/packages /app/apps/slackbot && \
+    chown -R slackbot:slackbot /app
+
+USER slackbot
 EXPOSE 8080
 CMD ["functions-framework", "--target", "handler", "--port", "8080"]


### PR DESCRIPTION
## Security Fix: Run slackbot container as non-root user

**Issue:** #851

**Problem:** The slackbot Dockerfile runs as root by default, which is a security risk. If an attacker compromises the application, they have root access to the container.

**Solution:** Create a dedicated `slackbot` user (UID 1000) and switch to it before running the application.

**Changes:**
- Added `slackbot` user and group (UID/GID 1000)
- Changed ownership of `/app` to `slackbot` user
- Added `USER slackbot` directive before `CMD`

This follows Docker security best practices and the principle of least privilege.

Closes #851

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * The Slack bot now runs as a non-root user, improving container security.
  * Dependency installation and application files use the correct ownership for safer, more reliable operation.
  * Required application directories are created with appropriate permissions to support consistent startup and execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->