### PR TITLE
feat(analytics): upgrade duckdb to 1.5.5

### DIFF
--- a/apps/analytics/Dockerfile
+++ b/apps/analytics/Dockerfile
@@ -12,7 +12,7 @@ ENV PYTHONUNBUFFERED=1 \
     UV_PROJECT_ENVIRONMENT=/app/.venv \
     PATH="/app/.venv/bin:$PATH" \
     DUCKDB_EXTENSION_DIR=/opt/duckdb/extensions \
-    DUCKDB_POSTGRES_EXTENSION_PATH=/opt/duckdb/extensions/v1.4.3/linux_amd64/postgres_scanner.duckdb_extension
+    DUCKDB_POSTGRES_EXTENSION_PATH=/opt/duckdb/extensions/v1.5.5/linux_amd64/postgres_scanner.duckdb_extension
 
 WORKDIR /app
 COPY pyproject.toml uv.lock ./
@@ -24,15 +24,15 @@ COPY apps/analytics ./apps/analytics
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --locked --package f3-nation-analytics --no-dev --no-editable
 
-# DuckDB 1.4.3's platform-matched postgres_scanner artifact is installed at
+# DuckDB 1.5.5's platform-matched postgres_scanner artifact is installed at
 # image build time using DuckDB's signed extension repository. This is more
 # reliable than guessing a release artifact's platform identifier. Signature
 # verification remains enabled: runtime LOAD validates the installed file.
-# linux_amd64 artifact SHA-256: 0cde6a6b625ef16e1b024dac373206a0d3f97bd45533aa7b81b548901f0d2c00
+# linux_amd64 artifact SHA-256: b1ced4cfc6311313e117c2afb3eac76508718778dde0716421503c7dbfb5605c
 RUN mkdir -p "$DUCKDB_EXTENSION_DIR" && \
     python -c "import duckdb; c=duckdb.connect(':memory:'); c.execute(\"SET extension_directory = '/opt/duckdb/extensions'\"); c.execute('INSTALL postgres'); c.close()" && \
     test -f "$DUCKDB_POSTGRES_EXTENSION_PATH" && \
-    echo "0cde6a6b625ef16e1b024dac373206a0d3f97bd45533aa7b81b548901f0d2c00  $DUCKDB_POSTGRES_EXTENSION_PATH" | sha256sum --check --status && \
+    echo "b1ced4cfc6311313e117c2afb3eac76508718778dde0716421503c7dbfb5605c  $DUCKDB_POSTGRES_EXTENSION_PATH" | sha256sum --check --status && \
     chmod 0555 "$DUCKDB_POSTGRES_EXTENSION_PATH"
 
 RUN groupadd --gid 1000 analytics && \

--- a/apps/analytics/README.md
+++ b/apps/analytics/README.md
@@ -74,7 +74,7 @@ reads the approved nonprod database and publishes to the approved nonprod GCS
 prefix. Run it only with explicit approval from
 the responsible security/platform and analytics operators. It requires real
 read-only PostgreSQL credentials, approved database connectivity, a real signed
-DuckDB 1.4.3 `postgres_scanner` extension at the configured version/platform
+DuckDB 1.5.5 `postgres_scanner` extension at the configured version/platform
 path, and Google Application Default Credentials (ADC) with the narrowly
 scoped nonprod permissions. An empty extension placeholder is not valid. Never
 use production targets or put credentials in logs or source control.
@@ -93,12 +93,12 @@ gcloud auth application-default login
 
 ### Obtain and verify the local DuckDB extension
 
-Use DuckDB **1.4.3** and the architecture of the runtime that will execute the
+Use DuckDB **1.5.5** and the architecture of the runtime that will execute the
 local CLI. Use an isolated extension directory; never copy an extension across
 operating systems or architectures. The Docker image's extension artifact is
 Linux amd64 only and is not suitable for a Mac/ARM local runtime.
 
-The commands below are Bash-specific; run them in Bash, not Fish. DuckDB 1.4.3
+The commands below are Bash-specific; run them in Bash, not Fish. DuckDB 1.5.5
 does not reliably expose usable `extension_path` metadata in
 `duckdb_extensions()`, so discovery deliberately searches the isolated
 directory instead.
@@ -106,15 +106,15 @@ directory instead.
 The following is a one-time preparation step, not an ETL runtime operation:
 
 ```bash
-EXT_DIR="$(cd "$HOME" && pwd)/.cache/f3-analytics/duckdb-1.4.3-$(uname -s)-$(uname -m)"
+EXT_DIR="$(cd "$HOME" && pwd)/.cache/f3-analytics/duckdb-1.5.5-$(uname -s)-$(uname -m)"
 mkdir -p "$EXT_DIR"
 export EXT_DIR
 uv --directory apps/analytics run python -c '
 import os
 import duckdb
 
-if duckdb.__version__ != "1.4.3":
-    raise SystemExit(f"expected DuckDB 1.4.3, got {duckdb.__version__}")
+if duckdb.__version__ != "1.5.5":
+    raise SystemExit(f"expected DuckDB 1.5.5, got {duckdb.__version__}")
 connection = duckdb.connect()
 extension_dir = os.environ["EXT_DIR"].replace(chr(39), chr(39) * 2)
 connection.execute(f"SET extension_directory = {chr(39)}{extension_dir}{chr(39)}")
@@ -134,8 +134,8 @@ import os
 from pathlib import Path
 import duckdb
 
-if duckdb.__version__ != "1.4.3":
-    raise SystemExit(f"expected DuckDB 1.4.3, got {duckdb.__version__}")
+if duckdb.__version__ != "1.5.5":
+    raise SystemExit(f"expected DuckDB 1.5.5, got {duckdb.__version__}")
 extension_dir = Path(os.environ["EXT_DIR"]).resolve()
 candidates = sorted(extension_dir.rglob("postgres*.duckdb_extension"))
 if len(candidates) != 1:
@@ -148,8 +148,8 @@ uv --directory apps/analytics run python -c '
 import os
 import duckdb
 
-if duckdb.__version__ != "1.4.3":
-    raise SystemExit(f"expected DuckDB 1.4.3, got {duckdb.__version__}")
+if duckdb.__version__ != "1.5.5":
+    raise SystemExit(f"expected DuckDB 1.5.5, got {duckdb.__version__}")
 connection = duckdb.connect()
 extension_path = os.environ["DUCKDB_POSTGRES_EXTENSION_PATH"]
 connection.load_extension(extension_path)
@@ -264,6 +264,8 @@ docker run --rm f3-analytics
 
 The image resolves the exact DuckDB version from `uv.lock` and uses DuckDB's
 signed extension repository to download/install the matching platform-specific
-`postgres_scanner` extension only during the image build. That DuckDB 1.4.3 /
-Linux x86_64 pairing is the image-build-tested target; cross-platform deploy
-builds must select the corresponding build platform.
+`postgres_scanner` extension only during the image build. That DuckDB 1.5.5 /
+Linux x86_64 pairing is the image-build-tested target. The prebundled
+`linux_amd64` extension SHA-256 is
+`b1ced4cfc6311313e117c2afb3eac76508718778dde0716421503c7dbfb5605c`;
+cross-platform deploy builds must select the corresponding build platform.

--- a/apps/analytics/pyproject.toml
+++ b/apps/analytics/pyproject.toml
@@ -5,7 +5,7 @@ description = "Foundation for the F3 Nation analytics Parquet ETL"
 readme = "README.md"
 requires-python = ">=3.13,<3.14"
 dependencies = [
-    "duckdb==1.4.3",
+    "duckdb==1.5.5",
     "google-cloud-storage>=2.18.0,<3.0.0",
     "pytz>=2024.1,<2027.0",
 ]

--- a/docs/ANALYTICS_ETL_OPERATIONS.md
+++ b/docs/ANALYTICS_ETL_OPERATIONS.md
@@ -36,7 +36,7 @@ the approved nonprod PostgreSQL database and publishes to
 `gs://f3-analytics-nonprod/parquets/pv_regions`.
 It requires explicit human approval,
 real read-only database credentials, access to
-`/cloudsql/f3data:us-central1:f3data-nonprod`, a real signed DuckDB 1.4.3
+`/cloudsql/f3data:us-central1:f3data-nonprod`, a real signed DuckDB 1.5.5
 `postgres_scanner` extension in the configured absolute version/platform path,
 and Google ADC with the narrowly scoped nonprod IAM grants. Do not use
 production targets, database write credentials, unsigned or placeholder

--- a/uv.lock
+++ b/uv.lock
@@ -508,17 +508,17 @@ wheels = [
 
 [[package]]
 name = "duckdb"
-version = "1.4.3"
+version = "1.5.5"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7f/da/17c3eb5458af69d54dedc8d18e4a32ceaa8ce4d4c699d45d6d8287e790c3/duckdb-1.4.3.tar.gz", hash = "sha256:fea43e03604c713e25a25211ada87d30cd2a044d8f27afab5deba26ac49e5268", size = 18478418, upload-time = "2025-12-09T10:59:22.945Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/19/e57151753576373c6696a12022648546cca6038e8833fda2908ee2342d9b/duckdb-1.5.5.tar.gz", hash = "sha256:72f33ee57ca7595b23957671a2cc7f7fe2be0ecc2d68f63abedcfcaa3a5c1238", size = 18066741, upload-time = "2026-07-22T10:55:17.819Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fd/76/288cca43a10ddd082788e1a71f1dc68d9130b5d078c3ffd0edf2f3a8719f/duckdb-1.4.3-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:16952ac05bd7e7b39946695452bf450db1ebbe387e1e7178e10f593f2ea7b9a8", size = 29033392, upload-time = "2025-12-09T10:58:34.631Z" },
-    { url = "https://files.pythonhosted.org/packages/64/07/cbad3d3da24af4d1add9bccb5fb390fac726ffa0c0cebd29bf5591cef334/duckdb-1.4.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:de984cd24a6cbefdd6d4a349f7b9a46e583ca3e58ce10d8def0b20a6e5fcbe78", size = 15414567, upload-time = "2025-12-09T10:58:37.051Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/19/57af0cc66ba2ffb8900f567c9aec188c6ab2a7b3f2260e9c6c3c5f9b57b1/duckdb-1.4.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1e5457dda91b67258aae30fb1a0df84183a9f6cd27abac1d5536c0d876c6dfa1", size = 13740960, upload-time = "2025-12-09T10:58:39.658Z" },
-    { url = "https://files.pythonhosted.org/packages/73/dd/23152458cf5fd51e813fadda60b9b5f011517634aa4bb9301f5f3aa951d8/duckdb-1.4.3-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:006aca6a6d6736c441b02ff5c7600b099bb8b7f4de094b8b062137efddce42df", size = 18484312, upload-time = "2025-12-09T10:58:42.054Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/7b/adf3f611f11997fc429d4b00a730604b65d952417f36a10c4be6e38e064d/duckdb-1.4.3-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a2813f4635f4d6681cc3304020374c46aca82758c6740d7edbc237fe3aae2744", size = 20495571, upload-time = "2025-12-09T10:58:44.646Z" },
-    { url = "https://files.pythonhosted.org/packages/40/d5/6b7ddda7713a788ab2d622c7267ec317718f2bdc746ce1fca49b7ff0e50f/duckdb-1.4.3-cp313-cp313-win_amd64.whl", hash = "sha256:6db124f53a3edcb32b0a896ad3519e37477f7e67bf4811cb41ab60c1ef74e4c8", size = 12335680, upload-time = "2025-12-09T10:58:46.883Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/28/0670135cf54525081fded9bac1254f78984e3b96a6059cd15aca262e3430/duckdb-1.4.3-cp313-cp313-win_arm64.whl", hash = "sha256:a8b0a8764e1b5dd043d168c8f749314f7a1252b5a260fa415adaa26fa3b958fd", size = 13075161, upload-time = "2025-12-09T10:58:49.47Z" },
+    { url = "https://files.pythonhosted.org/packages/47/37/4a38116e7700720fd152c666292214fd3abdf916496991296d8d1f66efbf/duckdb-1.5.5-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:cd98829b67788609017e65c761bd42a5dd0f9129441bed8bda4d6881ccf819f0", size = 32754294, upload-time = "2026-07-22T10:54:29.822Z" },
+    { url = "https://files.pythonhosted.org/packages/66/42/7d392f1ba1eee0eaf4ab4c8c7a604bfe3536cd63f979cf5c98798664f807/duckdb-1.5.5-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:feead93c56679b79592d437c62975d39cb67adedffa7592c763baf8160ac7366", size = 17368211, upload-time = "2026-07-22T10:54:33.359Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/a5/0a6f4fa60562faa615e55e15bd1953a2f2b17a8edd8105e5cda215e43457/duckdb-1.5.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:49c963d9469373d7aba8d750d9ea565ab823e94166efed953f184dd9b169b98c", size = 15509136, upload-time = "2026-07-22T10:54:36.369Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/cb/023c89f51978545b9fab318581bba0c457a58e7530d2d933e54ae7d8647c/duckdb-1.5.5-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a736217825461732b5442d05a220f3da2e23a0dae114efbf08c9bf171b53098a", size = 19392147, upload-time = "2026-07-22T10:54:39.551Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/c5/41bef391fb8b23dbc133c9f2ba016e7a7a8124513d2cc1b430f1897d87e4/duckdb-1.5.5-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:078e6a60dd8eedde5832f45422ca5c4a6b8c837aeabd8a56ca0b7d933f588053", size = 21511060, upload-time = "2026-07-22T10:54:42.788Z" },
+    { url = "https://files.pythonhosted.org/packages/07/9f/c44dfc1f924ac29b3252dc1b91393c01d009dbfe9f8ed33f10b986151bd1/duckdb-1.5.5-cp313-cp313-win_amd64.whl", hash = "sha256:6826504277dba513c0c5d71d828456c94d729c9d2482f94b2e289f90a9167e28", size = 13168028, upload-time = "2026-07-22T10:54:46.127Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/88/591384b2cd59abddd6f5dc175e60374f9abae6064429f0c4402854c10f44/duckdb-1.5.5-cp313-cp313-win_arm64.whl", hash = "sha256:baa9c5702002fabb559ded2a39008f9f421fcbc7237d388b8213eff1e08858de", size = 13989955, upload-time = "2026-07-22T10:54:49.262Z" },
 ]
 
 [[package]]
@@ -591,7 +591,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "duckdb", specifier = "==1.4.3" },
+    { name = "duckdb", specifier = "==1.5.5" },
     { name = "google-cloud-storage", specifier = ">=2.18.0,<3.0.0" },
     { name = "pytz", specifier = ">=2024.1,<2027.0" },
 ]


### PR DESCRIPTION
Fairly straightforward upgrade to duckdb 1.5.5, though it's not quite as simple as a pyproject + uv.lock upgrade.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Upgraded the analytics environment to DuckDB 1.5.5.
  * Updated the bundled PostgreSQL scanner extension to the matching version.
  * Refreshed setup and operations documentation with the new version and verification details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->