### PR TITLE
chore(repo): change renovate to pin strategy for python

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -49,6 +49,7 @@
       "groupName": "Python dependencies (non-major)",
       "groupSlug": "python-non-major",
       "matchManagers": ["pep621"],
+      "rangeStrategy": "pin",
       "matchUpdateTypes": ["minor", "patch"]
     },
     {


### PR DESCRIPTION
Right now slackbot has ranges for dependencies. But Renovate is here to keep them where they should be. Having the ranges caused an issue. uv sync tried to update a dependency to a version that is not 7 days old. Renovate won't allow newer dependencies. So it complained.