### PR TITLE
chore(slackbot): keep app_manifest

### DIFF
--- a/apps/slackbot/.gitignore
+++ b/apps/slackbot/.gitignore
@@ -156,5 +156,4 @@ env.json
 
 # manifest files
 app_manifest.yaml
-app_manifest.json
 lt_output.txt


### PR DESCRIPTION
Moneyball changed how the local dev setup works. We used to not need app_manifest.json. Now we do.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project file tracking to include `app_manifest.json` while continuing to ignore `app_manifest.yaml`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->