### PR TITLE
fix(repo): make Python dependency pinning in Renovate actually work

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -45,11 +45,15 @@
       "enabled": false
     },
     {
+      "description": "Pin Python (uv/pyproject.toml) dependencies to exact versions on every update, instead of a range. Required for minimumReleaseAge to actually work with uv: Renovate can only stop `uv lock` from grabbing a too-new version if the version in pyproject.toml is an exact pin, not a range (see renovatebot/renovate#41624). Must stay its own rule — rangeStrategy can't be combined with matchUpdateTypes in one packageRule, because rangeStrategy is evaluated before Renovate knows the update type.",
+      "matchManagers": ["pep621"],
+      "rangeStrategy": "pin"
+    },
+    {
       "description": "Group Python (uv/pyproject.toml) minor and patch updates into one PR, separate from the npm non-major group — different lockfile, keeps uv.lock churn reviewable on its own",
       "groupName": "Python dependencies (non-major)",
       "groupSlug": "python-non-major",
       "matchManagers": ["pep621"],
-      "rangeStrategy": "pin",
       "matchUpdateTypes": ["minor", "patch"]
     },
     {


### PR DESCRIPTION
## Overview

This fixes the problem that [#903](https://github.com/F3-Nation/f3-nation/pull/903) and [#904](https://github.com/F3-Nation/f3-nation/pull/904) were trying to fix, but didn't: Renovate (our dependency-update bot) keeps failing to update Python packages on [#861](https://github.com/F3-Nation/f3-nation/pull/861), with a comment saying it can't update because a version is "too new" (hasn't passed our 7-day waiting period yet).

**In plain terms:** we told Renovate "wait 7 days before using a new package version, in case it turns out to be broken." That rule only works if we also tell Renovate to write an *exact* version number into our config files (like `3.16.2`) instead of a *range* (like `3.16.2 or anything newer`). If we leave a range in place, the tool that actually installs the Python packages (`uv`) is free to grab whatever the newest version is the moment it runs — completely ignoring the 7-day wait, because it never even looked at Renovate's rule.

#904 tried to fix this by telling Renovate "always write an exact version for Python packages," but that instruction was written in a way Renovate can't actually carry out — it was combined with a second, unrelated instruction ("only for regular updates, not major version bumps") in the same rule, and Renovate's own documentation says these two instructions can't be combined in one place. So the fix silently did nothing, and #861 is still failing today with the same error.

This PR splits that one rule into two separate rules, which is what Renovate actually requires. No app code changes — this only touches `renovate.json`, the bot's configuration file.

## What to expect next

Once this merges, Renovate needs to re-run PR #861 under the fixed config before it will actually contain pinned versions — that happens automatically the next time Renovate revisits that PR (or it can be nudged via the "rebase" checkbox on the dependency dashboard).

## Verification

- `renovate.json` still parses as valid JSON.
- `pnpm typecheck` passes (config-only change, but ran it as a sanity check via the pre-commit hook).
- No `.agents/skills` renovate-config-validator is wired into this repo's CI, so the real proof will be Renovate successfully re-processing #861 after this merges.

_written by Claude Sonnet 5_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency update configuration to pin Python dependency versions to exact versions.
  * Preserved existing grouping behavior for non-major Python updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->