### PR TITLE
fix(slackbot): format preblast start time for display

### DIFF
--- a/apps/slackbot/features/calendar/event_preblast.py
+++ b/apps/slackbot/features/calendar/event_preblast.py
@@ -49,6 +49,7 @@ from utilities.helper_functions import (
     current_date_cst,
     extract_state_values,
     fix_from_llm_tags,
+    format_event_time,
     get_location_display_name,
     get_user,
     get_user_names,
@@ -1093,7 +1094,7 @@ def build_preblast_info(
     event_details = (
         f"*Preblast: {event.name}*"
         f"\n*Date:* {event.start_date.strftime('%A, %B %d') if event.start_date else 'TBD'}"
-        f"\n*Time:* {event.start_time or 'TBD'}"
+        f"\n*Time:* {format_event_time(event.start_time)}"
         f"\n*Where:* {location_display or 'TBD'}"
         f"\n*Event Type:* {event_type_display}"
         + (f"\n*Event Tag:* {event_tag_display}" if event_tag_display else "")

--- a/apps/slackbot/tests/features/calendar/test_preblast_views.py
+++ b/apps/slackbot/tests/features/calendar/test_preblast_views.py
@@ -256,6 +256,70 @@ class PreblastViewsTest(unittest.TestCase):
         self.assertNotIn("*Q:* Open!", event_details)
         self.assertNotIn("*HCs:* None", event_details)
 
+    @patch("f3_data_models.utils.DbManager.find_records")
+    @patch("features.calendar.event_preblast._build_attendance_service")
+    @patch("features.calendar.event_preblast._build_event_instance_service")
+    def test_build_preblast_info_formats_start_time_for_display(
+        self,
+        mock_build_event_service,
+        mock_build_attendance_service,
+        mock_find_records,
+    ):
+        """The posted preblast renders a readable time, not the stored HHMM value.
+
+        Unit tests cover ``format_event_time`` itself; this pins the rendering
+        path so the formatter cannot be dropped from ``build_preblast_info``
+        without a test failing.
+        """
+        event_id = 42
+        event_service = MagicMock()
+        event_service.get_by_id.return_value = _event(id=event_id, start_time="0530")
+        mock_build_event_service.return_value = event_service
+
+        attendance_service = MagicMock()
+        attendance_service.get_planned_for_event_instance.return_value = []
+        mock_build_attendance_service.return_value = attendance_service
+        mock_find_records.return_value = []
+
+        preblast_info = build_preblast_info(
+            logger=MagicMock(),
+            region_record=MagicMock(team_id="T123"),
+            event_instance_id=event_id,
+        )
+
+        event_details = preblast_info.preblast_blocks[0]["text"]["text"]
+        self.assertIn("*Time:* 05:30 AM", event_details)
+        self.assertNotIn("*Time:* 0530", event_details)
+
+    @patch("f3_data_models.utils.DbManager.find_records")
+    @patch("features.calendar.event_preblast._build_attendance_service")
+    @patch("features.calendar.event_preblast._build_event_instance_service")
+    def test_build_preblast_info_renders_tbd_when_start_time_missing(
+        self,
+        mock_build_event_service,
+        mock_build_attendance_service,
+        mock_find_records,
+    ):
+        """Preserves the previous ``or 'TBD'`` behavior for unset times."""
+        event_id = 43
+        event_service = MagicMock()
+        event_service.get_by_id.return_value = _event(id=event_id, start_time=None)
+        mock_build_event_service.return_value = event_service
+
+        attendance_service = MagicMock()
+        attendance_service.get_planned_for_event_instance.return_value = []
+        mock_build_attendance_service.return_value = attendance_service
+        mock_find_records.return_value = []
+
+        preblast_info = build_preblast_info(
+            logger=MagicMock(),
+            region_record=MagicMock(team_id="T123"),
+            event_instance_id=event_id,
+        )
+
+        event_details = preblast_info.preblast_blocks[0]["text"]["text"]
+        self.assertIn("*Time:* TBD", event_details)
+
     @patch("f3_data_models.utils.DbManager.find_records", side_effect=RuntimeError("db unavailable"))
     @patch("features.calendar.event_preblast._build_attendance_service")
     @patch("features.calendar.event_preblast._build_event_instance_service")

--- a/apps/slackbot/tests/utilities/test_helper_functions.py
+++ b/apps/slackbot/tests/utilities/test_helper_functions.py
@@ -1,8 +1,10 @@
 import os
 import sys
 
+import pytest
+
 sys.path.append(os.path.join(os.path.dirname(__file__), "..", ".."))
-from utilities.helper_functions import is_deactivated_slack_user, safe_get
+from utilities.helper_functions import format_event_time, is_deactivated_slack_user, safe_get
 
 
 def test_safe_get():
@@ -14,3 +16,68 @@ def test_is_deactivated_slack_user():
     assert is_deactivated_slack_user({"deleted": True}) is True
     assert is_deactivated_slack_user({"deleted": False}) is False
     assert is_deactivated_slack_user({}) is False
+
+
+# ---------------------------------------------------------------------------
+# format_event_time
+#
+# ``start_time`` is stored as a bare "HHMM" string, unlike ``start_date`` which
+# is a ``datetime.date``. The read path does no validation — the model declares
+# ``str | None`` and the API repository defaults it to "" — so None, empty and
+# unparseable values all reach this formatter and must not raise. An exception
+# here propagates out of ``build_preblast_info`` and stops the preblast posting.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("stored", "expected"),
+    [
+        ("0530", "05:30 AM"),
+        ("0600", "06:00 AM"),
+        ("1730", "05:30 PM"),
+        ("2359", "11:59 PM"),
+        ("0000", "12:00 AM"),  # midnight is 12 AM, not 00 AM
+        ("1200", "12:00 PM"),  # noon is 12 PM, not 00 PM
+        ("0059", "12:59 AM"),
+        ("1259", "12:59 PM"),
+    ],
+)
+def test_format_event_time_formats_stored_hhmm(stored, expected):
+    assert format_event_time(stored) == expected
+
+
+def test_format_event_time_uses_zero_padded_twelve_hour():
+    """``%I`` matches the style already used in emergency.py and calendar_images.py.
+
+    It is also the only portable choice: ``%-I`` is a glibc extension that fails
+    on Windows, which needs ``%#I``.
+    """
+    assert format_event_time("0530") == "05:30 AM"
+    assert format_event_time("0930") == "09:30 AM"
+
+
+@pytest.mark.parametrize("stored", [None, ""])
+def test_format_event_time_missing_value_returns_tbd(stored):
+    """``None`` is the model default; ``""`` is written by the API repository."""
+    assert format_event_time(stored) == "TBD"
+
+
+@pytest.mark.parametrize("stored", ["5:30", "05:30", "abcd", "99999", "7", "530pm"])
+def test_format_event_time_unparseable_falls_back_to_raw(stored):
+    """Unrecognized values pass through unchanged rather than raising.
+
+    Showing an odd string is cosmetic; raising here would propagate out of
+    ``build_preblast_info`` and stop the preblast posting entirely.
+    """
+    assert format_event_time(stored) == stored
+
+
+@pytest.mark.parametrize("stored", [None, "", "0530", "5:30", "abcd", "99999", "2400", "-100"])
+def test_format_event_time_never_raises(stored):
+    """No input reachable from storage may raise out of this function."""
+    assert isinstance(format_event_time(stored), str)
+
+
+def test_format_event_time_does_not_render_raw_hhmm():
+    """The original defect: the stored value reaching Slack unformatted."""
+    assert format_event_time("0530") != "0530"

--- a/apps/slackbot/utilities/helper_functions.py
+++ b/apps/slackbot/utilities/helper_functions.py
@@ -737,6 +737,14 @@ def time_str_to_int(time: str) -> int:
     return int(time.replace(":", ""))
 
 
+def format_event_time(time: str | None) -> str:
+    """Format an ``HHMM`` time string for display (e.g. ``0530`` -> ``05:30 AM``)."""
+    if not time:
+        return "TBD"
+    parsed = safe_convert(time, datetime.strptime, ["%H%M"])
+    return parsed.strftime("%I:%M %p") if parsed else time
+
+
 def current_date_cst() -> date:
     """Returns the current date in US/Central timezone."""
     return datetime.now(pytz.timezone("US/Central")).date()


### PR DESCRIPTION
<hr>
<h3>👋 TL;DR</h3>
<p>Posted preblasts showed the raw stored start time — <code>0515</code> instead of <code>05:15 AM</code>
— while the date on the line above was already formatted. This adds a small
helper to format the time for display. Verified in a live Slack dev workspace
(screenshot below) plus 419 passing tests.</p>
<h3>🔎 Details</h3>
<p>Closes #853 </p>
<p><code>EventInstance.start_time</code> is stored as a bare <code>HHMM</code> string, whereas
<code>start_date</code> is a <code>datetime.date</code>. Dates therefore have <code>.strftime()</code> available
and times don't, so <code>build_preblast_info()</code> formatted one and interpolated the
other raw:</p>
<pre><code class="language-python">f"\n*Date:* {event.start_date.strftime('%A, %B %d') if event.start_date else 'TBD'}"
f"\n*Time:* {event.start_time or 'TBD'}"
</code></pre>
<p><strong>Changes</strong></p>
<ol>
<li>
<p><strong><code>utilities/helper_functions.py</code></strong> — new <code>format_event_time()</code>, placed beside
the existing time helpers.</p>
<pre><code class="language-python">def format_event_time(time: str | None) -&gt; str:
    """Format an ``HHMM`` time string for display (e.g. ``0530`` -&gt; ``05:30 AM``)."""
    if not time:
        return "TBD"
    parsed = safe_convert(time, datetime.strptime, ["%H%M"])
    return parsed.strftime("%I:%M %p") if parsed else time
</code></pre>
</li>
<li>
<p><strong><code>features/calendar/event_preblast.py</code></strong> — L1096 now calls it, and the
fallback moves into the helper.</p>
<pre><code class="language-diff">-        f"\n*Time:* {event.start_time or 'TBD'}"
+        f"\n*Time:* {format_event_time(event.start_time)}"
</code></pre>
</li>
</ol>
<p><strong>Notes on the choices</strong></p>
<ul>
<li>
<p><strong><code>%I</code> rather than <code>%-I</code>.</strong> Matches the 12-hour style already used in
<code>features/emergency.py</code> L204 and <code>scripts/calendar_images.py</code> L384, and is the
only portable option — <code>%-I</code> is a glibc extension that fails on Windows, which
needs <code>%#I</code>.</p>
</li>
<li>
<p><strong>Cannot raise.</strong> The read path does no validation:
<code>application/preblast/__init__.py</code> L52 declares <code>str | None</code>, and
<code>infrastructure/api_client/event_instance_repository.py</code> defaults <code>start_time</code>
to <code>""</code> at L413 and L460. <code>safe_convert</code> (already the established idiom in this
file, L716) catches <code>TypeError</code>/<code>ValueError</code>, so unparseable values fall back
to the raw string. An exception here would propagate out of
<code>build_preblast_info</code> and stop the preblast posting entirely — worse than a
badly formatted time.</p>
</li>
<li>
<p><strong><code>"TBD"</code> preserved</strong> for <code>None</code> and <code>""</code>, matching the previous <code>or 'TBD'</code>.</p>
</li>
</ul>
<p><strong>Deliberately out of scope</strong></p>
<ul>
<li><code>preblast_views.py</code> L299 does a similar-looking conversion but feeds
<code>initial_time</code> on a Slack <code>TimePickerElement</code>, which requires 24-hour <code>HH:MM</code>.
It is correct as-is and left untouched.</li>
<li>The same raw interpolation exists in <code>home.py</code> (L245/247/249, L433),
<code>series.py</code> L424, <code>canvas.py</code> L20, and two scripts. Happy to follow up
separately if reviewers would prefer them consistent.</li>
<li>The two unused <code>time_int_to_str</code> / <code>time_str_to_int</code> helpers are left alone to
keep this diff small.</li>
</ul>
<h3>✅ How to Test</h3>
<p><strong>Verified locally in a Slack workspace</strong></p>
<p><img width="574" height="879" alt="formattedDate" src="https://github.com/user-attachments/assets/59e0bc8f-37be-453a-9f19-a7661a879b78" /></p>
<p>Three preblasts in the same channel:</p>

  | Preblast | Rendered | State
-- | -- | -- | --
Top | The Foundry Bootcamp | Time: 0515 | before the change
Middle | South End Station Ruck | Time: 05:00 AM | reposted after the change
Bottom | The Colosseum Run | Time: 05:16 AM | newly posted after the change


<p><code>test_format_event_time_never_raises</code> asserts every reachable input returns a
<code>str</code>.</p>
<p><em><code>tests/features/calendar/test_preblast_views.py</code></em> — 2 new cases against the
rendered preblast, following the existing
<code>test_build_preblast_info_uses_f3_name_fallback_*</code> pattern:</p>
<ul>
<li><code>test_build_preblast_info_formats_start_time_for_display</code> — asserts
<code>*Time:* 05:30 AM</code> appears and <code>*Time:* 0530</code> does not</li>
<li><code>test_build_preblast_info_renders_tbd_when_start_time_missing</code> — asserts
<code>*Time:* TBD</code> for an unset time</li>
</ul>
<p><strong>To reproduce the manual check</strong></p>
<ol>
<li>Set up the slackbot per <code>apps/slackbot/README.md</code> and run
<code>pnpm dev --include-py</code></li>
<li><strong>Given</strong> an event with a start time of 5:16 AM, <strong>when</strong> its preblast is
posted, <strong>then</strong> the <code>*Time:*</code> line reads <code>05:16 AM</code></li>
<li><strong>Given</strong> a preblast posted before this change, <strong>when</strong> it is edited and
resubmitted through the preblast modal, <strong>then</strong> it re-renders as <code>05:00 AM</code></li>
<li><strong>Given</strong> an event with no start time, <strong>then</strong> the line reads <code>TBD</code></li>
<li>Confirm the start-time picker still pre-populates correctly when editing
(guards the <code>preblast_views.py</code> L299 path, which must stay 24-hour)</li>
</ol>
<h3>🥜 GIF</h3>
&lt;!-- optional --&gt;</body></html>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Calendar event preblasts now display start times in a readable 12-hour format.
  * Missing event times are shown as “TBD.”
  * Invalid time values remain visible without causing errors.

* **Tests**
  * Added coverage for formatted, missing, invalid, and zero-padded event times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->