### PR TITLE
fix(ci): resolve Cloud Run job image digest using exact tag match via jq

### DIFF
--- a/.github/workflows/_deploy-cloudrun-job.yml
+++ b/.github/workflows/_deploy-cloudrun-job.yml
@@ -189,7 +189,11 @@ jobs:
           TAG: ${{ steps.meta.outputs.version }}
         run: |
           IMAGE_PATH="${IMAGE%:*}"
-          DIGESTS="$(gcloud artifacts docker images list "${IMAGE_PATH}" --project "${PROJECT_ID}" --include-tags --filter="tags=${TAG}" --format='value(digest)')"
+          DIGESTS="$(gcloud artifacts docker images list "${IMAGE_PATH}" \
+            --project "${PROJECT_ID}" \
+            --include-tags \
+            --format=json \
+            | jq -r --arg tag "${TAG}" '[.[] | select(.tags[]? == $tag) | .version] | unique[]')"
 
           if [[ -z "${DIGESTS}" ]]; then
             echo "No image found for exact tag ${TAG}" >&2
@@ -311,7 +315,11 @@ jobs:
             docker pull "${STAGING_IMAGE}"
             docker tag "${STAGING_IMAGE}" "${PROD_IMAGE}"
             docker push "${PROD_IMAGE}"
-            PROD_DIGEST="$(gcloud artifacts docker images describe "${PROD_IMAGE}" --project "${PROD_PROJECT}" --format='value(image_summary.digest)')"
+            PROD_DIGEST="$(gcloud artifacts docker images list "${PROD_IMAGE%:*}" \
+              --project "${PROD_PROJECT}" \
+              --include-tags \
+              --format=json \
+              | jq -r --arg tag "${VERSION}" '[.[] | select(.tags[]? == $tag) | .version] | unique[]')"
             test -n "${PROD_DIGEST}"
             echo "prod_image=${PROD_IMAGE}@${PROD_DIGEST}" >> "$GITHUB_ENV"
           fi

--- a/.github/workflows/_deploy-cloudrun-job.yml
+++ b/.github/workflows/_deploy-cloudrun-job.yml
@@ -193,7 +193,7 @@ jobs:
             --project "${PROJECT_ID}" \
             --include-tags \
             --format=json \
-            | jq -r --arg tag "${TAG}" '[.[] | select(.tags[]? == $tag) | .version] | unique[]')"
+            | jq -r --arg tag "${TAG}" '[.[] | select(any(.tags[]?; . == $tag)) | .version] | unique[]')"
 
           if [[ -z "${DIGESTS}" ]]; then
             echo "No image found for exact tag ${TAG}" >&2
@@ -315,13 +315,25 @@ jobs:
             docker pull "${STAGING_IMAGE}"
             docker tag "${STAGING_IMAGE}" "${PROD_IMAGE}"
             docker push "${PROD_IMAGE}"
-            PROD_DIGEST="$(gcloud artifacts docker images list "${PROD_IMAGE%:*}" \
+            IMAGE_PATH="${PROD_IMAGE%:*}"
+            PROD_DIGESTS="$(gcloud artifacts docker images list "${IMAGE_PATH}" \
               --project "${PROD_PROJECT}" \
               --include-tags \
               --format=json \
-              | jq -r --arg tag "${VERSION}" '[.[] | select(.tags[]? == $tag) | .version] | unique[]')"
-            test -n "${PROD_DIGEST}"
-            echo "prod_image=${PROD_IMAGE}@${PROD_DIGEST}" >> "$GITHUB_ENV"
+              | jq -r --arg tag "${VERSION}" '[.[] | select(any(.tags[]?; . == $tag)) | .version] | unique[]')"
+
+            if [[ -z "${PROD_DIGESTS}" ]]; then
+              echo "No image found in production Artifact Registry for exact tag ${VERSION}" >&2
+              exit 1
+            fi
+
+            mapfile -t PROD_DIGESTS <<< "${PROD_DIGESTS}"
+            if [[ "${#PROD_DIGESTS[@]}" -ne 1 ]] || [[ ! "${PROD_DIGESTS[0]}" =~ ^sha256: ]]; then
+              echo "Expected one valid digest for tag ${VERSION} in production, got ${#PROD_DIGESTS[@]}" >&2
+              exit 1
+            fi
+
+            echo "prod_image=${PROD_IMAGE}@${PROD_DIGESTS[0]}" >> "$GITHUB_ENV"
           fi
 
       - name: Deploy Cloud Run Job (prod)

--- a/apps/slackbot/main.py
+++ b/apps/slackbot/main.py
@@ -1,3 +1,5 @@
+# Entrypoint for the F3 Slackbot service.
+
 import logging
 import os
 import re


### PR DESCRIPTION
## Summary

Fixes the image digest resolution step in `.github/workflows/_deploy-cloudrun-job.yml` which caused release deployments for Cloud Run Jobs (e.g. `f3-slackbot-scripts` in run 34486751944) to fail with:

```
No image found for exact tag <version>
```

### Root Cause
1. In `build`, `gcloud artifacts docker images list --filter="tags=${TAG}" --format='value(digest)'` failed because:
   - `tags` is an array of strings in the `gcloud` resource representation, so scalar equality `tags=${TAG}` evaluates to `False`.
   - The field containing the sha256 digest is named `version`, not `digest`, so `value(digest)` returns empty string.
2. In `deploy-prod`, `gcloud artifacts docker images describe` was still being called, which queries the Container Analysis API and fails when the deployment service account lacks `containeranalysis.occurrences.list` permissions.

### Solution
- Output JSON from `gcloud artifacts docker images list` and filter using `jq -r --arg tag "${TAG}" '[.[] | select(.tags[]? == $tag) | .version] | unique[]'`. This guarantees exact tag matching (avoiding prefix/substring collisions) and retrieves the valid `.version` digest.
- Update `deploy-prod` to use the same `list` + `jq` query instead of `describe`.

### Impact & Verification
- **DB / Env Impact**: None.
- **Commands Run**:
  - Tested `jq` query against `f3-slackbot-scripts:2.4.1` in staging Artifact Registry.
  - `npx prettier --check .github/workflows/_deploy-cloudrun-job.yml` (passed).
  - `turbo typecheck` across all 30 packages (passed).
  - `commitlint` (passed).

_written by Gemini 3.8 Flash (High)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved container image digest resolution during Cloud Run deployments.
  * Deployment workflows now more reliably identify the correct tagged image before staging and production promotion.
  * Added validation to prevent deployments when a unique, valid image digest cannot be identified, helping avoid ambiguous or incorrect image promotions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->