### PR TITLE
fix(slackbot): temporarily disable broken confirmation dialogs

### DIFF
--- a/apps/map/vitest.config.ts
+++ b/apps/map/vitest.config.ts
@@ -18,10 +18,10 @@ export default defineConfig({
       exclude: coverageExclude,
       thresholds: {
         autoUpdate: true,
-        statements: 19.45,
-        branches: 17.35,
-        functions: 13.71,
-        lines: 19.86,
+        statements: 27.25,
+        branches: 26.69,
+        functions: 21.42,
+        lines: 27.27,
       },
     },
     exclude: [

--- a/apps/slackbot/features/backblast.py
+++ b/apps/slackbot/features/backblast.py
@@ -254,13 +254,14 @@ def backblast_middleware(
                     slack_orm.ButtonElement(
                         label="New Unscheduled Event",
                         action=actions.BACKBLAST_NEW_BLANK_BUTTON,
-                        confirm=slack_orm.ConfirmObject(
-                            title="Are you sure?",
-                            text="This option should ONLY BE USED FOR UNSCHEDULED EVENTS that are not listed on the calendar. If this is for a normal, scheduled event, please select it from the lists above.",  # noqa
-                            confirm="Yes, I'm sure",
-                            deny="Whups, never mind",
-                            style="danger",
-                        ),
+                        # Temporarily disabled: Slack confirmation dialogs dismiss the parent modal (#984).
+                        # confirm=slack_orm.ConfirmObject(
+                        #     title="Are you sure?",
+                        #     text="This option should ONLY BE USED FOR UNSCHEDULED EVENTS that are not listed on the calendar. If this is for a normal, scheduled event, please select it from the lists above.",  # noqa
+                        #     confirm="Yes, I'm sure",
+                        #     deny="Whups, never mind",
+                        #     style="danger",
+                        # ),
                     ),
                 ]
             ),

--- a/apps/slackbot/features/calendar/ao.py
+++ b/apps/slackbot/features/calendar/ao.py
@@ -4,7 +4,9 @@ from logging import Logger
 
 import requests
 from slack_sdk.models.blocks import ImageBlock, InputBlock, SectionBlock
-from slack_sdk.models.blocks.basic_components import ConfirmObject, PlainTextObject
+
+# from slack_sdk.models.blocks.basic_components import ConfirmObject  # Disabled for #984.
+from slack_sdk.models.blocks.basic_components import PlainTextObject
 from slack_sdk.models.blocks.block_elements import (
     ChannelSelectElement,
     FileInputElement,
@@ -100,16 +102,17 @@ class AoViews:
                 accessory=StaticSelectElement(
                     placeholder="Edit or Delete",
                     options=as_selector_options(names=["Edit", "Delete"]),
-                    confirm=ConfirmObject(
-                        title="Are you sure?",
-                        text=(
-                            "Are you sure you want to edit / delete this AO? "
-                            "This cannot be undone. Deleting an AO will also "
-                            "delete all associated series and events."
-                        ),
-                        confirm="Yes, I'm sure",
-                        deny="Whups, never mind",
-                    ),
+                    # Temporarily disabled: Slack confirmation dialogs dismiss the parent modal (#984).
+                    # confirm=ConfirmObject(
+                    #     title="Are you sure?",
+                    #     text=(
+                    #         "Are you sure you want to edit / delete this AO? "
+                    #         "This cannot be undone. Deleting an AO will also "
+                    #         "delete all associated series and events."
+                    #     ),
+                    #     confirm="Yes, I'm sure",
+                    #     deny="Whups, never mind",
+                    # ),
                     action_id=f"{actions.AO_EDIT_DELETE}_{a.id}",
                 ),
             )

--- a/apps/slackbot/features/calendar/event_instance.py
+++ b/apps/slackbot/features/calendar/event_instance.py
@@ -505,11 +505,11 @@ def build_event_instance_list_form(
             label += " [CLOSED]"
             placeholder = "Reopen, Edit, or Delete"
             options = ["Reopen", "Edit", "Delete"]
-            confirm_text = "Are you sure you want to reopen / edit / delete this event?"
+            # confirm_text = "Are you sure you want to reopen / edit / delete this event?"
         else:
             placeholder = "Edit, Close, or Delete"
             options = ["Edit", "Close", "Delete"]
-            confirm_text = "Are you sure you want to edit / close / delete this event?"
+            # confirm_text = "Are you sure you want to edit / close / delete this event?"
 
         form.blocks.append(
             orm.SectionBlock(
@@ -518,12 +518,13 @@ def build_event_instance_list_form(
                 element=orm.StaticSelectElement(
                     placeholder=placeholder,
                     options=orm.as_selector_options(names=options),
-                    confirm=orm.ConfirmObject(
-                        title="Are you sure?",
-                        text=confirm_text,
-                        confirm="Yes, I'm sure",
-                        deny="Whups, never mind",
-                    ),
+                    # Temporarily disabled: Slack confirmation dialogs dismiss the parent modal (#984).
+                    # confirm=orm.ConfirmObject(
+                    #     title="Are you sure?",
+                    #     text=confirm_text,
+                    #     confirm="Yes, I'm sure",
+                    #     deny="Whups, never mind",
+                    # ),
                 ),
             )
         )

--- a/apps/slackbot/features/calendar/event_preblast.py
+++ b/apps/slackbot/features/calendar/event_preblast.py
@@ -363,17 +363,18 @@ def build_event_preblast_select_form(
                 orm.ButtonElement(
                     label="New Unscheduled Event",
                     action=actions.EVENT_PREBLAST_NEW_BUTTON,
-                    confirm=orm.ConfirmObject(
-                        title="Are you sure?",
-                        text=(
-                            "This option should ONLY BE USED FOR UNSCHEDULED EVENTS that are not listed on "
-                            "the calendar. If this is for a normal, scheduled event, please select it from "
-                            "the lists above."
-                        ),
-                        confirm="Yes, I'm sure",
-                        deny="Whups, never mind",
-                        style="danger",
-                    ),
+                    # Temporarily disabled: Slack confirmation dialogs dismiss the parent modal (#984).
+                    # confirm=orm.ConfirmObject(
+                    #     title="Are you sure?",
+                    #     text=(
+                    #         "This option should ONLY BE USED FOR UNSCHEDULED EVENTS that are not listed on "
+                    #         "the calendar. If this is for a normal, scheduled event, please select it from "
+                    #         "the lists above."
+                    #     ),
+                    #     confirm="Yes, I'm sure",
+                    #     deny="Whups, never mind",
+                    #     style="danger",
+                    # ),
                 ),
             ]
         ),

--- a/apps/slackbot/features/calendar/series.py
+++ b/apps/slackbot/features/calendar/series.py
@@ -393,7 +393,7 @@ def build_series_list_form(
             filter_org = safe_convert(safe_get(filter_values, actions.CALENDAR_MANAGE_SERIES_AO), int)
 
     title_text = "Delete or Edit a Series"
-    confirm_text = "Are you sure you want to edit / delete this series? This cannot be undone. Also, editing or deleting a series will also edit or delete all future events associated with the series."  # noqa
+    # confirm_text = "Are you sure you want to edit / delete this series? This cannot be undone. Also, editing or deleting a series will also edit or delete all future events associated with the series."  # noqa
 
     series_service = _build_series_service()
     ao_service = _build_ao_service()
@@ -430,12 +430,13 @@ def build_series_list_form(
                 element=orm.StaticSelectElement(
                     placeholder="Edit or Delete",
                     options=orm.as_selector_options(names=["Edit", "Delete"]),
-                    confirm=orm.ConfirmObject(
-                        title="Are you sure?",
-                        text=confirm_text,
-                        confirm="Yes, I'm sure",
-                        deny="Whups, never mind",
-                    ),
+                    # Temporarily disabled: Slack confirmation dialogs dismiss the parent modal (#984).
+                    # confirm=orm.ConfirmObject(
+                    #     title="Are you sure?",
+                    #     text=confirm_text,
+                    #     confirm="Yes, I'm sure",
+                    #     deny="Whups, never mind",
+                    # ),
                 ),
             )
         )

--- a/apps/slackbot/features/positions.py
+++ b/apps/slackbot/features/positions.py
@@ -115,12 +115,13 @@ class PositionViews:
                         element=orm.StaticSelectElement(
                             placeholder="Edit or Delete",
                             options=orm.as_selector_options(names=["Edit", "Delete"]),
-                            confirm=orm.ConfirmObject(
-                                title="Are you sure?",
-                                text="Are you sure you want to edit / delete this Position? This cannot be undone.",
-                                confirm="Yes, I am sure",
-                                deny="Whups, never mind",
-                            ),
+                            # Temporarily disabled: Slack confirmation dialogs dismiss the parent modal (#984).
+                            # confirm=orm.ConfirmObject(
+                            #     title="Are you sure?",
+                            #     text="Are you sure you want to edit / delete this Position? This cannot be undone.",
+                            #     confirm="Yes, I am sure",
+                            #     deny="Whups, never mind",
+                            # ),
                         ),
                     )
                 )


### PR DESCRIPTION
### Summary

Slack’s built-in confirmation dialogs can leave users back in the channel without the parent modal or expected next form. Temporarily comment out the six active confirmation definitions for unscheduled backblasts/preblasts and series, single-event, AO, and position management.

Closes #984.

### Behavior and scope

- Edit and unscheduled-event actions open their forms directly. Close Event still opens its existing reason form.
- **Delete and Reopen execute immediately when selected, without an additional confirmation.**
- Preserve the confirmation code and unused supporting definitions as comments, with #984 references for restoration. No custom confirmations or feature flags.
- Action handlers and authorization checks are unchanged.
- `apps/slackbot/features/calendar/event_tag.py` already had a commented-out confirmation before this workaround; that file is unchanged.
- Full local CI automatically raised the map coverage thresholds in `apps/map/vitest.config.ts`. Retained as required by the repository’s coverage-ratchet policy; no map behavior changes.
- No database migrations or environment changes.

### Validation

- `pnpm ci:local` passed: formatting, lint, unused-code checks, type checks, builds, and tests, including all 410 Slackbot tests.
- Manual ChubbsSlack verification passed for all six form-opening paths: unscheduled backblast, unscheduled preblast, Edit Series, Edit Single Event, Edit AO, and Edit Position.
- Confirmed the six Python files differ semantically only by disabling confirmations and unused definitions; event-tag code is byte-for-byte unchanged.
- Delete/Reopen have existing automated coverage but were not manually exercised for this change.

### Manual reproduction

In a test workspace, use `/backblast` and `/preblast` → New Unscheduled Event. Use `/f3-nation-settings` → Manage Schedules & Events to edit a series, single event, or AO, and SLT Settings → Edit Positions to edit a custom position. Each should open its next form without a confirmation dialog or unexpected return to the channel.

Use disposable test records for any follow-up Delete/Reopen checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **User Experience**
  * Slack confirmation dialogs have been removed from several calendar, backblast, and position actions, including creating unscheduled events and editing, deleting, reopening, or closing items.
  * These actions now proceed directly after selection, while the existing actions and controls remain available.

* **Testing**
  * Increased minimum code coverage requirements across statements, branches, functions, and lines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->