### PR TITLE
chore(repo): pin python

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -39,11 +39,12 @@
       "enabled": false
     },
     {
-      "description": "Group Python (uv/pyproject.toml) minor and patch updates into one PR, separate from the npm non-major group — different lockfile, keeps uv.lock churn reviewable on its own",
+      "description": "Group Python (uv/pyproject.toml) minor and patch updates into one PR, separate from the npm non-major group — different lockfile, keeps uv.lock churn reviewable on its own. Never upgrade python runtime.",
       "groupName": "Python dependencies (non-major)",
       "groupSlug": "python-non-major",
       "matchManagers": ["pep621"],
-      "matchUpdateTypes": ["minor", "patch"]
+      "matchUpdateTypes": ["minor", "patch"],
+      "excludeDepTypes": ["requires-python"]
     },
     {
       "description": "Do not auto-update the Python base image; adopt interpreter upgrades manually",

--- a/renovate.json
+++ b/renovate.json
@@ -39,12 +39,17 @@
       "enabled": false
     },
     {
-      "description": "Group Python (uv/pyproject.toml) minor and patch updates into one PR, separate from the npm non-major group — different lockfile, keeps uv.lock churn reviewable on its own. Never upgrade python runtime.",
+      "description": "Do not automatically upgrade the Python runtime requirement",
+      "matchManagers": ["pep621"],
+      "matchDepTypes": ["requires-python"],
+      "enabled": false
+    },
+    {
+      "description": "Group Python (uv/pyproject.toml) minor and patch updates into one PR, separate from the npm non-major group — different lockfile, keeps uv.lock churn reviewable on its own",
       "groupName": "Python dependencies (non-major)",
       "groupSlug": "python-non-major",
       "matchManagers": ["pep621"],
-      "matchUpdateTypes": ["minor", "patch"],
-      "excludeDepTypes": ["requires-python"]
+      "matchUpdateTypes": ["minor", "patch"]
     },
     {
       "description": "Do not auto-update the Python base image; adopt interpreter upgrades manually",


### PR DESCRIPTION
prevent renovate from upgrading Slackbot's python runtime.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated dependency update settings to exclude Python runtime version changes while continuing to group minor and patch dependency updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->