### PR TITLE
refactor(api): swap @t3-oss/env-nextjs for env-core in apps/api

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -25,7 +25,7 @@
     "@orpc/zod": "catalog:",
     "@scalar/nextjs-api-reference": "catalog:",
     "@sentry/nextjs": "catalog:",
-    "@t3-oss/env-nextjs": "catalog:",
+    "@t3-oss/env-core": "catalog:",
     "dotenv-cli": "catalog:",
     "next": "catalog:",
     "next-auth": "catalog:",

--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -1,7 +1,8 @@
-import { createEnv } from "@t3-oss/env-nextjs";
+import { createEnv } from "@t3-oss/env-core";
 import { z } from "zod";
 
 export const env = createEnv({
+  clientPrefix: "NEXT_PUBLIC_",
   shared: {
     NODE_ENV: z
       .enum(["development", "production", "test"])
@@ -36,12 +37,16 @@ export const env = createEnv({
     // NEXT_PUBLIC_CLIENTVAR: z.string(),
   },
   /**
-   * Destructure all variables from `process.env` to make sure they aren't tree-shaken away.
+   * env-core has no bundler integration, so every var (client and server) must be
+   * listed explicitly here — unlike env-nextjs, server vars aren't auto-filled.
    */
-  experimental__runtimeEnv: {
+  runtimeEnv: {
     NEXT_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL,
     NODE_ENV: process.env.NODE_ENV,
     NEXT_PUBLIC_CHANNEL: process.env.NEXT_PUBLIC_CHANNEL,
+    AUTH_SECRET: process.env.AUTH_SECRET,
+    DATABASE_URL: process.env.DATABASE_URL,
+    TEST_DATABASE_URL: process.env.TEST_DATABASE_URL,
   },
   skipValidation:
     !!process.env.CI ||

--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -40,7 +40,7 @@ export const env = createEnv({
    * env-core has no bundler integration, so every var (client and server) must be
    * listed explicitly here — unlike env-nextjs, server vars aren't auto-filled.
    */
-  runtimeEnv: {
+  runtimeEnvStrict: {
     NEXT_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL,
     NODE_ENV: process.env.NODE_ENV,
     NEXT_PUBLIC_CHANNEL: process.env.NEXT_PUBLIC_CHANNEL,

--- a/apps/api/vitest.config.ts
+++ b/apps/api/vitest.config.ts
@@ -18,10 +18,10 @@ export default defineConfig({
       exclude: coverageExclude,
       thresholds: {
         autoUpdate: true,
-        statements: 90.62,
-        branches: 93.18,
+        statements: 91.04,
+        branches: 93.47,
         functions: 80,
-        lines: 90.62,
+        lines: 91.04,
       },
     },
     exclude: [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -123,6 +123,9 @@ catalogs:
     '@sentry/nextjs':
       specifier: ^10.69.0
       version: 10.70.0
+    '@t3-oss/env-core':
+      specifier: ^0.13.11
+      version: 0.13.11
     '@t3-oss/env-nextjs':
       specifier: ^0.13.11
       version: 0.13.11
@@ -644,7 +647,7 @@ importers:
       '@sentry/nextjs':
         specifier: 'catalog:'
         version: 10.70.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1))(next@16.3.0(@babel/core@7.29.0(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)(webpack@5.105.4(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))
-      '@t3-oss/env-nextjs':
+      '@t3-oss/env-core':
         specifier: 'catalog:'
         version: 0.13.11(typescript@6.0.3)(zod@4.4.3)
       dotenv-cli:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -44,6 +44,7 @@ catalog:
   "@react-hook/window-size": ^3.1.1
   "@scalar/nextjs-api-reference": ^0.11.12
   "@sentry/nextjs": ^10.69.0
+  "@t3-oss/env-core": ^0.13.11
   "@t3-oss/env-nextjs": ^0.13.11
   "@tailwindcss/postcss": ^4.3.3
   "@tanstack/react-query": 5.101.4


### PR DESCRIPTION
## Overview

`apps/api`'s environment-variable validation was the last piece of code coupled to Next.js-specific tooling ahead of the app's planned migration to Hono (epic #644). This PR swaps it to the framework-agnostic base library, with no change in runtime behavior — env validation still runs the same way, at the same time, with the same variable names.

This is Phase 0c of the Hono migration and ships while apps/api is still on Next.js, so it can be reviewed and merged independently of the framework swap itself.

## What changed

- `apps/api/src/env.ts`: `@t3-oss/env-nextjs` → `@t3-oss/env-core`. Added an explicit `clientPrefix: "NEXT_PUBLIC_"` (env-nextjs hardcodes this) and moved from `experimental__runtimeEnv` to `runtimeEnv`, now listing all 6 variables explicitly — env-core doesn't auto-fill server variables from `process.env` the way env-nextjs does.
- `apps/api/package.json` and `pnpm-workspace.yaml`: dependency swapped in the catalog. The two files that import `env` (`instrumentation-client.ts`, `docs/route.ts`) needed no changes.
- `apps/api/vitest.config.ts`: coverage thresholds ratcheted up (auto-generated by the test run, per repo convention).

## Scope decision

The issue flagged a decision: the shared `@acme/env` package (`packages/env`) is *also* built on `@t3-oss/env-nextjs`, consumed by non-Next contexts across `packages/db`, `packages/auth`, `packages/mail`, and the `packages/api` backend router package. This PR intentionally leaves it untouched — `apps/api/src/env.ts` doesn't import it, so converting it isn't required here, and keeping this change scoped to a single file keeps the blast radius and review surface minimal.

## Verification

- `pnpm turbo typecheck build --filter=f3-api` passes, including the `jiti("./src/env")` build-time validation hook in `next.config.mjs`.
- `pnpm turbo test --filter=f3-api` — 28/28 tests pass.
- `pnpm turbo lint format --filter=f3-api` and `pnpm lint:unused` (knip) — clean.
- Manually unset `AUTH_SECRET` locally and confirmed env-core throws `Invalid environment variables` immediately (fail-fast preserved). Confirmed a normal `.env` load still validates silently.

## Impact

No environment variable names changed. No DB/env changes beyond the dependency swap described above.

Closes #647

_written by Claude Sonnet 5_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved environment configuration handling for greater compatibility and more explicit validation of public and private settings.
  * Enhanced configuration reliability across authentication, database, and other runtime settings.
  * Improved consistency when loading runtime configuration across application environments.
* **Tests**
  * Increased coverage requirements for statements, branches, and lines, helping maintain overall application quality.
  * Continued enforcing the existing functions coverage threshold.
  * Strengthened safeguards against regressions in configuration-related behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->