### PR TITLE
ci(ci): fail PRs when drizzle-kit generate output drifts from committed migrations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -315,6 +315,10 @@ jobs:
           if [ -n "$(git status --porcelain -- drizzle)" ]; then
             echo "::error::drizzle-kit generate produced migration/snapshot output that doesn't match what's committed under packages/db/drizzle. This usually means schema.ts changed without regenerating migrations, or a stale local snapshot got committed on an earlier PR. Run 'pnpm --filter @acme/db generate' on a branch rebased on latest main, review the diff, and commit the result."
             git status --porcelain -- drizzle
+            # Intent-to-add so brand-new migration files (the most likely
+            # failure shape - see #862) show their full content below instead
+            # of being silently omitted: `git diff` skips untracked files.
+            git add -N -- drizzle
             git --no-pager diff -- drizzle
             exit 1
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,6 +292,33 @@ jobs:
       - uses: ./.github/actions/setup
       - run: pnpm typecheck
 
+  # Regenerates Drizzle migrations from packages/db/drizzle/schema.ts and fails
+  # if the output differs from what's committed. Exists because a snapshot can
+  # silently go stale in an unrelated PR (a contributor's local schema.ts is
+  # behind main when they run `drizzle-kit generate`, so the new snapshot bakes
+  # in an out-of-date field) and then sit unnoticed on main for weeks until the
+  # next `generate` run re-emits the transformation as a spurious "new"
+  # migration. That happened with the request_type enum: it drifted in the
+  # 0018/0019 snapshots and only surfaced when PR #845 generated 0020, an exact
+  # duplicate of 0017. This job catches that class of drift at PR time instead.
+  db-schema-sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup
+      - name: Regenerate migrations and diff against what's committed
+        working-directory: packages/db
+        run: |
+          node_modules/.bin/drizzle-kit generate
+          if [ -n "$(git status --porcelain -- drizzle)" ]; then
+            echo "::error::drizzle-kit generate produced migration/snapshot output that doesn't match what's committed under packages/db/drizzle. This usually means schema.ts changed without regenerating migrations, or a stale local snapshot got committed on an earlier PR. Run 'pnpm --filter @acme/db generate' on a branch rebased on latest main, review the diff, and commit the result."
+            git status --porcelain -- drizzle
+            git --no-pager diff -- drizzle
+            exit 1
+          fi
+
   build:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -311,7 +311,23 @@ jobs:
       - name: Regenerate migrations and diff against what's committed
         working-directory: packages/db
         run: |
-          pnpm exec drizzle-kit generate
+          # A rename-shaped change (column/table/enum) needs drizzle-kit to
+          # disambiguate rename-vs-drop+create interactively. In CI's non-TTY
+          # shell that prompt throws instead -- but only to stderr, with exit
+          # 0 and no file written, so a plain exit-code/git-status check goes
+          # green while the migration silently never gets generated. Catch
+          # both: a real crash, and this silent-success-with-stderr shape.
+          if ! pnpm exec drizzle-kit generate 2>drizzle-kit-stderr.log; then
+            cat drizzle-kit-stderr.log >&2
+            echo "::error::drizzle-kit generate exited non-zero"
+            exit 1
+          fi
+          if [ -s drizzle-kit-stderr.log ]; then
+            echo "::error::drizzle-kit generate wrote to stderr but reported success (exit 0). This happens when it needs an interactive prompt (e.g. disambiguating a column/table/enum rename) that CI's non-TTY shell can't answer. Resolve the rename locally, where drizzle-kit can prompt you, then commit the generated migration."
+            cat drizzle-kit-stderr.log >&2
+            exit 1
+          fi
+          rm -f drizzle-kit-stderr.log
           if [ -n "$(git status --porcelain -- drizzle)" ]; then
             echo "::error::drizzle-kit generate produced migration/snapshot output that doesn't match what's committed under packages/db/drizzle. This usually means schema.ts changed without regenerating migrations, or a stale local snapshot got committed on an earlier PR. Run 'pnpm --filter @acme/db generate' on a branch rebased on latest main, review the diff, and commit the result."
             git status --porcelain -- drizzle

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -311,7 +311,7 @@ jobs:
       - name: Regenerate migrations and diff against what's committed
         working-directory: packages/db
         run: |
-          node_modules/.bin/drizzle-kit generate
+          pnpm exec drizzle-kit generate
           if [ -n "$(git status --porcelain -- drizzle)" ]; then
             echo "::error::drizzle-kit generate produced migration/snapshot output that doesn't match what's committed under packages/db/drizzle. This usually means schema.ts changed without regenerating migrations, or a stale local snapshot got committed on an earlier PR. Run 'pnpm --filter @acme/db generate' on a branch rebased on latest main, review the diff, and commit the result."
             git status --porcelain -- drizzle


### PR DESCRIPTION
## Summary

Tackle noticed that PR #845's migration `0020_sync_request_type_enum.sql` is byte-identical to `0017_even_thing.sql`. Traced it to the actual root cause rather than guessing:

- `0017`'s committed snapshot correctly has the 13-value `request_type` enum.
- `0018` and `0019` (from #692, an earlier PR of mine, unrelated to `request_type`) both regress that enum back to its pre-`0017` 4-value set in their committed snapshot JSON, even though neither migration touches the column.
- That stale snapshot metadata sat on `main` unnoticed until `drizzle-kit generate` on #845 diffed against it and re-emitted `0017`'s entire transformation as a "new" migration, landing as `0020`.

Verified there's nothing left to fix in `packages/db` itself: a fresh `drizzle-kit generate` against current `main` produces "No schema changes, nothing to migrate" across all 39 tables, so the snapshot chain has already self-corrected. `0020` remains in history as a harmless, already-merged duplicate (confirmed `request_type` has exactly one dependent column, so re-running `0017`'s DROP/CREATE TYPE sequence is a safe no-op) — not worth rewriting merged migration history to remove.

What was actually missing is a check that would have caught the `0018`/`0019` drift at review time instead of letting it ride into `main` silently for weeks. This adds it.

## Changes

- New `db-schema-sync` job in `ci.yml`: regenerates migrations from `packages/db/drizzle/schema.ts` via `drizzle-kit generate` and fails the build if the output doesn't match what's committed (`git status --porcelain` on `packages/db/drizzle`).

## Test plan

- [x] Ran the check against current `main` in a clean worktree: passes (no diff).
- [x] Deliberately reintroduced the same class of bug (regressed the `request_type` enum values in the latest snapshot to simulate stale local state) and confirmed the check fails with the same diff shape this incident produced (spurious migration file, modified snapshot, modified journal).
- [x] Reverted the simulated corruption; worktree clean again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added continuous integration checks to verify that generated database migration files remain synchronized with the committed schema.
  * Checks now report file changes, errors, and detailed differences when validation fails.
  * These automated checks improve consistency and make schema-related changes easier to review before release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->