### PR TITLE
fix(slackbot): fixing HC button on non-default channel posting

### DIFF
--- a/apps/slackbot/features/calendar/event_preblast.py
+++ b/apps/slackbot/features/calendar/event_preblast.py
@@ -137,12 +137,15 @@ def get_preblast_channel(region_record: SlackSettings, preblast_info: PreblastIn
     """Return the Slack channel where the preblast should be posted.
 
     Fallback order is:
-    1. Event meta ``slack_channel_id``
-    2. Region default preblast destination channel
-    3. AO Slack channel from org meta
-    4. None
+    1. Persisted event meta ``preblast_channel_id``
+    2. Event meta ``slack_channel_id``
+    3. Region default preblast destination channel
+    4. AO Slack channel from org meta
+    5. None
     """
     event = preblast_info.event_record
+    if event.meta and event.meta.get("preblast_channel_id"):
+        return str(event.meta["preblast_channel_id"])
     if event.meta and event.meta.get("slack_channel_id"):
         return str(event.meta["slack_channel_id"])
     if (

--- a/apps/slackbot/tests/features/calendar/test_preblast_views.py
+++ b/apps/slackbot/tests/features/calendar/test_preblast_views.py
@@ -10,9 +10,15 @@ from application.attendance import CO_Q_TYPE_ID, HC_TYPE_ID, Q_TYPE_ID, Attendan
 from application.event_instance import EventInstanceData
 from application.preblast.service import PreblastService
 from features.calendar import get_preblast_action_blocks
-from features.calendar.event_preblast import build_preblast_info, handle_event_preblast_edit
+from features.calendar.event_preblast import (
+    PreblastInfo,
+    build_preblast_info,
+    get_preblast_channel,
+    handle_event_preblast_edit,
+)
 from features.calendar.preblast_views import PREBLAST_CHANNEL_SELECTOR, PreblastViews
 from utilities import constants
+from utilities.database.orm import SlackSettings
 from utilities.slack import actions
 from utilities.slack.sdk_orm import SdkBlockView
 
@@ -66,6 +72,26 @@ class PreblastViewsTest(unittest.TestCase):
             existing_preblast_ts=existing_preblast_ts,
             **kw,
         )
+
+    def test_get_preblast_channel_prefers_persisted_event_channel(self):
+        event = _event(meta={"preblast_channel_id": "CPOST", "slack_channel_id": "CEVENT"})
+        region = MagicMock(spec=SlackSettings)
+        region.default_preblast_destination = constants.CONFIG_DESTINATION_SPECIFIED["value"]
+        region.preblast_destination_channel = "CDEFAULT"
+
+        info = PreblastInfo(event_record=event, attendance_records=[], preblast_blocks=[], action_blocks=[])
+
+        self.assertEqual(get_preblast_channel(region, info), "CPOST")
+
+    def test_get_preblast_channel_uses_existing_fallbacks_without_persisted_channel(self):
+        event = _event(meta={"slack_channel_id": "CEVENT"})
+        region = MagicMock(spec=SlackSettings)
+        region.default_preblast_destination = constants.CONFIG_DESTINATION_SPECIFIED["value"]
+        region.preblast_destination_channel = "CDEFAULT"
+
+        info = PreblastInfo(event_record=event, attendance_records=[], preblast_blocks=[], action_blocks=[])
+
+        self.assertEqual(get_preblast_channel(region, info), "CEVENT")
 
     def test_build_preblast_form_returns_sdk_block_view(self):
         event = _event()


### PR DESCRIPTION
The `get_preblast_channel` function wasn't respecting the one-off `preblast_channel_id` meta tag, which was breaking the HC button when a non-default channel is selected for a preblast.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved calendar event preblast delivery by prioritizing the channel saved for the event.
  * Added reliable fallback handling when an event-specific channel is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->